### PR TITLE
Bump maxthreads to 512

### DIFF
--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -69,7 +69,7 @@ using namespace pvt;
 namespace {
 // Hidden global OIIO data.
 static spin_mutex attrib_mutex;
-static const int maxthreads  = 256;  // reasonable maximum for sanity check
+static const int maxthreads  = 512;  // reasonable maximum for sanity check
 static FILE* oiio_debug_file = NULL;
 
 class TimingLog {


### PR DESCRIPTION
## Description

The current limit has been already hit when AMD released second-generation Epyc processors (codename Rome) back in 2019. Top models have 64 cores per CPU, or 128 threads. This means 2 socket configuration has 256 threads.

Fourth generation Epyc processors (codename Genoa) are rumored to have 96 cores per CPU, or 192 threads. This means 2 socket configuration has 384 threads. While the CPUs have not been announced yet, it makes sense to prepare for them in advance.

## Tests

This is trivial change, no tests are needed.

## Checklist:

- [x] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-CORPORATE)).
- [not needed] I have updated the documentation, if applicable.
- [not needed] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

