### PR TITLE
(trivial) Address -Winconsistent-missing-destructor-override warning

### DIFF
--- a/src/bmp.imageio/bmpinput.cpp
+++ b/src/bmp.imageio/bmpinput.cpp
@@ -17,7 +17,7 @@ using namespace bmp_pvt;
 class BmpInput final : public ImageInput {
 public:
     BmpInput() { init(); }
-    virtual ~BmpInput() { close(); }
+    virtual ~BmpInput() override { close(); }
     virtual const char* format_name(void) const override { return "bmp"; }
     int supports(string_view feature) const override
     {

--- a/src/bmp.imageio/bmpoutput.cpp
+++ b/src/bmp.imageio/bmpoutput.cpp
@@ -18,7 +18,7 @@ using namespace bmp_pvt;
 class BmpOutput final : public ImageOutput {
 public:
     BmpOutput() { init(); }
-    virtual ~BmpOutput() { close(); }
+    virtual ~BmpOutput() override { close(); }
     virtual const char* format_name(void) const override { return "bmp"; }
     virtual int supports(string_view feature) const override;
     virtual bool open(const std::string& name, const ImageSpec& spec,

--- a/src/cineon.imageio/cineoninput.cpp
+++ b/src/cineon.imageio/cineoninput.cpp
@@ -19,7 +19,7 @@ OIIO_PLUGIN_NAMESPACE_BEGIN
 class CineonInput final : public ImageInput {
 public:
     CineonInput() { init(); }
-    virtual ~CineonInput() { close(); }
+    virtual ~CineonInput() override { close(); }
     virtual const char* format_name(void) const override { return "cineon"; }
     virtual bool open(const std::string& name, ImageSpec& newspec) override;
     virtual bool close() override;

--- a/src/dds.imageio/ddsinput.cpp
+++ b/src/dds.imageio/ddsinput.cpp
@@ -29,7 +29,7 @@ constexpr int kBlockSize = 4;
 class DDSInput final : public ImageInput {
 public:
     DDSInput() { init(); }
-    virtual ~DDSInput() { close(); }
+    virtual ~DDSInput() override { close(); }
     virtual const char* format_name(void) const override { return "dds"; }
     virtual int supports(string_view feature) const override
     {

--- a/src/dicom.imageio/dicominput.cpp
+++ b/src/dicom.imageio/dicominput.cpp
@@ -35,7 +35,7 @@ OIIO_PLUGIN_NAMESPACE_BEGIN
 class DICOMInput final : public ImageInput {
 public:
     DICOMInput() {}
-    virtual ~DICOMInput() { close(); }
+    virtual ~DICOMInput() override { close(); }
     virtual const char* format_name(void) const override { return "dicom"; }
     virtual int supports(string_view /*feature*/) const override
     {

--- a/src/doc/writingplugins.rst
+++ b/src/doc/writingplugins.rst
@@ -144,7 +144,7 @@ plug-in.
         class JpgInput final : public ImageInput {
          public:
             JpgInput () { init(); }
-            virtual ~JpgInput () { close(); }
+            virtual ~JpgInput () override { close(); }
             virtual const char * format_name (void) const override { return "jpeg"; }
             virtual bool open (const std::string &name, ImageSpec &spec) override;
             virtual bool read_native_scanline (int y, int z, void *data) override;
@@ -289,7 +289,7 @@ plug-in.
       class JpgOutput final : public ImageOutput {
        public:
           JpgOutput () { init(); }
-          virtual ~JpgOutput () { close(); }
+          virtual ~JpgOutput () override { close(); }
           virtual const char * format_name (void) const override { return "jpeg"; }
           virtual int supports (string_view property) const override { return false; }
           virtual bool open (const std::string &name, const ImageSpec &spec,

--- a/src/dpx.imageio/dpxinput.cpp
+++ b/src/dpx.imageio/dpxinput.cpp
@@ -23,7 +23,7 @@ OIIO_PLUGIN_NAMESPACE_BEGIN
 class DPXInput final : public ImageInput {
 public:
     DPXInput() { init(); }
-    virtual ~DPXInput() { close(); }
+    virtual ~DPXInput() override { close(); }
     virtual const char* format_name(void) const override { return "dpx"; }
     virtual int supports(string_view feature) const override
     {

--- a/src/dpx.imageio/dpxoutput.cpp
+++ b/src/dpx.imageio/dpxoutput.cpp
@@ -27,7 +27,7 @@ static const int MAX_DPX_IMAGE_ELEMENTS = 8;  // max subimages in DPX spec
 class DPXOutput final : public ImageOutput {
 public:
     DPXOutput();
-    virtual ~DPXOutput();
+    virtual ~DPXOutput() override;
     virtual const char* format_name(void) const override { return "dpx"; }
     virtual int supports(string_view feature) const override
     {

--- a/src/ffmpeg.imageio/ffmpeginput.cpp
+++ b/src/ffmpeg.imageio/ffmpeginput.cpp
@@ -88,7 +88,7 @@ OIIO_PLUGIN_NAMESPACE_BEGIN
 class FFmpegInput final : public ImageInput {
 public:
     FFmpegInput();
-    virtual ~FFmpegInput();
+    virtual ~FFmpegInput() override;
     virtual const char* format_name(void) const override
     {
         return "FFmpeg movie";

--- a/src/fits.imageio/fits_pvt.h
+++ b/src/fits.imageio/fits_pvt.h
@@ -39,7 +39,7 @@ struct Subimage {
 class FitsInput final : public ImageInput {
 public:
     FitsInput() { init(); }
-    virtual ~FitsInput() { close(); }
+    virtual ~FitsInput() override { close(); }
     virtual const char* format_name(void) const override { return "fits"; }
     virtual int supports(string_view feature) const override
     {
@@ -116,7 +116,7 @@ private:
 class FitsOutput final : public ImageOutput {
 public:
     FitsOutput() { init(); }
-    virtual ~FitsOutput() { close(); }
+    virtual ~FitsOutput() override { close(); }
     virtual const char* format_name(void) const override { return "fits"; }
     virtual int supports(string_view feature) const override;
     virtual bool open(const std::string& name, const ImageSpec& spec,

--- a/src/gif.imageio/gifinput.cpp
+++ b/src/gif.imageio/gifinput.cpp
@@ -37,7 +37,7 @@ OIIO_PLUGIN_NAMESPACE_BEGIN
 class GIFInput final : public ImageInput {
 public:
     GIFInput() { init(); }
-    virtual ~GIFInput() { close(); }
+    virtual ~GIFInput() override { close(); }
     virtual const char* format_name(void) const override { return "gif"; }
     virtual int supports(string_view feature) const override
     {

--- a/src/gif.imageio/gifoutput.cpp
+++ b/src/gif.imageio/gifoutput.cpp
@@ -62,7 +62,7 @@ OIIO_PLUGIN_NAMESPACE_BEGIN
 class GIFOutput final : public ImageOutput {
 public:
     GIFOutput() { init(); }
-    virtual ~GIFOutput() { close(); }
+    virtual ~GIFOutput() override { close(); }
     virtual const char* format_name(void) const override { return "gif"; }
     virtual int supports(string_view feature) const override
     {

--- a/src/hdr.imageio/hdrinput.cpp
+++ b/src/hdr.imageio/hdrinput.cpp
@@ -35,7 +35,7 @@ OIIO_PLUGIN_NAMESPACE_BEGIN
 class HdrInput final : public ImageInput {
 public:
     HdrInput() { init(); }
-    virtual ~HdrInput() { close(); }
+    virtual ~HdrInput() override { close(); }
     virtual const char* format_name(void) const override { return "hdr"; }
     virtual int supports(string_view feature) const override
     {

--- a/src/hdr.imageio/hdroutput.cpp
+++ b/src/hdr.imageio/hdroutput.cpp
@@ -16,7 +16,7 @@ OIIO_PLUGIN_NAMESPACE_BEGIN
 class HdrOutput final : public ImageOutput {
 public:
     HdrOutput() { init(); }
-    virtual ~HdrOutput() { close(); }
+    virtual ~HdrOutput() override { close(); }
     virtual const char* format_name(void) const override { return "hdr"; }
     virtual int supports(string_view feature) const override
     {

--- a/src/heif.imageio/heifinput.cpp
+++ b/src/heif.imageio/heifinput.cpp
@@ -23,7 +23,7 @@ OIIO_PLUGIN_NAMESPACE_BEGIN
 class HeifInput final : public ImageInput {
 public:
     HeifInput() {}
-    virtual ~HeifInput() { close(); }
+    virtual ~HeifInput() override { close(); }
     virtual const char* format_name(void) const override { return "heif"; }
     virtual int supports(string_view feature) const override
     {

--- a/src/heif.imageio/heifoutput.cpp
+++ b/src/heif.imageio/heifoutput.cpp
@@ -15,7 +15,7 @@ OIIO_PLUGIN_NAMESPACE_BEGIN
 class HeifOutput final : public ImageOutput {
 public:
     HeifOutput() {}
-    virtual ~HeifOutput() { close(); }
+    virtual ~HeifOutput() override { close(); }
     virtual const char* format_name(void) const override { return "heif"; }
     virtual int supports(string_view feature) const override
     {

--- a/src/ico.imageio/icoinput.cpp
+++ b/src/ico.imageio/icoinput.cpp
@@ -23,7 +23,7 @@ using namespace ICO_pvt;
 class ICOInput final : public ImageInput {
 public:
     ICOInput() { init(); }
-    virtual ~ICOInput() { close(); }
+    virtual ~ICOInput() override { close(); }
     virtual const char* format_name(void) const override { return "ico"; }
     virtual bool open(const std::string& name, ImageSpec& newspec) override;
     virtual bool close() override;

--- a/src/ico.imageio/icooutput.cpp
+++ b/src/ico.imageio/icooutput.cpp
@@ -24,7 +24,7 @@ using namespace ICO_pvt;
 class ICOOutput final : public ImageOutput {
 public:
     ICOOutput();
-    virtual ~ICOOutput();
+    virtual ~ICOOutput() override;
     virtual const char* format_name(void) const override { return "ico"; }
     virtual int supports(string_view feature) const override;
     virtual bool open(const std::string& name, const ImageSpec& spec,

--- a/src/iff.imageio/iff_pvt.h
+++ b/src/iff.imageio/iff_pvt.h
@@ -133,7 +133,7 @@ tile_height_size(uint32_t height)
 class IffInput final : public ImageInput {
 public:
     IffInput() { init(); }
-    virtual ~IffInput() { close(); }
+    virtual ~IffInput() override { close(); }
     virtual const char* format_name(void) const override { return "iff"; }
     virtual bool open(const std::string& name, ImageSpec& spec) override;
     virtual bool close(void) override;
@@ -209,7 +209,7 @@ private:
 class IffOutput final : public ImageOutput {
 public:
     IffOutput() { init(); }
-    virtual ~IffOutput() { close(); }
+    virtual ~IffOutput() override { close(); }
     virtual const char* format_name(void) const override { return "iff"; }
     virtual int supports(string_view feature) const override;
     virtual bool open(const std::string& name, const ImageSpec& spec,

--- a/src/jpeg.imageio/jpeg_pvt.h
+++ b/src/jpeg.imageio/jpeg_pvt.h
@@ -56,7 +56,7 @@ static const int JPEG_411_COMP[6] = { 4, 1, 1, 1, 1, 1 };
 class JpgInput final : public ImageInput {
 public:
     JpgInput() { init(); }
-    virtual ~JpgInput() { close(); }
+    virtual ~JpgInput() override { close(); }
     virtual const char* format_name(void) const override { return "jpeg"; }
     virtual int supports(string_view feature) const override
     {

--- a/src/jpeg.imageio/jpegoutput.cpp
+++ b/src/jpeg.imageio/jpegoutput.cpp
@@ -29,7 +29,7 @@ OIIO_PLUGIN_NAMESPACE_BEGIN
 class JpgOutput final : public ImageOutput {
 public:
     JpgOutput() { init(); }
-    virtual ~JpgOutput() { close(); }
+    virtual ~JpgOutput() override { close(); }
     virtual const char* format_name(void) const override { return "jpeg"; }
     virtual int supports(string_view feature) const override
     {

--- a/src/jpeg2000.imageio/jpeg2000input.cpp
+++ b/src/jpeg2000.imageio/jpeg2000input.cpp
@@ -71,7 +71,7 @@ j2k_associateAlpha(T* data, int size, int channels, int alpha_channel,
 class Jpeg2000Input final : public ImageInput {
 public:
     Jpeg2000Input() { init(); }
-    virtual ~Jpeg2000Input() { close(); }
+    virtual ~Jpeg2000Input() override { close(); }
     virtual const char* format_name(void) const override { return "jpeg2000"; }
     virtual int supports(string_view feature) const override
     {

--- a/src/jpeg2000.imageio/jpeg2000output.cpp
+++ b/src/jpeg2000.imageio/jpeg2000output.cpp
@@ -29,7 +29,7 @@ OIIO_PLUGIN_NAMESPACE_BEGIN
 class Jpeg2000Output final : public ImageOutput {
 public:
     Jpeg2000Output() { init(); }
-    virtual ~Jpeg2000Output() { close(); }
+    virtual ~Jpeg2000Output() override { close(); }
     virtual const char* format_name(void) const override { return "jpeg2000"; }
     virtual int supports(string_view feature) const override
     {

--- a/src/null.imageio/nullimageio.cpp
+++ b/src/null.imageio/nullimageio.cpp
@@ -22,7 +22,7 @@ OIIO_PLUGIN_NAMESPACE_BEGIN
 class NullOutput final : public ImageOutput {
 public:
     NullOutput() {}
-    virtual ~NullOutput() {}
+    virtual ~NullOutput() override {}
     virtual const char* format_name(void) const override { return "null"; }
     virtual int supports(string_view /*feature*/) const override
     {
@@ -58,7 +58,7 @@ public:
 class NullInput final : public ImageInput {
 public:
     NullInput() { init(); }
-    virtual ~NullInput() {}
+    virtual ~NullInput() override {}
     virtual const char* format_name(void) const override { return "null"; }
     virtual bool valid_file(const std::string& filename) const override;
     virtual int supports(string_view /*feature*/) const override

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -124,7 +124,7 @@ private:
 class OpenEXRInput final : public ImageInput {
 public:
     OpenEXRInput();
-    virtual ~OpenEXRInput() { close(); }
+    virtual ~OpenEXRInput() override { close(); }
     virtual const char* format_name(void) const override { return "openexr"; }
     virtual int supports(string_view feature) const override
     {

--- a/src/openexr.imageio/exrinput_c.cpp
+++ b/src/openexr.imageio/exrinput_c.cpp
@@ -101,7 +101,7 @@ oiio_exr_read_func(exr_const_context_t ctxt, void* userdata, void* buffer,
 class OpenEXRCoreInput final : public ImageInput {
 public:
     OpenEXRCoreInput();
-    virtual ~OpenEXRCoreInput() { close(); }
+    virtual ~OpenEXRCoreInput() override { close(); }
     virtual const char* format_name(void) const override { return "openexr"; }
     virtual int supports(string_view feature) const override
     {

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -122,7 +122,7 @@ private:
 class OpenEXROutput final : public ImageOutput {
 public:
     OpenEXROutput();
-    virtual ~OpenEXROutput();
+    virtual ~OpenEXROutput() override;
     virtual const char* format_name(void) const override { return "openexr"; }
     virtual int supports(string_view feature) const override;
     virtual bool open(const std::string& name, const ImageSpec& spec,

--- a/src/openvdb.imageio/openvdbinput.cpp
+++ b/src/openvdb.imageio/openvdbinput.cpp
@@ -65,7 +65,7 @@ class OpenVDBInput final : public ImageInput {
 
 public:
     OpenVDBInput() { init(); }
-    virtual ~OpenVDBInput() { close(); }
+    virtual ~OpenVDBInput() override { close(); }
 
     virtual const char* format_name(void) const override { return "openvdb"; }
     virtual int supports(string_view feature) const override

--- a/src/png.imageio/pnginput.cpp
+++ b/src/png.imageio/pnginput.cpp
@@ -14,7 +14,7 @@ OIIO_PLUGIN_NAMESPACE_BEGIN
 class PNGInput final : public ImageInput {
 public:
     PNGInput() { init(); }
-    virtual ~PNGInput() { close(); }
+    virtual ~PNGInput() override { close(); }
     virtual const char* format_name(void) const override { return "png"; }
     virtual int supports(string_view feature) const override
     {

--- a/src/png.imageio/pngoutput.cpp
+++ b/src/png.imageio/pngoutput.cpp
@@ -17,7 +17,7 @@ OIIO_PLUGIN_NAMESPACE_BEGIN
 class PNGOutput final : public ImageOutput {
 public:
     PNGOutput();
-    virtual ~PNGOutput();
+    virtual ~PNGOutput() override;
     virtual const char* format_name(void) const override { return "png"; }
     virtual int supports(string_view feature) const override
     {

--- a/src/pnm.imageio/pnminput.cpp
+++ b/src/pnm.imageio/pnminput.cpp
@@ -24,7 +24,7 @@ OIIO_PLUGIN_NAMESPACE_BEGIN
 class PNMInput final : public ImageInput {
 public:
     PNMInput() { init(); }
-    virtual ~PNMInput() { close(); }
+    virtual ~PNMInput() override { close(); }
     virtual const char* format_name(void) const override { return "pnm"; }
     virtual int supports(string_view feature) const override
     {

--- a/src/pnm.imageio/pnmoutput.cpp
+++ b/src/pnm.imageio/pnmoutput.cpp
@@ -13,7 +13,7 @@ OIIO_PLUGIN_NAMESPACE_BEGIN
 class PNMOutput final : public ImageOutput {
 public:
     PNMOutput() { init(); }
-    virtual ~PNMOutput() { close(); }
+    virtual ~PNMOutput() override { close(); }
     virtual const char* format_name(void) const override { return "pnm"; }
     virtual int supports(string_view feature) const override
     {

--- a/src/psd.imageio/psdinput.cpp
+++ b/src/psd.imageio/psdinput.cpp
@@ -31,7 +31,7 @@ using namespace psd_pvt;
 class PSDInput final : public ImageInput {
 public:
     PSDInput();
-    virtual ~PSDInput() { close(); }
+    virtual ~PSDInput() override { close(); }
     virtual const char* format_name(void) const override { return "psd"; }
     virtual int supports(string_view feature) const override
     {

--- a/src/ptex.imageio/ptexinput.cpp
+++ b/src/ptex.imageio/ptexinput.cpp
@@ -18,7 +18,7 @@ public:
     {
         init();
     }
-    virtual ~PtexInput() { close(); }
+    virtual ~PtexInput() override { close(); }
     virtual const char* format_name(void) const override { return "ptex"; }
     virtual int supports(string_view feature) const override
     {

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -57,7 +57,7 @@ OIIO_PLUGIN_NAMESPACE_BEGIN
 class RawInput final : public ImageInput {
 public:
     RawInput() {}
-    virtual ~RawInput() { close(); }
+    virtual ~RawInput() override { close(); }
     virtual const char* format_name(void) const override { return "raw"; }
     virtual int supports(string_view feature) const override
     {

--- a/src/rla.imageio/rlainput.cpp
+++ b/src/rla.imageio/rlainput.cpp
@@ -22,7 +22,7 @@ using namespace RLA_pvt;
 class RLAInput final : public ImageInput {
 public:
     RLAInput() { init(); }
-    virtual ~RLAInput() { close(); }
+    virtual ~RLAInput() override { close(); }
     virtual const char* format_name(void) const override { return "rla"; }
     virtual bool open(const std::string& name, ImageSpec& newspec) override;
     virtual int current_subimage(void) const override

--- a/src/rla.imageio/rlaoutput.cpp
+++ b/src/rla.imageio/rlaoutput.cpp
@@ -27,7 +27,7 @@ using namespace RLA_pvt;
 class RLAOutput final : public ImageOutput {
 public:
     RLAOutput();
-    virtual ~RLAOutput();
+    virtual ~RLAOutput() override;
     virtual const char* format_name(void) const override { return "rla"; }
     virtual int supports(string_view feature) const override;
     virtual bool open(const std::string& name, const ImageSpec& spec,

--- a/src/sgi.imageio/sgi_pvt.h
+++ b/src/sgi.imageio/sgi_pvt.h
@@ -65,7 +65,7 @@ enum ColorMap {
 class SgiInput final : public ImageInput {
 public:
     SgiInput() { init(); }
-    virtual ~SgiInput() { close(); }
+    virtual ~SgiInput() override { close(); }
     virtual const char* format_name(void) const override { return "sgi"; }
     virtual bool valid_file(const std::string& filename) const override;
     virtual bool open(const std::string& name, ImageSpec& spec) override;
@@ -118,7 +118,7 @@ private:
 class SgiOutput final : public ImageOutput {
 public:
     SgiOutput() {}
-    virtual ~SgiOutput() { close(); }
+    virtual ~SgiOutput() override { close(); }
     virtual const char* format_name(void) const override { return "sgi"; }
     virtual int supports(string_view feature) const override;
     virtual bool open(const std::string& name, const ImageSpec& spec,

--- a/src/socket.imageio/socket_pvt.h
+++ b/src/socket.imageio/socket_pvt.h
@@ -36,7 +36,7 @@ using namespace boost::asio;
 class SocketOutput final : public ImageOutput {
 public:
     SocketOutput();
-    virtual ~SocketOutput() { close(); }
+    virtual ~SocketOutput() override { close(); }
     virtual const char* format_name(void) const override { return "socket"; }
     virtual int supports(string_view property) const override;
     virtual bool open(const std::string& name, const ImageSpec& spec,
@@ -64,7 +64,7 @@ private:
 class SocketInput final : public ImageInput {
 public:
     SocketInput();
-    virtual ~SocketInput() { close(); }
+    virtual ~SocketInput() override { close(); }
     virtual const char* format_name(void) const override { return "socket"; }
     virtual bool valid_file(const std::string& filename) const override;
     virtual bool open(const std::string& name, ImageSpec& spec) override;

--- a/src/softimage.imageio/softimageinput.cpp
+++ b/src/softimage.imageio/softimageinput.cpp
@@ -13,7 +13,7 @@ using namespace softimage_pvt;
 class SoftimageInput final : public ImageInput {
 public:
     SoftimageInput() { init(); }
-    virtual ~SoftimageInput() { close(); }
+    virtual ~SoftimageInput() override { close(); }
     virtual const char* format_name(void) const override { return "softimage"; }
     virtual bool open(const std::string& name, ImageSpec& spec) override;
     virtual bool close() override;

--- a/src/targa.imageio/targainput.cpp
+++ b/src/targa.imageio/targainput.cpp
@@ -35,7 +35,7 @@ static bool tgadebug = Strutil::stoi(Sysutil::getenv("OIIO_TARGA_DEBUG"));
 class TGAInput final : public ImageInput {
 public:
     TGAInput() { init(); }
-    virtual ~TGAInput() { close(); }
+    virtual ~TGAInput() override { close(); }
     virtual const char* format_name(void) const override { return "targa"; }
     virtual int supports(string_view feature) const override
     {

--- a/src/targa.imageio/targaoutput.cpp
+++ b/src/targa.imageio/targaoutput.cpp
@@ -25,7 +25,7 @@ using namespace TGA_pvt;
 class TGAOutput final : public ImageOutput {
 public:
     TGAOutput();
-    virtual ~TGAOutput();
+    virtual ~TGAOutput() override;
     virtual const char* format_name(void) const override { return "targa"; }
     virtual int supports(string_view feature) const override
     {

--- a/src/testtex/testtex.cpp
+++ b/src/testtex/testtex.cpp
@@ -1364,7 +1364,7 @@ public:
         : m_miplevel(-1)
     {
     }
-    virtual ~GridImageInput() { close(); }
+    virtual ~GridImageInput() override { close(); }
     virtual const char* format_name(void) const final { return "grid"; }
     virtual bool valid_file(const std::string& /*filename*/) const final
     {
@@ -1376,7 +1376,7 @@ public:
         newspec = spec();
         return ok;
     }
-    virtual bool close() { return true; }
+    virtual bool close() override { return true; }
     virtual int current_miplevel(void) const final { return m_miplevel; }
     virtual bool seek_subimage(int subimage, int miplevel) final
     {

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -72,7 +72,7 @@ struct TIFF_tag_info {
 class TIFFInput final : public ImageInput {
 public:
     TIFFInput();
-    virtual ~TIFFInput();
+    virtual ~TIFFInput() override;
     virtual const char* format_name(void) const override { return "tiff"; }
     virtual bool valid_file(const std::string& filename) const override;
     virtual int supports(string_view feature) const override

--- a/src/tiff.imageio/tiffoutput.cpp
+++ b/src/tiff.imageio/tiffoutput.cpp
@@ -39,7 +39,7 @@ static int MIN_SCANLINES_OR_TILES_PER_CHECKPOINT  = 64;
 class TIFFOutput final : public ImageOutput {
 public:
     TIFFOutput();
-    virtual ~TIFFOutput();
+    virtual ~TIFFOutput() override;
     virtual const char* format_name(void) const override { return "tiff"; }
     virtual int supports(string_view feature) const override;
     virtual bool open(const std::string& name, const ImageSpec& spec,

--- a/src/webp.imageio/webpinput.cpp
+++ b/src/webp.imageio/webpinput.cpp
@@ -18,7 +18,7 @@ namespace webp_pvt {
 class WebpInput final : public ImageInput {
 public:
     WebpInput() {}
-    virtual ~WebpInput() { close(); }
+    virtual ~WebpInput() override { close(); }
     virtual const char* format_name() const override { return "webp"; }
     virtual int supports(string_view feature) const override
     {

--- a/src/webp.imageio/webpoutput.cpp
+++ b/src/webp.imageio/webpoutput.cpp
@@ -18,7 +18,7 @@ namespace webp_pvt {
 class WebpOutput final : public ImageOutput {
 public:
     WebpOutput() { init(); }
-    virtual ~WebpOutput() { close(); }
+    virtual ~WebpOutput() override { close(); }
     virtual const char* format_name() const override { return "webp"; }
     virtual bool open(const std::string& name, const ImageSpec& spec,
                       OpenMode mode = Create) override;

--- a/src/zfile.imageio/zfile.cpp
+++ b/src/zfile.imageio/zfile.cpp
@@ -55,7 +55,7 @@ open_gz(const std::string& filename, const char* mode)
 class ZfileInput final : public ImageInput {
 public:
     ZfileInput() { init(); }
-    virtual ~ZfileInput() { close(); }
+    virtual ~ZfileInput() override { close(); }
     virtual const char* format_name(void) const override { return "zfile"; }
     virtual bool valid_file(const std::string& filename) const override;
     virtual bool open(const std::string& name, ImageSpec& newspec) override;
@@ -84,7 +84,7 @@ private:
 class ZfileOutput final : public ImageOutput {
 public:
     ZfileOutput() { init(); }
-    virtual ~ZfileOutput() { close(); }
+    virtual ~ZfileOutput() override { close(); }
     virtual const char* format_name(void) const override { return "zfile"; }
     virtual bool open(const std::string& name, const ImageSpec& spec,
                       OpenMode mode = Create) override;


### PR DESCRIPTION
Virtual destructors don't significantly differ from regular virtual functions, so it is customary to add override specifier when virtual destructor is overridden.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-CORPORATE)).
- [not applicable] I have updated the documentation, if applicable.
- [not applicable] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

