### PR TITLE
Use a separate mutex to protect oiio_debug_file

### DIFF
--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -69,7 +69,9 @@ using namespace pvt;
 namespace {
 // Hidden global OIIO data.
 static spin_mutex attrib_mutex;
-static const int maxthreads  = 256;  // reasonable maximum for sanity check
+static const int maxthreads = 256;  // reasonable maximum for sanity check
+
+mutex oiio_debug_mutex;
 static FILE* oiio_debug_file = NULL;
 
 class TimingLog {
@@ -268,7 +270,7 @@ geterror(bool clear)
 void
 debug(string_view message)
 {
-    recursive_lock_guard lock(pvt::imageio_mutex);
+    lock_guard lock(oiio_debug_mutex);
     if (oiio_print_debug) {
         if (!oiio_debug_file) {
             const char* filename = getenv("OPENIMAGEIO_DEBUG_FILE");


### PR DESCRIPTION
## Description

This is first of PRs that will allow ImageInput::create(), ImageOutput::create() and similar functions that query the internal format database to be able to run concurrently. The access to internal format database has the property that it is frequently read from, but very infrequently written to. Currently only one concurrent read or write operation is allowed. However, it is safe to do reads concurrently as they do not modify the data structures. The situation could be improved by using std::shared_mutex (C++17) which allows multiple concurrent "shared" locks for reads and a single exclusive lock for writing.

The ability to do concurrent read access to the internal format database is becoming important, because servers already have 256 usable threads and access to the format database is becoming a bottleneck in that case, especially if images are tiny and don't have enough information about the format in their filename which needs a locked looping through the format database.  

First step is to make imageio_mutex a regular, not recursive mutex as std::shared_mutex is not recursive. This PR is the first step in this direction.

If we currently don't want to switch to C++17, it still makes sense to do the preparatory work, as the final PR to switch imageio_mutex from std::mutex to std::shared_mutex and adjust shared/exclusive locking will be trivial.

## Tests

This is very frequently used code, existing tests should cover it well. Since it affects threading, reliably reproducing issues, if any, is not possible unfortunately.

## Checklist:

- [x] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-CORPORATE)).
- [not applicable] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

