### PR TITLE
parallel.h refactoring and add support for TBB

### DIFF
--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -189,7 +189,7 @@ checked_find_package (OpenCV 3.0
 # Intel TBB
 set (TBB_USE_DEBUG_BUILD OFF)
 checked_find_package (TBB 2017
-                      DEFINITIONS  -DUSE_TBB=1
+                      SETVARIABLES OIIO_TBB
                       PREFER_CONFIG)
 
 checked_find_package (DCMTK VERSION_MIN 3.6.1)  # For DICOM images

--- a/src/include/OpenImageIO/imagebufalgo_util.h
+++ b/src/include/OpenImageIO/imagebufalgo_util.h
@@ -2,22 +2,21 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 
-// clang-format off
 
 #pragma once
 
 #include <functional>
 
-#include <OpenImageIO/parallel.h>
 #include <OpenImageIO/imagebufalgo.h>
+#include <OpenImageIO/parallel.h>
 
 
 
 OIIO_NAMESPACE_BEGIN
 
 using std::bind;
-using std::ref;
 using std::cref;
+using std::ref;
 using namespace std::placeholders;
 using std::placeholders::_1;
 
@@ -27,86 +26,77 @@ namespace ImageBufAlgo {
 
 
 /// Helper template for generalized multithreading for image processing
-/// functions.  Some function/functor f is applied to every pixel the
-/// region of interest roi, dividing the region into multiple threads if
-/// threads != 1.  Note that threads == 0 indicates that the number of
-/// threads should be as set by the global OIIO "threads" attribute.
+/// functions.  Some function/functor or lambda `f` is applied to every pixel
+/// the region of interest roi, dividing the region into multiple threads if
+/// threads != 1.  Note that threads == 0 indicates that the number of threads
+/// should be as set by the global OIIO "threads" attribute.
 ///
-/// The optional splitdir determines along which axis the split will be
-/// made. The default is Split_Y (vertical splits), which generally seems
-/// the fastest (due to cache layout issues?), but perhaps there are
-/// algorithms where it's better to split in X, Z, or along the longest
-/// axis.
+/// The `opt.splitdir` determines along which axis the split will be made. The
+/// default is SplitDir::Y (vertical splits), which generally seems the
+/// fastest (due to cache layout issues?), but perhaps there are algorithms
+/// where it's better to split in X, Z, or along the longest axis.
 ///
-/// Most image operations will require additional arguments, including
-/// additional input and output images or other parameters.  The
-/// parallel_image template can still be used by employing the
-/// std::bind. For example, suppose you have an image operation defined as:
-///     void my_image_op (ImageBuf &out, const ImageBuf &in,
-///                       float scale, ROI roi);
-/// Then you can parallelize it as follows:
-///     ImageBuf R, A;   // result, input
-///     ROI roi = get_roi (R.spec());
-///     parallel_image (bind(my_image_op,ref(R), cref(A),3.14,_1), roi);
 inline void
-parallel_image (ROI roi, paropt opt,
-                std::function<void(ROI)> f)
+parallel_image(ROI roi, paropt opt, std::function<void(ROI)> f)
 {
-    opt.resolve ();
+    opt.resolve();
     // Try not to assign a thread less than 16k pixels, or it's not worth
     // the thread startup/teardown cost.
-    opt.maxthreads(std::min (opt.maxthreads(), 1 + int(roi.npixels() / opt.minitems())));
+    opt.maxthreads(
+        std::min(opt.maxthreads(), 1 + int(roi.npixels() / opt.minitems())));
     if (opt.singlethread()) {
         // Just one thread, or a small image region, or if recursive use of
         // parallel_image is disallowed: use this thread only
-        f (roi);
+        f(roi);
         return;
     }
 
     // If splitdir was not explicit, find the longest edge.
-    SplitDir splitdir = opt.splitdir();
-    if (splitdir == Split_Biggest)
-        splitdir = roi.width() > roi.height() ? Split_X : Split_Y;
+    paropt::SplitDir splitdir = opt.splitdir();
+    if (splitdir == paropt::SplitDir::Biggest)
+        splitdir = roi.width() > roi.height() ? paropt::SplitDir::X
+                                              : paropt::SplitDir::Y;
 
     int64_t xchunk = 0, ychunk = 0;
-    if (splitdir == Split_Y) {
+    if (splitdir == paropt::SplitDir::Y) {
         xchunk = roi.width();
         // ychunk = std::max (64, minitems/xchunk);
-    } else if (splitdir == Split_X) {
+    } else if (splitdir == paropt::SplitDir::X) {
         ychunk = roi.height();
         // ychunk = std::max (64, minitems/xchunk);
-    } else if (splitdir == Split_Tile) {
+    } else if (splitdir == paropt::SplitDir::Tile) {
         int64_t n = std::min<imagesize_t>(opt.minitems(), roi.npixels());
-        xchunk = ychunk = std::max (1, int(std::sqrt(n))/4);
+        xchunk = ychunk = std::max(1, int(std::sqrt(n)) / 4);
     } else {
-        xchunk = ychunk = std::max (int64_t(1), int64_t(std::sqrt(opt.maxthreads()))/2);
+        xchunk = ychunk = std::max(int64_t(1),
+                                   int64_t(std::sqrt(opt.maxthreads())) / 2);
     }
 
-    auto task = [&](int64_t xbegin, int64_t xend,
-                    int64_t ybegin, int64_t yend) {
-        f (ROI (xbegin, xend, ybegin, yend, roi.zbegin, roi.zend,
-                roi.chbegin, roi.chend));
+    auto task = [&](int64_t xbegin, int64_t xend, int64_t ybegin,
+                    int64_t yend) {
+        f(ROI(xbegin, xend, ybegin, yend, roi.zbegin, roi.zend, roi.chbegin,
+              roi.chend));
     };
-    parallel_for_chunked_2D (roi.xbegin, roi.xend, xchunk,
-                             roi.ybegin, roi.yend, ychunk, task, opt);
+    parallel_for_chunked_2D(roi.xbegin, roi.xend, xchunk, roi.ybegin, roi.yend,
+                            ychunk, task, opt);
 }
 
 
 inline void
-parallel_image (ROI roi, std::function<void(ROI)> f)
+parallel_image(ROI roi, std::function<void(ROI)> f)
 {
-    parallel_image (roi, paropt(), f);
+    parallel_image(roi, paropt(), f);
 }
 
 
 
 // DEPRECATED(1.8) -- eventually enable the OIIO_DEPRECATION
-template <class Func>
+template<class Func>
 OIIO_DEPRECATED("switch to new parallel_image (1.8)")
-void
-parallel_image (Func f, ROI roi, int nthreads=0, SplitDir splitdir=Split_Y)
+void parallel_image(Func f, ROI roi, int nthreads = 0,
+                    SplitDir splitdir = Split_Y)
 {
-    parallel_image (roi, paropt(nthreads, splitdir), f);
+    parallel_image(roi, paropt(nthreads, paropt::SplitDir(splitdir)), f);
 }
 
 
@@ -123,22 +113,31 @@ parallel_image (Func f, ROI roi, int nthreads=0, SplitDir splitdir=Split_Y)
 /// If all is ok, return true.  Some additional checks and behaviors may be
 /// specified by the 'prepflags', which is a bit field defined by
 /// IBAprep_flags.
-bool OIIO_API IBAprep (ROI &roi, ImageBuf *dst, const ImageBuf *A=NULL,
-                       const ImageBuf *B=NULL, const ImageBuf *C=NULL,
-                       ImageSpec *force_spec=NULL, int prepflags=0);
-inline bool IBAprep (ROI &roi, ImageBuf *dst, const ImageBuf *A,
-                     const ImageBuf *B, ImageSpec *force_spec,
-                     int prepflags=0) {
-    return IBAprep (roi, dst, A, B, NULL, force_spec, prepflags);
+bool OIIO_API
+IBAprep(ROI& roi, ImageBuf* dst, const ImageBuf* A = NULL,
+        const ImageBuf* B = NULL, const ImageBuf* C = NULL,
+        ImageSpec* force_spec = NULL, int prepflags = 0);
+inline bool
+IBAprep(ROI& roi, ImageBuf* dst, const ImageBuf* A, const ImageBuf* B,
+        ImageSpec* force_spec, int prepflags = 0)
+{
+    return IBAprep(roi, dst, A, B, NULL, force_spec, prepflags);
 }
-inline bool IBAprep (ROI &roi, ImageBuf *dst,
-                     const ImageBuf *A, const ImageBuf *B, int prepflags) {
-    return IBAprep (roi, dst, A, B, NULL, NULL, prepflags);
+inline bool
+IBAprep(ROI& roi, ImageBuf* dst, const ImageBuf* A, const ImageBuf* B,
+        int prepflags)
+{
+    return IBAprep(roi, dst, A, B, NULL, NULL, prepflags);
 }
-inline bool IBAprep (ROI &roi, ImageBuf *dst,
-                     const ImageBuf *A, int prepflags) {
-    return IBAprep (roi, dst, A, NULL, NULL, NULL, prepflags);
+inline bool
+IBAprep(ROI& roi, ImageBuf* dst, const ImageBuf* A, int prepflags)
+{
+    return IBAprep(roi, dst, A, NULL, NULL, NULL, prepflags);
 }
+
+
+// clang-format off
+
 
 enum IBAprep_flags {
     IBAprep_DEFAULT = 0,
@@ -514,5 +513,6 @@ inline TypeDesc type_merge (TypeDesc a, TypeDesc b, TypeDesc c)
 
 }  // end namespace ImageBufAlgo
 
+// clang-format on
 
 OIIO_NAMESPACE_END

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -2683,6 +2683,14 @@ OIIO_API std::string geterror(bool clear = true);
 ///    Colon-separated (or semicolon-separated) list of directories to search
 ///    if fonts are needed. (Such as for `ImageBufAlgo::render_text()`.)
 ///
+/// - `int use_tbb`
+///
+///    If nonzero and TBB was found and support configured when OIIO was
+///    compiled, parallel processing within OIIO (including inside the
+///    parallel.h utilities) will try to use TBB by default where possible.
+///    If zero, they will try to use OIIO's native thread pool even if TBB
+///    is available.
+///
 /// - `string plugin_searchpath`
 ///
 ///    Colon-separated (or semicolon-separated) list of directories to search

--- a/src/include/OpenImageIO/oiioversion.h.in
+++ b/src/include/OpenImageIO/oiioversion.h.in
@@ -161,5 +161,9 @@ namespace @PROJ_NAME@ = @PROJ_NAMESPACE_V@;
 #define OIIO_BUILD_CPP17 (@CMAKE_CXX_STANDARD@ >= 17)
 #define OIIO_BUILD_CPP20 (@CMAKE_CXX_STANDARD@ >= 20)
 
-#endif
 
+// Was the project built with TBB support?
+#cmakedefine01 OIIO_TBB
+
+
+#endif  /* defined(OPENIMAGEIO_VERSION_H) */

--- a/src/include/OpenImageIO/parallel.h
+++ b/src/include/OpenImageIO/parallel.h
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 
-// clang-format off
-
 #pragma once
 
 #include <algorithm>
@@ -87,17 +85,21 @@ public:
         , m_minitems(minitems)
     {
     }
-    paropt(string_view name, int maxthreads = 0,
-           SplitDir splitdir = Split_Y, size_t minitems = 1024) noexcept
+    paropt(string_view name, int maxthreads = 0, SplitDir splitdir = Split_Y,
+           size_t minitems = 1024) noexcept
         : paropt(maxthreads, splitdir, minitems)
     {
         // m_name = name;
     }
 
-    constexpr paropt(ParStrategy strat) noexcept : m_strategy(strat) { }
+    constexpr paropt(ParStrategy strat) noexcept
+        : m_strategy(strat)
+    {
+    }
 
     constexpr paropt(int maxthreads, ParStrategy strat) noexcept
-        : m_maxthreads(maxthreads), m_strategy(strat)
+        : m_maxthreads(maxthreads)
+        , m_strategy(strat)
     {
     }
 
@@ -106,7 +108,7 @@ public:
         : paropt(po.name, po.maxthreads, po.splitdir, po.minitems)
     {
         m_recursive = po.recursive;
-        m_pool = po.pool;
+        m_pool      = po.pool;
     }
 
     // Fix up all the TBD parameters:
@@ -119,42 +121,54 @@ public:
     constexpr bool singlethread() const noexcept { return m_maxthreads == 1; }
 
     constexpr int maxthreads() const noexcept { return m_maxthreads; }
-    paropt& maxthreads(int m) noexcept { m_maxthreads = m; return *this; }
+    paropt& maxthreads(int m) noexcept
+    {
+        m_maxthreads = m;
+        return *this;
+    }
 
     constexpr SplitDir splitdir() const noexcept { return m_splitdir; }
-    paropt& splitdir(SplitDir s) noexcept { m_splitdir = s; return *this; }
+    paropt& splitdir(SplitDir s) noexcept
+    {
+        m_splitdir = s;
+        return *this;
+    }
 
     constexpr bool recursive() const noexcept { return m_recursive; }
-    paropt& recursive(bool r) noexcept { m_recursive = r; return *this; }
+    paropt& recursive(bool r) noexcept
+    {
+        m_recursive = r;
+        return *this;
+    }
 
     constexpr int minitems() const noexcept { return m_minitems; }
-    paropt& minitems(int m) noexcept { m_minitems = m; return *this; }
+    paropt& minitems(int m) noexcept
+    {
+        m_minitems = m;
+        return *this;
+    }
 
     thread_pool* pool() const noexcept { return m_pool; }
-    paropt& pool(thread_pool* p) noexcept { m_pool = p; return *this; }
+    paropt& pool(thread_pool* p) noexcept
+    {
+        m_pool = p;
+        return *this;
+    }
 
     constexpr ParStrategy strategy() const noexcept { return m_strategy; }
-    paropt& strategy(ParStrategy s) noexcept { m_strategy = s; return *this; }
+    paropt& strategy(ParStrategy s) noexcept
+    {
+        m_strategy = s;
+        return *this;
+    }
 
 private:
-    int m_maxthreads    = 0;        // Max threads (0 = use all)
-    SplitDir m_splitdir = Split_Y;  // Primary split direction
-    bool m_recursive    = false;    // Allow thread pool recursion
-    size_t m_minitems   = 16384;    // Min items per task
-    thread_pool* m_pool = nullptr;  // If non-NULL, custom thread pool
-    // string_view m_name;             // For debugging
+    int m_maxthreads       = 0;        // Max threads (0 = use all)
+    SplitDir m_splitdir    = Split_Y;  // Primary split direction
+    size_t m_minitems      = 16384;    // Min items per task
+    thread_pool* m_pool    = nullptr;  // If non-NULL, custom thread pool
     ParStrategy m_strategy = ParStrategy::Default;
-};
-
-
-
-// Mimic Cuda dim3 type
-struct dim3 {
-    unsigned int x, y, z;
-
-    OIIO_HOSTDEVICE constexpr dim3(unsigned int x = 1, unsigned int y = 1,
-                                   unsigned int z = 1)
-        : x(x), y(y), z(z) {}
+    bool m_recursive       = false;  // Allow thread pool recursion
 };
 
 
@@ -194,20 +208,20 @@ parallel_for_chunked(int64_t begin, int64_t end, int64_t chunksize,
 /// (to aid data coherence and minimize the amount of thread queue
 /// diddling). The chunk size is chosen automatically.
 OIIO_UTIL_API void
-parallel_for(int32_t begin, int32_t end,
-             function_view<void(int32_t)> task, paropt opt = 0);
+parallel_for(int32_t begin, int32_t end, function_view<void(int32_t)> task,
+             paropt opt = 0);
 
 OIIO_UTIL_API void
-parallel_for(int64_t begin, int64_t end,
-             function_view<void(int64_t)> task, paropt opt = 0);
+parallel_for(int64_t begin, int64_t end, function_view<void(int64_t)> task,
+             paropt opt = 0);
 
 OIIO_UTIL_API void
-parallel_for(uint32_t begin, uint32_t end,
-             function_view<void(uint32_t)> task, paropt opt = 0);
+parallel_for(uint32_t begin, uint32_t end, function_view<void(uint32_t)> task,
+             paropt opt = 0);
 
 OIIO_UTIL_API void
-parallel_for(uint64_t begin, uint64_t end,
-             function_view<void(uint64_t)> task, paropt opt = 0);
+parallel_for(uint64_t begin, uint64_t end, function_view<void(uint64_t)> task,
+             paropt opt = 0);
 
 
 /// Parallel "for" loop, for a task that takes an integer range, run it
@@ -256,11 +270,11 @@ parallel_for_range(uint64_t begin, uint64_t end,
 /// (We do this to offer better load balancing than if we used exactly the
 /// thread count.)
 OIIO_UTIL_API void
-parallel_for_chunked_2D (int64_t xbegin, int64_t xend, int64_t xchunksize,
-                         int64_t ybegin, int64_t yend, int64_t ychunksize,
-                         std::function<void(int64_t xbeg, int64_t xend,
-                                            int64_t ybeg, int64_t yend)>&& task,
-                         paropt opt=0);
+parallel_for_chunked_2D(int64_t xbegin, int64_t xend, int64_t xchunksize,
+                        int64_t ybegin, int64_t yend, int64_t ychunksize,
+                        std::function<void(int64_t xbeg, int64_t xend,
+                                           int64_t ybeg, int64_t yend)>&& task,
+                        paropt opt = 0);
 
 
 
@@ -274,14 +288,13 @@ parallel_for_chunked_2D (int64_t xbegin, int64_t xend, int64_t xchunksize,
 ///    ...
 ///    task (xend-1, yend-1);
 OIIO_UTIL_API void
-parallel_for_2D (int64_t xbegin, int64_t xend,
-                 int64_t ybegin, int64_t yend,
-                 std::function<void(int64_t x, int64_t y)>&& task,
-                 paropt opt=0);
+parallel_for_2D(int64_t xbegin, int64_t xend, int64_t ybegin, int64_t yend,
+                std::function<void(int64_t x, int64_t y)>&& task,
+                paropt opt = 0);
 
 
 
-#if OIIO_VERSION < OIIO_MAKE_VERSION(3,0,0)
+#if OIIO_VERSION < OIIO_MAKE_VERSION(3, 0, 0)
 
 // Deprecated versions of parallel loops where the task functions take a
 // thread ID in addition to the range. These are deprecated as of OIIO 2.3,
@@ -298,29 +311,30 @@ parallel_for_chunked(int64_t begin, int64_t end, int64_t chunksize,
 OIIO_UTIL_API void
 parallel_for(int64_t begin, int64_t end,
              std::function<void(int id, int64_t index)>&& task,
-             paropt opt = paropt(0,Split_Y,1));
+             paropt opt = paropt(0, Split_Y, 1));
 
 // OIIO_DEPRECATED("Use tasks that don't take a thread ID (2.3)")
 OIIO_UTIL_API void
-parallel_for_chunked_2D (int64_t xbegin, int64_t xend, int64_t xchunksize,
-                         int64_t ybegin, int64_t yend, int64_t ychunksize,
-                         std::function<void(int id, int64_t, int64_t,
-                                            int64_t, int64_t)>&& task,
-                         paropt opt=0);
+parallel_for_chunked_2D(
+    int64_t xbegin, int64_t xend, int64_t xchunksize, int64_t ybegin,
+    int64_t yend, int64_t ychunksize,
+    std::function<void(int id, int64_t, int64_t, int64_t, int64_t)>&& task,
+    paropt opt = 0);
 
 // OIIO_DEPRECATED("Use tasks that don't take a thread ID (2.3)")
 inline void
-parallel_for_2D (int64_t xbegin, int64_t xend,
-                 int64_t ybegin, int64_t yend,
-                 std::function<void(int id, int64_t i, int64_t j)>&& task,
-                 paropt opt=0)
+parallel_for_2D(int64_t xbegin, int64_t xend, int64_t ybegin, int64_t yend,
+                std::function<void(int id, int64_t i, int64_t j)>&& task,
+                paropt opt = 0)
 {
-    parallel_for_chunked_2D (xbegin, xend, 0, ybegin, yend, 0,
-            [&task](int id, int64_t xb, int64_t xe, int64_t yb, int64_t ye) {
-        for (auto y = yb; y < ye; ++y)
-            for (auto x = xb; x < xe; ++x)
-                task (id, x, y);
-    }, opt);
+    parallel_for_chunked_2D(
+        xbegin, xend, 0, ybegin, yend, 0,
+        [&task](int id, int64_t xb, int64_t xe, int64_t yb, int64_t ye) {
+            for (auto y = yb; y < ye; ++y)
+                for (auto x = xb; x < xe; ++x)
+                    task(id, x, y);
+        },
+        opt);
 }
 
 // Deprecated parallel_for_each. We never used it and I decided I didn't
@@ -331,8 +345,8 @@ parallel_for_2D (int64_t xbegin, int64_t xend,
 template<class InputIt, class UnaryFunction>
 // OIIO_DEPRECATED("Don't use this (2.3)")
 UnaryFunction
-parallel_for_each (InputIt begin, InputIt end, UnaryFunction f,
-                   paropt opt = paropt(0,Split_Y,1))
+parallel_for_each(InputIt begin, InputIt end, UnaryFunction f,
+                  paropt opt = paropt(0, Split_Y, 1))
 {
     return std::for_each(begin, end, f);
 }
@@ -341,12 +355,13 @@ parallel_for_each (InputIt begin, InputIt end, UnaryFunction f,
 // weren't used. Preserve for a version to not break 3rd party apps.
 OIIO_DEPRECATED("Use the version without chunk sizes (1.8)")
 inline void
-parallel_for_2D (int64_t xbegin, int64_t xend, int64_t /*xchunksize*/,
-                 int64_t ybegin, int64_t yend, int64_t /*ychunksize*/,
-                 std::function<void(int id, int64_t i, int64_t j)>&& task)
+parallel_for_2D(int64_t xbegin, int64_t xend, int64_t /*xchunksize*/,
+                int64_t ybegin, int64_t yend, int64_t /*ychunksize*/,
+                std::function<void(int id, int64_t i, int64_t j)>&& task)
 {
-    parallel_for_2D (xbegin, xend, ybegin, yend,
-                     std::forward<std::function<void(int,int64_t,int64_t)>>(task));
+    parallel_for_2D(xbegin, xend, ybegin, yend,
+                    std::forward<std::function<void(int, int64_t, int64_t)>>(
+                        task));
 }
 
 #endif /* Deprecated functions */

--- a/src/include/OpenImageIO/parallel.h
+++ b/src/include/OpenImageIO/parallel.h
@@ -76,7 +76,7 @@ public:
 
 /// Encapsulation of options that control parallel_for() and
 /// parallel_image().
-class paropt {
+class OIIO_UTIL_API paropt {
 public:
     enum class ParStrategy { Default = 0, TryTBB, OIIOpool };
 
@@ -114,7 +114,7 @@ public:
     // * If no max thread count was specified, use the pool size.
     // * If the calling thread is itself in the pool and the recursive flag
     //   was not turned on, just use one thread.
-    OIIO_API void resolve();
+    void resolve();
 
     constexpr bool singlethread() const noexcept { return m_maxthreads == 1; }
 
@@ -174,7 +174,7 @@ struct dim3 {
 /// a number of chunks equal to the twice number of threads in the queue.
 /// (We do this to offer better load balancing than if we used exactly the
 /// thread count.)
-OIIO_API void
+OIIO_UTIL_API void
 parallel_for_chunked(int64_t begin, int64_t end, int64_t chunksize,
                      std::function<void(int64_t, int64_t)>&& task,
                      paropt opt = paropt(0, Split_Y, 1));
@@ -193,19 +193,19 @@ parallel_for_chunked(int64_t begin, int64_t end, int64_t chunksize,
 /// actually each thread will iterate over some chunk of adjacent indices
 /// (to aid data coherence and minimize the amount of thread queue
 /// diddling). The chunk size is chosen automatically.
-OIIO_API void
+OIIO_UTIL_API void
 parallel_for(int32_t begin, int32_t end,
              function_view<void(int32_t)> task, paropt opt = 0);
 
-OIIO_API void
+OIIO_UTIL_API void
 parallel_for(int64_t begin, int64_t end,
              function_view<void(int64_t)> task, paropt opt = 0);
 
-OIIO_API void
+OIIO_UTIL_API void
 parallel_for(uint32_t begin, uint32_t end,
              function_view<void(uint32_t)> task, paropt opt = 0);
 
-OIIO_API void
+OIIO_UTIL_API void
 parallel_for(uint64_t begin, uint64_t end,
              function_view<void(uint64_t)> task, paropt opt = 0);
 
@@ -220,22 +220,22 @@ parallel_for(uint64_t begin, uint64_t end,
 ///
 /// The chunk sizes will be chosen automatically, and are not guaranteed
 /// to all be the same size.
-OIIO_API void
+OIIO_UTIL_API void
 parallel_for_range(int32_t begin, int32_t end,
                    std::function<void(int32_t, int32_t)>&& task,
                    paropt opt = 0);
 
-OIIO_API void
+OIIO_UTIL_API void
 parallel_for_range(int64_t begin, int64_t end,
                    std::function<void(int64_t, int64_t)>&& task,
                    paropt opt = 0);
 
-OIIO_API void
+OIIO_UTIL_API void
 parallel_for_range(uint32_t begin, uint32_t end,
                    std::function<void(uint32_t, uint32_t)>&& task,
                    paropt opt = 0);
 
-OIIO_API void
+OIIO_UTIL_API void
 parallel_for_range(uint64_t begin, uint64_t end,
                    std::function<void(uint64_t, uint64_t)>&& task,
                    paropt opt = 0);
@@ -255,7 +255,7 @@ parallel_for_range(uint64_t begin, uint64_t end,
 /// a number of chunks equal to the twice number of threads in the queue.
 /// (We do this to offer better load balancing than if we used exactly the
 /// thread count.)
-OIIO_API void
+OIIO_UTIL_API void
 parallel_for_chunked_2D (int64_t xbegin, int64_t xend, int64_t xchunksize,
                          int64_t ybegin, int64_t yend, int64_t ychunksize,
                          std::function<void(int64_t xbeg, int64_t xend,
@@ -273,7 +273,7 @@ parallel_for_chunked_2D (int64_t xbegin, int64_t xend, int64_t xchunksize,
 ///    task (xend-1, ybegin+1);
 ///    ...
 ///    task (xend-1, yend-1);
-OIIO_API void
+OIIO_UTIL_API void
 parallel_for_2D (int64_t xbegin, int64_t xend,
                  int64_t ybegin, int64_t yend,
                  std::function<void(int64_t x, int64_t y)>&& task,
@@ -289,19 +289,19 @@ parallel_for_2D (int64_t xbegin, int64_t xend,
 // starting with OIIO 3.0.
 
 // OIIO_DEPRECATED("Use tasks that don't take a thread ID (2.3)")
-OIIO_API void
+OIIO_UTIL_API void
 parallel_for_chunked(int64_t begin, int64_t end, int64_t chunksize,
                      std::function<void(int id, int64_t b, int64_t e)>&& task,
                      paropt opt = paropt(0, Split_Y, 1));
 
 // OIIO_DEPRECATED("Use tasks that don't take a thread ID (2.3)")
-OIIO_API void
+OIIO_UTIL_API void
 parallel_for(int64_t begin, int64_t end,
              std::function<void(int id, int64_t index)>&& task,
              paropt opt = paropt(0,Split_Y,1));
 
 // OIIO_DEPRECATED("Use tasks that don't take a thread ID (2.3)")
-OIIO_API void
+OIIO_UTIL_API void
 parallel_for_chunked_2D (int64_t xbegin, int64_t xend, int64_t xchunksize,
                          int64_t ybegin, int64_t yend, int64_t ychunksize,
                          std::function<void(int id, int64_t, int64_t,

--- a/src/include/OpenImageIO/parallel.h
+++ b/src/include/OpenImageIO/parallel.h
@@ -14,6 +14,7 @@
 #include <thread>
 #include <vector>
 
+#include <OpenImageIO/function_view.h>
 #include <OpenImageIO/strutil.h>
 #include <OpenImageIO/thread.h>
 
@@ -24,7 +25,8 @@ OIIO_NAMESPACE_BEGIN
 enum SplitDir { Split_X, Split_Y, Split_Z, Split_Biggest, Split_Tile };
 
 
-/// Encapsulation of options that control parallel_image().
+/// Encapsulation of options that control parallel_for() and
+/// parallel_image().
 class parallel_options {
 public:
     parallel_options(int maxthreads = 0, SplitDir splitdir = Split_Y,
@@ -70,14 +72,101 @@ public:
 
 
 
-/// Parallel "for" loop, chunked: for a task that takes an int thread ID
-/// followed by an int64_t [begin,end) range, break it into non-overlapping
-/// sections that run in parallel using the default thread pool:
+#define OIIO_PARALLEL_PAROPT
+
+/// Encapsulation of options that control parallel_for() and
+/// parallel_image().
+class paropt {
+public:
+    enum class ParStrategy { Default = 0, TryTBB, OIIOpool };
+
+    constexpr paropt(int maxthreads = 0, SplitDir splitdir = Split_Y,
+                     size_t minitems = 1024) noexcept
+        : m_maxthreads(maxthreads)
+        , m_splitdir(splitdir)
+        , m_minitems(minitems)
+    {
+    }
+    paropt(string_view name, int maxthreads = 0,
+           SplitDir splitdir = Split_Y, size_t minitems = 1024) noexcept
+        : paropt(maxthreads, splitdir, minitems)
+    {
+        // m_name = name;
+    }
+
+    constexpr paropt(ParStrategy strat) noexcept : m_strategy(strat) { }
+
+    constexpr paropt(int maxthreads, ParStrategy strat) noexcept
+        : m_maxthreads(maxthreads), m_strategy(strat)
+    {
+    }
+
+    // For back compatibility
+    paropt(const parallel_options& po) noexcept
+        : paropt(po.name, po.maxthreads, po.splitdir, po.minitems)
+    {
+        m_recursive = po.recursive;
+        m_pool = po.pool;
+    }
+
+    // Fix up all the TBD parameters:
+    // * If no pool was specified, use the default pool.
+    // * If no max thread count was specified, use the pool size.
+    // * If the calling thread is itself in the pool and the recursive flag
+    //   was not turned on, just use one thread.
+    OIIO_API void resolve();
+
+    constexpr bool singlethread() const noexcept { return m_maxthreads == 1; }
+
+    constexpr int maxthreads() const noexcept { return m_maxthreads; }
+    paropt& maxthreads(int m) noexcept { m_maxthreads = m; return *this; }
+
+    constexpr SplitDir splitdir() const noexcept { return m_splitdir; }
+    paropt& splitdir(SplitDir s) noexcept { m_splitdir = s; return *this; }
+
+    constexpr bool recursive() const noexcept { return m_recursive; }
+    paropt& recursive(bool r) noexcept { m_recursive = r; return *this; }
+
+    constexpr int minitems() const noexcept { return m_minitems; }
+    paropt& minitems(int m) noexcept { m_minitems = m; return *this; }
+
+    thread_pool* pool() const noexcept { return m_pool; }
+    paropt& pool(thread_pool* p) noexcept { m_pool = p; return *this; }
+
+    constexpr ParStrategy strategy() const noexcept { return m_strategy; }
+    paropt& strategy(ParStrategy s) noexcept { m_strategy = s; return *this; }
+
+private:
+    int m_maxthreads    = 0;        // Max threads (0 = use all)
+    SplitDir m_splitdir = Split_Y;  // Primary split direction
+    bool m_recursive    = false;    // Allow thread pool recursion
+    size_t m_minitems   = 16384;    // Min items per task
+    thread_pool* m_pool = nullptr;  // If non-NULL, custom thread pool
+    // string_view m_name;             // For debugging
+    ParStrategy m_strategy = ParStrategy::Default;
+};
+
+
+
+// Mimic Cuda dim3 type
+struct dim3 {
+    unsigned int x, y, z;
+
+    OIIO_HOSTDEVICE constexpr dim3(unsigned int x = 1, unsigned int y = 1,
+                                   unsigned int z = 1)
+        : x(x), y(y), z(z) {}
+};
+
+
+
+/// Parallel "for" loop, chunked: for a task that takes an int64_t
+/// [begin,end) range, break it into non-overlapping sections that run in
+/// parallel:
 ///
-///    task (threadid, start, start+chunksize);
-///    task (threadid, start+chunksize, start+2*chunksize);
+///    task (begin, begin+chunksize);
+///    task (begin+chunksize, begin+2*chunksize);
 ///    ...
-///    task (threadid, start+n*chunksize, end);
+///    task (begin+n*chunksize, end);
 ///
 /// and wait for them all to complete.
 ///
@@ -85,32 +174,14 @@ public:
 /// a number of chunks equal to the twice number of threads in the queue.
 /// (We do this to offer better load balancing than if we used exactly the
 /// thread count.)
-///
-/// Note that the thread_id may be -1, indicating that it's being executed
-/// by the calling thread itself, or perhaps some other helpful thread that
-/// is stealing work from the pool.
 OIIO_API void
-parallel_for_chunked(int64_t start, int64_t end, int64_t chunksize,
-                     std::function<void(int id, int64_t b, int64_t e)>&& task,
-                     parallel_options opt = parallel_options(0, Split_Y, 1));
-// Implementation is in thread.cpp
-
-
-
-/// Parallel "for" loop, chunked: for a task that takes a [begin,end) range
-/// (but not a thread ID).
-inline void
-parallel_for_chunked(int64_t start, int64_t end, int64_t chunksize,
+parallel_for_chunked(int64_t begin, int64_t end, int64_t chunksize,
                      std::function<void(int64_t, int64_t)>&& task,
-                     parallel_options opt = parallel_options(0, Split_Y, 1))
-{
-    auto wrapper = [&](int /*id*/, int64_t b, int64_t e) { task(b, e); };
-    parallel_for_chunked(start, end, chunksize, wrapper, opt);
-}
+                     paropt opt = paropt(0, Split_Y, 1));
 
 
 
-/// Parallel "for" loop, for a task that takes a single int64_t index, run
+/// Parallel "for" loop, for a task that takes a single integer index, run
 /// it on all indices on the range [begin,end):
 ///
 ///    task (begin);
@@ -118,74 +189,65 @@ parallel_for_chunked(int64_t start, int64_t end, int64_t chunksize,
 ///    ...
 ///    task (end-1);
 ///
-/// Using the default thread pool, spawn parallel jobs. Conceptually, it
-/// behaves as if each index gets called separately, but actually each
-/// thread will iterate over some chunk of adjacent indices (to aid data
-/// coherence and minimize the amount of thread queue diddling). The chunk
-/// size is chosen automatically.
-inline void
-parallel_for (int64_t start, int64_t end,
-              std::function<void(int64_t index)>&& task,
-              parallel_options opt=parallel_options(0,Split_Y,1))
-{
-    parallel_for_chunked (start, end, 0, [&task](int /*id*/, int64_t i, int64_t e) {
-        for ( ; i < e; ++i)
-            task (i);
-    }, opt);
-}
+/// Conceptually, it behaves as if each index gets called separately, but
+/// actually each thread will iterate over some chunk of adjacent indices
+/// (to aid data coherence and minimize the amount of thread queue
+/// diddling). The chunk size is chosen automatically.
+OIIO_API void
+parallel_for(int32_t begin, int32_t end,
+             function_view<void(int32_t)> task, paropt opt = 0);
+
+OIIO_API void
+parallel_for(int64_t begin, int64_t end,
+             function_view<void(int64_t)> task, paropt opt = 0);
+
+OIIO_API void
+parallel_for(uint32_t begin, uint32_t end,
+             function_view<void(uint32_t)> task, paropt opt = 0);
+
+OIIO_API void
+parallel_for(uint64_t begin, uint64_t end,
+             function_view<void(uint64_t)> task, paropt opt = 0);
 
 
-/// parallel_for, for a task that takes an int threadid and an int64_t
-/// index, running all of:
-///    task (id, begin);
-///    task (id, begin+1);
-///    ...
-///    task (id, end-1);
-inline void
-parallel_for (int64_t start, int64_t end,
-              std::function<void(int id, int64_t index)>&& task,
-              parallel_options opt=parallel_options(0,Split_Y,1))
-{
-    parallel_for_chunked (start, end, 0, [&task](int id, int64_t i, int64_t e) {
-        for ( ; i < e; ++i)
-            task (id, i);
-    }, opt);
-}
-
-
-
-/// parallel_for_each, semantically is like std::for_each(), but each
-/// iteration is a separate job for the default thread pool.
-template<class InputIt, class UnaryFunction>
-UnaryFunction
-parallel_for_each (InputIt first, InputIt last, UnaryFunction f,
-                   parallel_options opt=parallel_options(0,Split_Y,1))
-{
-    opt.resolve ();
-    task_set ts (opt.pool);
-    for ( ; first != last; ++first) {
-        if (opt.singlethread() || opt.pool->very_busy()) {
-            // If we are using just one thread, or if the pool is already
-            // oversubscribed, do it ourselves and avoid messing with the
-            // queue or handing off between threads.
-            f (*first);
-        } else {
-            ts.push (opt.pool->push ([&](int /*id*/){ f(*first); }));
-        }
-    }
-    return std::move(f);
-}
-
-
-
-/// Parallel "for" loop in 2D, chunked: for a task that takes an int thread
-/// ID followed by begin, end, chunksize for each of x and y, subdivide that
-/// run in parallel using the default thread pool.
+/// Parallel "for" loop, for a task that takes an integer range, run it
+/// on all indices on the range [begin,end):
 ///
-///    task (threadid, xstart, xstart+xchunksize, );
-///    task (threadid, start+chunksize, start+2*chunksize);
+///    task (begin, i1);
+///    task (i1+1, i2);
 ///    ...
-///    task (threadid, start+n*chunksize, end);
+///    task (iN+1, end);
+///
+/// The chunk sizes will be chosen automatically, and are not guaranteed
+/// to all be the same size.
+OIIO_API void
+parallel_for_range(int32_t begin, int32_t end,
+                   std::function<void(int32_t, int32_t)>&& task,
+                   paropt opt = 0);
+
+OIIO_API void
+parallel_for_range(int64_t begin, int64_t end,
+                   std::function<void(int64_t, int64_t)>&& task,
+                   paropt opt = 0);
+
+OIIO_API void
+parallel_for_range(uint32_t begin, uint32_t end,
+                   std::function<void(uint32_t, uint32_t)>&& task,
+                   paropt opt = 0);
+
+OIIO_API void
+parallel_for_range(uint64_t begin, uint64_t end,
+                   std::function<void(uint64_t, uint64_t)>&& task,
+                   paropt opt = 0);
+
+
+/// Parallel "for" loop, chunked: for a task that takes a 2D [begin,end)
+/// range and chunk sizes, subdivide that range and run in parallel:
+///
+///    task (begin, begin+chunksize);
+///    task (begin+chunksize, begin+2*chunksize);
+///    ...
+///    task (begin+n*chunksize, end);
 ///
 /// and wait for them all to complete.
 ///
@@ -194,48 +256,66 @@ parallel_for_each (InputIt first, InputIt last, UnaryFunction f,
 /// (We do this to offer better load balancing than if we used exactly the
 /// thread count.)
 OIIO_API void
-parallel_for_chunked_2D (int64_t xstart, int64_t xend, int64_t xchunksize,
-                         int64_t ystart, int64_t yend, int64_t ychunksize,
-                         std::function<void(int id, int64_t, int64_t,
-                                            int64_t, int64_t)>&& task,
-                         parallel_options opt=0);
-// Implementation is in thread.cpp
-
-
-
-/// Parallel "for" loop, chunked: for a task that takes a 2D [begin,end)
-/// range and chunk sizes.
-inline void
-parallel_for_chunked_2D (int64_t xstart, int64_t xend, int64_t xchunksize,
-                         int64_t ystart, int64_t yend, int64_t ychunksize,
-                         std::function<void(int64_t, int64_t,
-                                            int64_t, int64_t)>&& task,
-                         parallel_options opt=0)
-{
-    auto wrapper = [&](int /*id*/, int64_t xb, int64_t xe,
-                       int64_t yb, int64_t ye) { task(xb,xe,yb,ye); };
-    parallel_for_chunked_2D (xstart, xend, xchunksize,
-                             ystart, yend, ychunksize, wrapper, opt);
-}
+parallel_for_chunked_2D (int64_t xbegin, int64_t xend, int64_t xchunksize,
+                         int64_t ybegin, int64_t yend, int64_t ychunksize,
+                         std::function<void(int64_t xbeg, int64_t xend,
+                                            int64_t ybeg, int64_t yend)>&& task,
+                         paropt opt=0);
 
 
 
 /// parallel_for, for a task that takes an int threadid and int64_t x & y
 /// indices, running all of:
-///    task (id, xstart, ystart);
+///    task (xbegin, ybegin);
 ///    ...
-///    task (id, xend-1, ystart);
-///    task (id, xstart, ystart+1);
-///    task (id, xend-1, ystart+1);
+///    task (xend-1, ybegin);
+///    task (xbegin, ybegin+1);
+///    task (xend-1, ybegin+1);
 ///    ...
-///    task (id, xend-1, yend-1);
+///    task (xend-1, yend-1);
+OIIO_API void
+parallel_for_2D (int64_t xbegin, int64_t xend,
+                 int64_t ybegin, int64_t yend,
+                 std::function<void(int64_t x, int64_t y)>&& task,
+                 paropt opt=0);
+
+
+
+#if OIIO_VERSION < OIIO_MAKE_VERSION(3,0,0)
+
+// Deprecated versions of parallel loops where the task functions take a
+// thread ID in addition to the range. These are deprecated as of OIIO 2.3,
+// will warn about deprecation starting in OIIO 2.4, and will be removed
+// starting with OIIO 3.0.
+
+// OIIO_DEPRECATED("Use tasks that don't take a thread ID (2.3)")
+OIIO_API void
+parallel_for_chunked(int64_t begin, int64_t end, int64_t chunksize,
+                     std::function<void(int id, int64_t b, int64_t e)>&& task,
+                     paropt opt = paropt(0, Split_Y, 1));
+
+// OIIO_DEPRECATED("Use tasks that don't take a thread ID (2.3)")
+OIIO_API void
+parallel_for(int64_t begin, int64_t end,
+             std::function<void(int id, int64_t index)>&& task,
+             paropt opt = paropt(0,Split_Y,1));
+
+// OIIO_DEPRECATED("Use tasks that don't take a thread ID (2.3)")
+OIIO_API void
+parallel_for_chunked_2D (int64_t xbegin, int64_t xend, int64_t xchunksize,
+                         int64_t ybegin, int64_t yend, int64_t ychunksize,
+                         std::function<void(int id, int64_t, int64_t,
+                                            int64_t, int64_t)>&& task,
+                         paropt opt=0);
+
+// OIIO_DEPRECATED("Use tasks that don't take a thread ID (2.3)")
 inline void
-parallel_for_2D (int64_t xstart, int64_t xend,
-                 int64_t ystart, int64_t yend,
+parallel_for_2D (int64_t xbegin, int64_t xend,
+                 int64_t ybegin, int64_t yend,
                  std::function<void(int id, int64_t i, int64_t j)>&& task,
-                 parallel_options opt=0)
+                 paropt opt=0)
 {
-    parallel_for_chunked_2D (xstart, xend, 0, ystart, yend, 0,
+    parallel_for_chunked_2D (xbegin, xend, 0, ybegin, yend, 0,
             [&task](int id, int64_t xb, int64_t xe, int64_t yb, int64_t ye) {
         for (auto y = yb; y < ye; ++y)
             for (auto x = xb; x < xe; ++x)
@@ -243,43 +323,33 @@ parallel_for_2D (int64_t xstart, int64_t xend,
     }, opt);
 }
 
-
-
-/// parallel_for, for a task that takes an int threadid and int64_t x & y
-/// indices, running all of:
-///    task (xstart, ystart);
-///    ...
-///    task (xend-1, ystart);
-///    task (xstart, ystart+1);
-///    task (xend-1, ystart+1);
-///    ...
-///    task (xend-1, yend-1);
-inline void
-parallel_for_2D (int64_t xstart, int64_t xend,
-                 int64_t ystart, int64_t yend,
-                 std::function<void(int64_t i, int64_t j)>&& task,
-                 parallel_options opt=0)
+// Deprecated parallel_for_each. We never used it and I decided I didn't
+// like the implementation and didn't want its guts exposed any more. For
+// compatibility (just in case somebody has used it), implement it serially
+// so that it's correct, even if it's not fast. It will eventually be
+// removed.
+template<class InputIt, class UnaryFunction>
+// OIIO_DEPRECATED("Don't use this (2.3)")
+UnaryFunction
+parallel_for_each (InputIt begin, InputIt end, UnaryFunction f,
+                   paropt opt = paropt(0,Split_Y,1))
 {
-    parallel_for_chunked_2D (xstart, xend, 0, ystart, yend, 0,
-            [&task](int /*id*/, int64_t xb, int64_t xe, int64_t yb, int64_t ye) {
-        for (auto y = yb; y < ye; ++y)
-            for (auto x = xb; x < xe; ++x)
-                task (x, y);
-    }, opt);
+    return std::for_each(begin, end, f);
 }
-
-
 
 // DEPRECATED(1.8): This version accidentally accepted chunksizes that
 // weren't used. Preserve for a version to not break 3rd party apps.
 OIIO_DEPRECATED("Use the version without chunk sizes (1.8)")
 inline void
-parallel_for_2D (int64_t xstart, int64_t xend, int64_t /*xchunksize*/,
-                 int64_t ystart, int64_t yend, int64_t /*ychunksize*/,
+parallel_for_2D (int64_t xbegin, int64_t xend, int64_t /*xchunksize*/,
+                 int64_t ybegin, int64_t yend, int64_t /*ychunksize*/,
                  std::function<void(int id, int64_t i, int64_t j)>&& task)
 {
-    parallel_for_2D (xstart, xend, ystart, yend,
+    parallel_for_2D (xbegin, xend, ybegin, yend,
                      std::forward<std::function<void(int,int64_t,int64_t)>>(task));
 }
+
+#endif /* Deprecated functions */
+
 
 OIIO_NAMESPACE_END

--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -137,6 +137,7 @@ target_link_libraries (OpenImageIO
             $<TARGET_NAME_IF_EXISTS:OpenColorIO::OpenColorIO>
             $<TARGET_NAME_IF_EXISTS:OpenColorIO::OpenColorIOHeaders>
             $<TARGET_NAME_IF_EXISTS:pugixml::pugixml>
+            $<TARGET_NAME_IF_EXISTS:TBB::tbb>
             ${BZIP2_LIBRARIES}
             ZLIB::ZLIB
             Boost::filesystem

--- a/src/libOpenImageIO/imagebufalgo_compare.cpp
+++ b/src/libOpenImageIO/imagebufalgo_compare.cpp
@@ -137,7 +137,7 @@ computePixelStats_(const ImageBuf& src, ImageBufAlgo::PixelStats& stats,
     parallel_options opt(nthreads);
     if (src.deep()) {
         parallel_for_chunked(roi.ybegin, roi.yend, 64,
-                             [&](int /*id*/, int64_t ybegin, int64_t yend) {
+                             [&](int64_t ybegin, int64_t yend) {
             ROI subroi(roi.xbegin, roi.xend, ybegin, yend, roi.zbegin,
                        roi.zend, roi.chbegin, roi.chend);
             ImageBufAlgo::PixelStats tmp(nchannels);
@@ -159,7 +159,7 @@ computePixelStats_(const ImageBuf& src, ImageBufAlgo::PixelStats& stats,
 
     } else {  // Non-deep case
         parallel_for_chunked(roi.ybegin, roi.yend, 64,
-                             [&](int /*id*/, int64_t ybegin, int64_t yend) {
+                             [&](int64_t ybegin, int64_t yend) {
             ROI subroi(roi.xbegin, roi.xend, ybegin, yend, roi.zbegin,
                        roi.zend, roi.chbegin, roi.chend);
             ImageBufAlgo::PixelStats tmp(nchannels);

--- a/src/libOpenImageIO/imageio_pvt.h.in
+++ b/src/libOpenImageIO/imageio_pvt.h.in
@@ -38,6 +38,7 @@ extern int oiio_log_times;
 extern int openexr_core;
 extern int limit_channels;
 extern int limit_imagesize_MB;
+extern OIIO_UTIL_API int oiio_use_tbb; // This lives in libOpenImageIO_Util
 
 
 // For internal use - use error() below for a nicer interface.

--- a/src/libutil/CMakeLists.txt
+++ b/src/libutil/CMakeLists.txt
@@ -14,8 +14,9 @@ target_link_libraries (OpenImageIO_Util
         PUBLIC
             $<TARGET_NAME_IF_EXISTS:Threads::Threads>
             ${GCC_ATOMIC_LIBRARIES}
-        ${OPENIMAGEIO_IMATH_DEPENDENCY_VISIBILITY}
+            ${OPENIMAGEIO_IMATH_DEPENDENCY_VISIBILITY}
             ${OPENIMAGEIO_IMATH_TARGETS}
+            $<TARGET_NAME_IF_EXISTS:TBB::tbb>
         PRIVATE
             Boost::filesystem
             Boost::system

--- a/src/libutil/parallel_test.cpp
+++ b/src/libutil/parallel_test.cpp
@@ -124,13 +124,13 @@ test_thread_pool_recursion()
     static spin_mutex print_mutex;
     thread_pool* pool(default_thread_pool());
     pool->resize(2);
-    parallel_for(0, 10, [&](int /*id*/, int64_t /*i*/) {
+    parallel_for(0, 10, [&](int64_t /*i*/) {
         // sleep long enough that we can push all the jobs before any get
         // done.
         Sysutil::usleep(10);
         // then run something else that itself will push jobs onto the
         // thread pool queue.
-        parallel_for(0, 10, [&](int /*id*/, int64_t /*i*/) {
+        parallel_for(0, 10, [&](int64_t /*i*/) {
             Sysutil::usleep(2);
             spin_lock lock(print_mutex);
             // std::cout << "  recursive running thread " << id << std::endl;

--- a/src/libutil/thread.cpp
+++ b/src/libutil/thread.cpp
@@ -29,7 +29,8 @@
 #include <OpenImageIO/thread.h>
 
 #if OIIO_TBB
-#    include <tbb/tbb.h>
+#    include <tbb/parallel_for.h>
+#    include <tbb/task_arena.h>
 #endif
 
 #include <boost/container/flat_map.hpp>
@@ -657,7 +658,7 @@ parallel_for_chunked(int64_t begin, int64_t end, int64_t chunksize,
 void
 parallel_for_chunked(int64_t begin, int64_t end, int64_t chunksize,
                      std::function<void(int id, int64_t b, int64_t e)>&& task,
-                     paropt opt)
+                     parallel_options opt)
 {
     parallel_for_chunked_id(begin, end, chunksize, std::move(task), opt);
 }
@@ -861,7 +862,7 @@ parallel_for_chunked_2D(
     int64_t xbegin, int64_t xend, int64_t xchunksize, int64_t ybegin,
     int64_t yend, int64_t ychunksize,
     std::function<void(int id, int64_t, int64_t, int64_t, int64_t)>&& task,
-    paropt opt)
+    parallel_options opt)
 {
     parallel_for_chunked_2D_id(xbegin, xend, xchunksize, ybegin, yend,
                                ychunksize, std::move(task), opt);

--- a/src/libutil/thread.cpp
+++ b/src/libutil/thread.cpp
@@ -28,6 +28,10 @@
 #include <OpenImageIO/sysutil.h>
 #include <OpenImageIO/thread.h>
 
+#if OIIO_TBB
+#    include <tbb/tbb.h>
+#endif
+
 #include <boost/container/flat_map.hpp>
 
 #if 0
@@ -86,6 +90,11 @@ OIIO_NAMESPACE_END
 
 
 OIIO_NAMESPACE_BEGIN
+
+namespace pvt {
+OIIO_UTIL_API int oiio_use_tbb(0);  // Use TBB if available
+}
+
 
 static int
 threads_default()
@@ -585,34 +594,47 @@ parallel_recursive_depth(int change = 0)
 
 
 void
-parallel_for_chunked(int64_t start, int64_t end, int64_t chunksize,
-                     std::function<void(int id, int64_t b, int64_t e)>&& task,
-                     parallel_options opt)
+paropt::resolve()
+{
+    if (m_pool == nullptr)
+        m_pool = default_thread_pool();
+    if (m_maxthreads <= 0)
+        m_maxthreads = m_pool->size() + 1;  // pool size + caller
+    if (!m_recursive && m_pool->is_worker())
+        m_maxthreads = 1;
+}
+
+
+
+void
+parallel_for_chunked_id(int64_t begin, int64_t end, int64_t chunksize,
+                        std::function<void(int id, int64_t b, int64_t e)>&& task,
+                        paropt opt)
 {
     if (parallel_recursive_depth(1) > 1)
-        opt.maxthreads = 1;
+        opt.maxthreads(1);
     opt.resolve();
-    chunksize = std::min(chunksize, end - start);
+    chunksize = std::min(chunksize, end - begin);
     if (chunksize < 1) {           // If caller left chunk size to us...
         if (opt.singlethread()) {  // Single thread: do it all in one shot
-            chunksize = end - start;
+            chunksize = end - begin;
         } else {  // Multithread: choose a good chunk size
-            int p     = std::max(1, 2 * opt.maxthreads);
-            chunksize = std::max(int64_t(opt.minitems), (end - start) / p);
+            int p     = std::max(1, 2 * opt.maxthreads());
+            chunksize = std::max(int64_t(opt.minitems()), (end - begin) / p);
         }
     }
     // N.B. If chunksize was specified, honor it, even for the single
     // threaded case.
-    for (task_set ts(opt.pool); start < end; start += chunksize) {
-        int64_t e = std::min(end, start + chunksize);
-        if (e == end || opt.singlethread() || opt.pool->very_busy()) {
+    for (task_set ts(opt.pool()); begin < end; begin += chunksize) {
+        int64_t e = std::min(end, begin + chunksize);
+        if (e == end || opt.singlethread() || opt.pool()->very_busy()) {
             // For the last (or only) subtask, or if we are using just one
             // thread, or if the pool is already oversubscribed, do it
             // ourselves and avoid messing with the queue or handing off
             // between threads.
-            task(-1, start, e);
+            task(-1, begin, e);
         } else {
-            ts.push(opt.pool->push(task, start, e));
+            ts.push(opt.pool()->push(task, begin, e));
         }
     }
     parallel_recursive_depth(-1);
@@ -621,39 +643,258 @@ parallel_for_chunked(int64_t start, int64_t end, int64_t chunksize,
 
 
 void
-parallel_for_chunked_2D(
-    int64_t xstart, int64_t xend, int64_t xchunksize, int64_t ystart,
+parallel_for_chunked(int64_t begin, int64_t end, int64_t chunksize,
+                     std::function<void(int64_t b, int64_t e)>&& task,
+                     paropt opt)
+{
+    auto wrapper = [&](int /*id*/, int64_t b, int64_t e) { task(b, e); };
+    parallel_for_chunked_id(begin, end, chunksize, wrapper, opt);
+}
+
+
+
+// DEPRECATED(2.3)
+void
+parallel_for_chunked(int64_t begin, int64_t end, int64_t chunksize,
+                     std::function<void(int id, int64_t b, int64_t e)>&& task,
+                     paropt opt)
+{
+    parallel_for_chunked_id(begin, end, chunksize, std::move(task), opt);
+}
+
+
+
+template<typename Index>
+inline void
+parallel_for_impl(Index begin, Index end, function_view<void(Index)> task,
+                  paropt opt)
+{
+    if (opt.maxthreads() == 1) {
+        // One thread max? Run in caller's thread.
+        for (auto i = begin; i != end; ++i)
+            task(i);
+        return;
+    }
+#if OIIO_TBB
+    if (opt.strategy() == paropt::ParStrategy::TryTBB
+        || (opt.strategy() == paropt::ParStrategy::Default
+            && pvt::oiio_use_tbb)) {
+        if (opt.maxthreads()) {
+            tbb::task_arena arena(opt.maxthreads());
+            arena.execute([=] { tbb::parallel_for(begin, end, task); });
+        } else {
+            tbb::parallel_for(begin, end, task);
+        }
+        return;
+    }
+#endif
+    parallel_for_chunked_id(
+        int64_t(begin), int64_t(end), 0,
+        [&task](int /*id*/, int64_t b, int64_t e) {
+            for (Index i(b), end(e); i != end; ++i)
+                task(i);
+        },
+        opt);
+}
+
+
+
+void
+parallel_for(int begin, int end, function_view<void(int)> task, paropt opt)
+{
+    parallel_for_impl(begin, end, task, opt);
+}
+
+
+void
+parallel_for(uint32_t begin, uint32_t end, function_view<void(uint32_t)> task,
+             paropt opt)
+{
+    parallel_for_impl(begin, end, task, opt);
+}
+
+
+void
+parallel_for(int64_t begin, int64_t end, function_view<void(int64_t)> task,
+             paropt opt)
+{
+    parallel_for_impl(begin, end, task, opt);
+}
+
+
+void
+parallel_for(uint64_t begin, uint64_t end, function_view<void(uint64_t)> task,
+             paropt opt)
+{
+    parallel_for_impl(begin, end, task, opt);
+}
+
+
+
+template<typename Index>
+inline void
+parallel_for_range_impl(Index begin, Index end,
+                        std::function<void(Index, Index)>&& task, paropt opt)
+{
+    if (opt.maxthreads() == 1) {  // One thread max? Run in caller's thread.
+        task(begin, end);
+        return;
+    }
+#if parlab_TBB
+    if (opt.strategy() == paropt::ParStrategy::TryTBB
+        || (opt.strategy() == paropt::ParStrategy::Default
+            && pvt::oiio_use_tbb)) {
+        auto wrapper = [=](const tbb::blocked_range<Index>& r) {
+            task(r.begin(), r.end());
+        };
+        // OIIO::Strutil::print("tbb\n");
+        if (opt.maxthreads()) {
+            tbb::task_arena arena(opt.maxthreads());
+            arena.execute([=] {
+                tbb::parallel_for(tbb::blocked_range<Index>(begin, end),
+                                  wrapper);
+            });
+        } else {
+            tbb::parallel_for(tbb::blocked_range<Index>(begin, end), wrapper);
+        }
+        return;
+    }
+#endif
+    // OIIO::Strutil::print("oiio\n");
+    OIIO::parallel_for_chunked(
+        int64_t(begin), int64_t(end), 0,
+        [&](int64_t b, int64_t e) { task(Index(b), Index(e)); }, opt);
+}
+
+
+
+void
+parallel_for_range(int32_t begin, int32_t end,
+                   std::function<void(int32_t, int32_t)>&& task, paropt opt)
+{
+    parallel_for_range_impl(begin, end, std::move(task), opt);
+}
+
+
+void
+parallel_for_range(uint32_t begin, uint32_t end,
+                   std::function<void(uint32_t, uint32_t)>&& task, paropt opt)
+{
+    parallel_for_range_impl(begin, end, std::move(task), opt);
+}
+
+
+void
+parallel_for_range(int64_t begin, int64_t end,
+                   std::function<void(int64_t, int64_t)>&& task, paropt opt)
+{
+    parallel_for_range_impl(begin, end, std::move(task), opt);
+}
+
+
+void
+parallel_for_range(uint64_t begin, uint64_t end,
+                   std::function<void(uint64_t, uint64_t)>&& task, paropt opt)
+{
+    parallel_for_range_impl(begin, end, std::move(task), opt);
+}
+
+
+
+// DEPRECATED(2.3)
+void
+parallel_for(int64_t begin, int64_t end,
+             std::function<void(int id, int64_t index)>&& task, paropt opt)
+{
+    parallel_for_chunked_id(
+        begin, end, 0,
+        [&task](int id, int64_t i, int64_t e) {
+            for (; i < e; ++i)
+                task(id, i);
+        },
+        opt);
+}
+
+
+
+void
+parallel_for_chunked_2D_id(
+    int64_t xbegin, int64_t xend, int64_t xchunksize, int64_t ybegin,
     int64_t yend, int64_t ychunksize,
     std::function<void(int id, int64_t, int64_t, int64_t, int64_t)>&& task,
-    parallel_options opt)
+    paropt opt)
 {
     if (parallel_recursive_depth(1) > 1)
-        opt.maxthreads = 1;
+        opt.maxthreads(1);
     opt.resolve();
     if (opt.singlethread()
-        || (xchunksize >= (xend - xstart) && ychunksize >= (yend - ystart))
-        || opt.pool->very_busy()) {
-        task(-1, xstart, xend, ystart, yend);
+        || (xchunksize >= (xend - xbegin) && ychunksize >= (yend - ybegin))
+        || opt.pool()->very_busy()) {
+        task(-1, xbegin, xend, ybegin, yend);
         parallel_recursive_depth(-1);
         return;
     }
     if (ychunksize < 1)
         ychunksize = std::max(int64_t(1),
-                              (yend - ystart) / (2 * opt.maxthreads));
+                              (yend - ybegin) / (2 * opt.maxthreads()));
     if (xchunksize < 1) {
-        int64_t ny = std::max(int64_t(1), (yend - ystart) / ychunksize);
-        int64_t nx = std::max(int64_t(1), opt.maxthreads / ny);
-        xchunksize = std::max(int64_t(1), (xend - xstart) / nx);
+        int64_t ny = std::max(int64_t(1), (yend - ybegin) / ychunksize);
+        int64_t nx = std::max(int64_t(1), opt.maxthreads() / ny);
+        xchunksize = std::max(int64_t(1), (xend - xbegin) / nx);
     }
-    task_set ts(opt.pool);
-    for (auto y = ystart; y < yend; y += ychunksize) {
+    task_set ts(opt.pool());
+    for (auto y = ybegin; y < yend; y += ychunksize) {
         int64_t ychunkend = std::min(yend, y + ychunksize);
-        for (auto x = xstart; x < xend; x += xchunksize) {
+        for (auto x = xbegin; x < xend; x += xchunksize) {
             int64_t xchunkend = std::min(xend, x + xchunksize);
-            ts.push(opt.pool->push(task, x, xchunkend, y, ychunkend));
+            ts.push(opt.pool()->push(task, x, xchunkend, y, ychunkend));
         }
     }
     parallel_recursive_depth(-1);
+}
+
+
+
+// DEPRECATED(2.3)
+void
+parallel_for_chunked_2D(
+    int64_t xbegin, int64_t xend, int64_t xchunksize, int64_t ybegin,
+    int64_t yend, int64_t ychunksize,
+    std::function<void(int id, int64_t, int64_t, int64_t, int64_t)>&& task,
+    paropt opt)
+{
+    parallel_for_chunked_2D_id(xbegin, xend, xchunksize, ybegin, yend,
+                               ychunksize, std::move(task), opt);
+}
+
+
+
+void
+parallel_for_chunked_2D(
+    int64_t xbegin, int64_t xend, int64_t xchunksize, int64_t ybegin,
+    int64_t yend, int64_t ychunksize,
+    std::function<void(int64_t, int64_t, int64_t, int64_t)>&& task, paropt opt)
+{
+    auto wrapper = [&](int /*id*/, int64_t xb, int64_t xe, int64_t yb,
+                       int64_t ye) { task(xb, xe, yb, ye); };
+    parallel_for_chunked_2D_id(xbegin, xend, xchunksize, ybegin, yend,
+                               ychunksize, wrapper, opt);
+}
+
+
+
+void
+parallel_for_2D(int64_t xbegin, int64_t xend, int64_t ybegin, int64_t yend,
+                std::function<void(int64_t i, int64_t j)>&& task, paropt opt)
+{
+    parallel_for_chunked_2D_id(
+        xbegin, xend, 0, ybegin, yend, 0,
+        [&task](int /*id*/, int64_t xb, int64_t xe, int64_t yb, int64_t ye) {
+            for (auto y = yb; y < ye; ++y)
+                for (auto x = xb; x < xe; ++x)
+                    task(x, y);
+        },
+        opt);
 }
 
 

--- a/src/libutil/ustring_test.cpp
+++ b/src/libutil/ustring_test.cpp
@@ -251,7 +251,7 @@ void
 verify_no_collisions()
 {
     // Try to force a hash collision
-    parallel_for(0LL, 1000000LL * int64_t(collide),
+    parallel_for(int64_t(0), int64_t(1000000LL * int64_t(collide)),
                  [](int64_t i) { ustring u = ustring::fmtformat("{:x}", i); });
     std::vector<ustring> collisions;
     size_t ncollisions = ustring::hash_collisions(&collisions);

--- a/src/openvdb.imageio/CMakeLists.txt
+++ b/src/openvdb.imageio/CMakeLists.txt
@@ -4,9 +4,7 @@
 
 if (OpenVDB_FOUND)
     add_oiio_plugin (openvdbinput.cpp
-                     INCLUDE_DIRS ${OPENVDB_INCLUDES} ${TBB_INCLUDE_DIRS}
-                     LINK_LIBRARIES ${OPENVDB_LIBRARIES}
-                                    ${TBB_tbb_LIBRARY}
-                                    $<TARGET_NAME_IF_EXISTS:TBB::tbb>
-    )
+                     INCLUDE_DIRS  ${OPENVDB_INCLUDES} ${TBB_INCLUDE_DIRS}
+                     LINK_LIBRARIES  ${OPENVDB_LIBRARIES}
+                                     $<TARGET_NAME_IF_EXISTS:TBB::tbb>)
 endif()


### PR DESCRIPTION
Hide nearly all of the implementation of the parallel_for family of
methods rather than expose them as inline. This gives us more freedom
to change the implementation in the future without breaking ABI.

Deprecate the parallel methods that take task functions whose first
parameter is the thread ID. The only reason they existed is because
our cobbled together thread_pool used that in its inner workings.  But
there are good reasons why we should not expose that:

  * We never used it anyway.

  * It was not very useful, since sometimes it was a real thread ID, but
    other times it was -1 in cases where the calling thread executed the
    task directly.

  * It is inconsistent with other thread pool implementations that we may
    wish to try in the future.

So better just to not expose those thread IDs at all. Mark those
versions of the parallel loops as deprecated and schedule them for
removal in OIIO 3.0.

If TBB is detected at build time, support will be built in that allows
either the old OIIO built-in pool, or TBB, depending on the setting of
a new global OIIO attribute, "use_tbb" (default 0), if set to nonzero
will use the TBB thread pool.

In my experiments, the TBB thread pool seems slightly better -- I
think because there is less overhead, and maybe the clever
work-stealing it does elps to load balance. It's not used by default,
set the attribute if you want to use it (assuming the build
included. After we've had a chance to test more thoroughly, we may
change to use TBB by default. I'm interested to hear people's thoughts
on the matter.

One case where you almost certainly will want to use the TBB thread
pool is if you're using libOpenImageIO from within an application that
uses TBB for its own threding -- that way you're using one pool for
everything, rather than have two separate thread pools that don't know
about each other (and probably twice as many threads as you have
cores).
