### PR TITLE
Make access to imageio_mutex not recursive

### DIFF
--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -35,7 +35,7 @@ threads_default()
 
 // Global private data
 namespace pvt {
-recursive_mutex imageio_mutex;
+mutex imageio_mutex;
 atomic_int oiio_threads(threads_default());
 atomic_int oiio_exr_threads(threads_default());
 atomic_int oiio_read_chunk(256);

--- a/src/libOpenImageIO/imageio_pvt.h.in
+++ b/src/libOpenImageIO/imageio_pvt.h.in
@@ -21,7 +21,7 @@ OIIO_NAMESPACE_BEGIN
 namespace pvt {
 
 // Mutex allowing thread safety of the ImageIO internals below
-extern recursive_mutex imageio_mutex;
+extern mutex imageio_mutex;
 
 extern atomic_int oiio_threads;
 extern atomic_int oiio_read_chunk;


### PR DESCRIPTION
## Description

This is first of two PRs that will allow ImageInput::create(), ImageOutput::create() and similar functions that query the internal format database to be able to run concurrently. The access to internal format database has the property that it is frequently read from, but very infrequently written to. Currently only one concurrent read or write operation is allowed. However, it is safe to do reads concurrently as they do not modify the data structures. The situation could be improved by using std::shared_mutex (C++17) which allows multiple concurrent "shared" locks for reads and a single exclusive lock for writing.

The ability to do concurrent read access to the internal format database is becoming important, because servers already have 256 usable threads and access to the format database is becoming a bottleneck in that case, especially if images are tiny and don't have enough information about the format in their filename which needs a locked looping through the format database.

First step is to make imageio_mutex a regular, not recursive mutex as std::shared_mutex is not recursive.

If we currently don't want to switch to C++17, it still makes sense to do the preparatory work, as the final PR to switch imageio_mutex from std::mutex to std::shared_mutex and adjust shared/exclusive locking will be trivial.

## Tests

This is very frequently used code, existing tests should cover it well. The breakage will be easy to see as the thread will deadlock if this commit makes any errors.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-CORPORATE)).
- [not needed] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

