### PR TITLE
filesystem.h: Don't require IOProxy pread and pwrite to be thread safe

### DIFF
--- a/src/include/OpenImageIO/filesystem.h
+++ b/src/include/OpenImageIO/filesystem.h
@@ -411,7 +411,7 @@ public:
     // number of bytes successfully written.
     virtual size_t write (const void *buf, size_t size);
     // pread(), pwrite() are stateless, do not alter the current file
-    // position, and are thread-safe (against each other).
+    // position.
     virtual size_t pread (void *buf, size_t size, int64_t offset);
     virtual size_t pwrite (const void *buf, size_t size, int64_t offset);
     // Return the total size of the proxy data, in bytes.


### PR DESCRIPTION
Currently IOProxy::pread() and IOProxy::pwrite() are required to be thread safe by a comment. This puts additional burden on deriving classes as each of them must ensure thread safety of these functions. In certain cases it may even not be possible to satisfy it. However it seems that this requirement is extraneous and could be dropped.

Closer inspection of the usages of pread() and pwrite() reveals that none of the actual usages require thread safety. Instead, these functions are used simply as means to read/write to specific location of a file without changing the current file pointer.

The comment itself dates back to the initial IOProxy implementation. It is likely that the comment reflected the guarantees provided by the available implementations of IOProxy at the time. In particular, the documentation of Linux pread() and pwrite() functions have a note that "calls are especially useful in multithreaded applications".

Therefore, thread-safety requirement is not actually needed and could be dropped to make user code simpler.

## Checklist:

- [x] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-CORPORATE)).
- [not applicable] I have updated the documentation, if applicable.
- [not applicable] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

