### PR TITLE
cmake: Fix value of OpenImageIO_INCLUDE_DIR in cmake config

### DIFF
--- a/src/cmake/Config.cmake.in
+++ b/src/cmake/Config.cmake.in
@@ -17,16 +17,19 @@ if (NOT @OPENIMAGEIO_CONFIG_DO_NOT_FIND_IMATH@ AND NOT OPENIMAGEIO_CONFIG_DO_NOT
     endif ()
 endif ()
 
-# Compute the installation prefix relative to this file
-get_filename_component(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_DIR}/../../../" ABSOLUTE)
+# Compute the installation prefix relative to this file. Note that cmake files are installed
+# to ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME} (see OIIO_CONFIG_INSTALL_DIR)
+get_filename_component(_CURR_INSTALL_LIBDIR "${CMAKE_CURRENT_LIST_DIR}/../../" ABSOLUTE)
+get_filename_component(_ABS_CMAKE_INSTALL_LIBDIR "@CMAKE_INSTALL_FULL_LIBDIR@" ABSOLUTE)
+get_filename_component(_ABS_CMAKE_INSTALL_INCLUDEDIR "@CMAKE_INSTALL_FULL_INCLUDEDIR@" ABSOLUTE)
+file(RELATIVE_PATH _INCLUDEDIR_RELATIVE_TO_LIBDIR
+     "${_ABS_CMAKE_INSTALL_LIBDIR}" "${_ABS_CMAKE_INSTALL_INCLUDEDIR}")
+get_filename_component(_CURR_INSTALL_INCLUDE_DIR
+                       "${_CURR_INSTALL_LIBDIR}/${_INCLUDEDIR_RELATIVE_TO_LIBDIR}" ABSOLUTE)
 
-# There's no guarantee that CMAKE_INSTALL_XXXDIR is a relative path so we extract the final component to handle asbolute paths
-get_filename_component(_INCLUDE_DIR_NAME "@CMAKE_INSTALL_INCLUDEDIR@" NAME)
-get_filename_component(_LIB_DIR_NAME "@CMAKE_INSTALL_LIBDIR@" NAME)
-
-set_and_check (@PROJECT_NAME@_INCLUDE_DIR "${_IMPORT_PREFIX}/${_INCLUDE_DIR_NAME}")
-set_and_check (@PROJECT_NAME@_INCLUDES    "${_IMPORT_PREFIX}/${_INCLUDE_DIR_NAME}")
-set_and_check (@PROJECT_NAME@_LIB_DIR     "${_IMPORT_PREFIX}/${_LIB_DIR_NAME}")
+set_and_check (@PROJECT_NAME@_INCLUDE_DIR "${_CURR_INSTALL_INCLUDE_DIR}")
+set_and_check (@PROJECT_NAME@_INCLUDES    "${_CURR_INSTALL_INCLUDE_DIR}")
+set_and_check (@PROJECT_NAME@_LIB_DIR     "${_CURR_INSTALL_LIBDIR}")
 set (@PROJECT_NAME@_PLUGIN_SEARCH_PATH    "@PLUGIN_SEARCH_PATH_NATIVE@")
 
 if (NOT @FOUND_OPENEXR_WITH_CONFIG@)


### PR DESCRIPTION
## Description

Current code assumes that CMAKE_INSTALL_INCLUDEDIR and CMAKE_INSTALL_LIBDIR has exactly one filesystem component. This is not the case on e.g. Debian, where libraries for multiple architectures are supported and standard paths are as follows:

CMAKE_INSTALL_INCLUDEDIR=include
CMAKE_INSTALL_LIBDIR=lib/x86_64-linux-gnu

Fortunately the Config.cmake file is installed into a path that is itself relative to CMAKE_INSTALL_LIBDIR, so we can get CMAKE_INSTALL_LIBDIR from CMAKE_CURRENT_LIST_DIR and then get CMAKE_INSTALL_INCLUDEDIR by applying relative path from CMAKE_INSTALL_LIBDIR to CMAKE_INSTALL_INCLUDEDIR on top of that.

Fixes: c8dfbd70664a3f45dfb033bb5aa55b0e8def4c12

## Tests

Tested by building Debian package and a regular build without Debian-specific settings.

## Checklist:

- [x] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-CORPORATE)).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

