### PR TITLE
Fix mistake in unordered_map_concurrent

### DIFF
--- a/src/include/OpenImageIO/unordered_map_concurrent.h
+++ b/src/include/OpenImageIO/unordered_map_concurrent.h
@@ -455,7 +455,7 @@ public:
         Bin& bin(m_bins[b]);
         if (do_lock)
             bin.lock();
-        bin.map.erase(key, hash);
+        bin.map.erase(key);
         --m_size;
         if (do_lock)
             bin.unlock();


### PR DESCRIPTION
Should not have passed an argument. Went undetected for a long time
because I guess we didn't previously call the erase() method. (Until
I did when working on something unrelated.)
