### PR TITLE
Build: Use std::filesystem when we can

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,7 @@ jobs:
       OPENEXR_VERSION: ${{matrix.openexr_ver}}
       PYBIND11_VERSION: ${{matrix.pybind11_ver}}
       PYTHON_VERSION: ${{matrix.python_ver}}
+      DEBUG_CI: 1
     steps:
       # We would like to use harden-runner, but it flags too many false
       # positives, every time we download a dependency. We should use it only
@@ -274,6 +275,7 @@ jobs:
           - desc: gcc8 C++17 avx exr2.5
             nametag: linux-gcc8
             os: ubuntu-18.04
+            cc_compiler: gcc-8
             cxx_compiler: g++-8
             cxx_std: 17
             openexr_ver: v2.5.8
@@ -301,6 +303,7 @@ jobs:
       OPENEXR_VERSION: ${{matrix.openexr_ver}}
       PYBIND11_VERSION: ${{matrix.pybind11_ver}}
       PYTHON_VERSION: ${{matrix.python_ver}}
+      DEBUG_CI: 1
     steps:
       # We would like to use harden-runner, but it flags too many false
       # positives, every time we download a dependency. We should use it only

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -52,24 +52,23 @@ if (MSVC)
     endif ()
 endif ()
 
-if (BOOST_CUSTOM)
-    set (Boost_FOUND true)
-    # N.B. For a custom version, the caller had better set up the variables
-    # Boost_VERSION, Boost_INCLUDE_DIRS, Boost_LIBRARY_DIRS, Boost_LIBRARIES.
-else ()
-    set (Boost_COMPONENTS filesystem system thread)
-    # The FindBoost.cmake interface is broken if it uses boost's installed
-    # cmake output (e.g. boost 1.70.0, cmake <= 3.14). Specifically it fails
-    # to set the expected variables printed below. So until that's fixed
-    # force FindBoost.cmake to use the original brute force path.
-    set (Boost_NO_BOOST_CMAKE ON)
-    checked_find_package (Boost REQUIRED
-                          VERSION_MIN 1.53
-                          COMPONENTS ${Boost_COMPONENTS}
-                          RECOMMEND_MIN 1.66
-                          RECOMMEND_MIN_REASON "Boost 1.66 is the oldest version our CI tests against"
-                          PRINT Boost_INCLUDE_DIRS Boost_LIBRARIES )
+set (Boost_COMPONENTS system thread)
+# if (NOT USE_STD_FILESYSTEM AND NOT USE_EXP_FILESYSTEM)
+if (NOT USE_STD_FILESYSTEM)
+    list (APPEND Boost_COMPONENTS filesystem)
 endif ()
+message (STATUS "Boost_COMPONENTS = ${Boost_COMPONENTS}")
+# The FindBoost.cmake interface is broken if it uses boost's installed
+# cmake output (e.g. boost 1.70.0, cmake <= 3.14). Specifically it fails
+# to set the expected variables printed below. So until that's fixed
+# force FindBoost.cmake to use the original brute force path.
+set (Boost_NO_BOOST_CMAKE ON)
+checked_find_package (Boost REQUIRED
+                      VERSION_MIN 1.53
+                      COMPONENTS ${Boost_COMPONENTS}
+                      RECOMMEND_MIN 1.66
+                      RECOMMEND_MIN_REASON "Boost 1.66 is the oldest version our CI tests against"
+                      PRINT Boost_INCLUDE_DIRS Boost_LIBRARIES )
 
 # On Linux, Boost 1.55 and higher seems to need to link against -lrt
 if (CMAKE_SYSTEM_NAME MATCHES "Linux"

--- a/src/include/OpenImageIO/filesystem.h
+++ b/src/include/OpenImageIO/filesystem.h
@@ -204,6 +204,11 @@ OIIO_UTIL_API std::string temp_directory_path ();
 
 /// Return a unique filename suitable for making a temporary file or
 /// directory.  The file names are all UTF-8 encoded.
+/// NOTE: this function is not recommended, because it's a known security
+/// and stability issue, since another process *could* create a file of the
+/// same name after the path is retrieved but before it is created. So in
+/// the long run, we want to wean ourselves off this. But in practice, it's
+/// not an emergency. We'll replace this with something else eventually.
 OIIO_UTIL_API std::string unique_path (string_view model="%%%%-%%%%-%%%%-%%%%");
 
 /// Version of fopen that can handle UTF-8 paths even on Windows.

--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -127,7 +127,7 @@ target_compile_features (OpenImageIO
 target_link_libraries (OpenImageIO
         PUBLIC
             OpenImageIO_Util
-        ${OPENIMAGEIO_IMATH_DEPENDENCY_VISIBILITY}
+            ${OPENIMAGEIO_IMATH_DEPENDENCY_VISIBILITY}
             ${OPENIMAGEIO_IMATH_TARGETS}
         PRIVATE
             ${OPENIMAGEIO_OPENEXR_TARGETS}
@@ -139,9 +139,7 @@ target_link_libraries (OpenImageIO
             $<TARGET_NAME_IF_EXISTS:pugixml::pugixml>
             ${BZIP2_LIBRARIES}
             ZLIB::ZLIB
-            Boost::filesystem
-            Boost::system
-            Boost::thread
+            $<TARGET_NAME_IF_EXISTS:Boost::thread>
             ${CMAKE_DL_LIBS}
         )
 

--- a/src/libutil/CMakeLists.txt
+++ b/src/libutil/CMakeLists.txt
@@ -14,12 +14,12 @@ target_link_libraries (OpenImageIO_Util
         PUBLIC
             $<TARGET_NAME_IF_EXISTS:Threads::Threads>
             ${GCC_ATOMIC_LIBRARIES}
-        ${OPENIMAGEIO_IMATH_DEPENDENCY_VISIBILITY}
+            ${OPENIMAGEIO_IMATH_DEPENDENCY_VISIBILITY}
             ${OPENIMAGEIO_IMATH_TARGETS}
         PRIVATE
-            Boost::filesystem
-            Boost::system
-            Boost::thread
+            $<TARGET_NAME_IF_EXISTS:Boost::filesystem>
+            $<TARGET_NAME_IF_EXISTS:Boost::system>
+            $<TARGET_NAME_IF_EXISTS:Boost::thread>
             ${SANITIZE_LIBRARIES}
             ${CMAKE_DL_LIBS}
         )


### PR DESCRIPTION
C++17 (and/or adequately new versions of the compilers) support
std::filesystem, and in those cases we no longer need boost.filesystem.

