### PR TITLE
CI: Try newest ubuntu 22.04 and MacOS 12 images, test gcc12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,10 +206,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - desc: latest releases gcc10 C++17 avx2 exr3.1 ocio2.1
+          - desc: latest releases gcc11 C++17 avx2 exr3.1 ocio2.1
             nametag: linux-latest-releases
             os: ubuntu-20.04
-            cxx_compiler: g++-10
+            cc_compiler: gcc-11
+            cxx_compiler: g++-11
             cxx_std: 17
             fmt_ver: 9.0.0
             openexr_ver: v3.1.5
@@ -226,15 +227,16 @@ jobs:
                             USE_OPENVDB=0
                             WEBP_VERSION=v1.2.1
                             # The installed OpenVDB has a TLS conflict with Python 3.8
-          - desc: bleeding edge gcc11 C++20 py38 OCIO/libtiff/exr-master boost1.71 avx2
+          - desc: bleeding edge gcc12 C++20 py3.10 OCIO/libtiff/exr-master boost1.74 avx2
             nametag: linux-bleeding-edge
-            os: ubuntu-20.04
-            cxx_compiler: g++-11
+            os: ubuntu-22.04
+            cc_compiler: gcc-12
+            cxx_compiler: g++-12
             cxx_std: 20
             fmt_ver: master
             openexr_ver: main
             pybind11_ver: master
-            python_ver: 3.8
+            python_ver: "3.10"
             simd: avx2,f16c
             setenvs: export LIBRAW_VERSION=master
                             LIBTIFF_VERSION=master
@@ -364,6 +366,12 @@ jobs:
             cxx_std: 17
             python_ver: 3.9
             aclang: 13
+          - desc: MacOS-12
+            os: macos-12
+            cxx_std: 20
+            python_ver: 3.9
+            aclang: 13
+            setenvs: export CTEST_TEST_TIMEOUT=300
     runs-on: ${{ matrix.os }}
     env:
       CC: clang

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,14 +17,14 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
  * **C++14** (also builds with C++17, and C++20)
      * The default build mode is C++14. This can be controlled by via the
        CMake configuration flag: `-DCMAKE_CXX_STANDARD=17`, etc.
- * Compilers: **gcc 6.1 - 11.2**, **clang 3.4 - 14**, **MSVS 2017 - 2019**,
+ * Compilers: **gcc 6.1 - 12.1**, **clang 3.4 - 14**, **MSVS 2017 - 2019**,
    **Intel icc 17+**, **Intel OneAPI C++ compiler 2022+**.
  * CMake >= 3.12 (tested through 3.23)
  * OpenEXR/Imath >= 2.3 (recommended: 2.4 or higher; tested through 3.1)
  * libTIFF >= 3.9 (recommended: 4.0+; tested through 4.4)
  * libjpeg >= 8, or libjpeg-turbo >= 1.1 (tested through jpeg9d and jpeg-turbo
    2.1)
- * Boost >= 1.53 (recommended: at least 1.66; tested through 1.78)
+ * Boost >= 1.53 (recommended: at least 1.66; tested through 1.79)
  * [fmtlib](https://github.com/fmtlib/fmt) >= 6.1.2 (tested through 9.0). If
    not found at build time, this will be automatically downloaded unless the
    build sets `-DBUILD_MISSING_FMT=OFF`.
@@ -35,7 +35,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
      * Qt >= 5.6 (tested through 5.15)
      * OpenGL
  * If you are building the Python bindings or running the testsuite:
-     * Python >= 2.7 (tested against 2.7, 3.7, 3.8, 3.9)
+     * Python >= 2.7 (tested against 2.7, 3.7, 3.8, 3.9, 3.10)
      * pybind11 >= 2.4.2 (Tested through 2.10. Note that pybind11 v2.10+ does
        not support Python < 3.6.)
      * NumPy

--- a/src/build-scripts/gh-installdeps.bash
+++ b/src/build-scripts/gh-installdeps.bash
@@ -62,8 +62,9 @@ else
         locales wget \
         libopencolorio-dev \
         libopencv-dev \
-        qt5-default \
         libhdf5-dev
+    time sudo apt-get -q install -y \
+        qt5-default || /bin/true
     if [[ "${EXTRA_DEP_PACKAGES}" != "" ]] ; then
         time sudo apt-get -q install -y ${EXTRA_DEP_PACKAGES}
     fi
@@ -99,6 +100,8 @@ else
         time sudo apt-get install -y g++-10
     elif [[ "$CXX" == "g++-11" ]] ; then
         time sudo apt-get install -y g++-11
+    elif [[ "$CXX" == "g++-12" ]] ; then
+        time sudo apt-get install -y g++-12
     fi
 
     if [[ "$CXX" == "icpc" || "$CC" == "icc" || "$USE_ICC" != "" || "$USE_ICX" != "" ]] ; then

--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -313,7 +313,7 @@ Strutil::escape_chars(string_view unescaped)
             case '\f': c = 'f'; break;
             case '\a': c = 'a'; break;
             }
-            s.insert(i, &c, 1);
+            s.insert(i, 1, c);
         }
     }
     return s;

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -5677,12 +5677,15 @@ action_printinfo(cspan<const char*> argv)
 }
 
 
+namespace pvtcrash {
+size_t crasher = 37;
+}
+
 
 static void
 crash_me()
 {
-    size_t a   = 37;
-    char* addr = (char*)a;
+    char* addr = (char*)pvtcrash::crasher;
     OIIO_PRAGMA_WARNING_PUSH
 #if OIIO_GNUC_VERSION >= 110000
     OIIO_GCC_ONLY_PRAGMA(GCC diagnostic ignored "-Wstringop-overflow")


### PR DESCRIPTION
Bump the bleeding edge test to use gcc12, C++20, and python 3.10.

Address the couple of new warnings that popped up.

Add a test on MacOS 12.
