### PR TITLE
Remove a stray reference to half.h in a public header

### DIFF
--- a/src/include/OpenImageIO/imagebufalgo_util.h
+++ b/src/include/OpenImageIO/imagebufalgo_util.h
@@ -8,7 +8,6 @@
 
 #include <functional>
 
-#include <OpenImageIO/half.h>
 #include <OpenImageIO/parallel.h>
 #include <OpenImageIO/imagebufalgo.h>
 


### PR DESCRIPTION
There's no reason to expose this here.
