### PR TITLE
Protections against 0-length string attributes

### DIFF
--- a/src/jpeg.imageio/jpegoutput.cpp
+++ b/src/jpeg.imageio/jpegoutput.cpp
@@ -221,11 +221,10 @@ JpgOutput::open(const std::string& name, const ImageSpec& newspec,
     m_next_scanline = 0;  // next scanline we'll write
 
     // Write JPEG comment, if sent an 'ImageDescription'
-    ParamValue* comment = m_spec.find_attribute("ImageDescription",
-                                                TypeDesc::STRING);
-    if (comment && comment->data()) {
-        const char** c = (const char**)comment->data();
-        jpeg_write_marker(&m_cinfo, JPEG_COM, (JOCTET*)*c, strlen(*c) + 1);
+    std::string comment = m_spec.get_string_attribute("ImageDescription");
+    if (comment.size()) {
+        jpeg_write_marker(&m_cinfo, JPEG_COM, (JOCTET*)comment.c_str(),
+                          comment.size() + 1);
     }
 
     if (Strutil::iequals(m_spec.get_string_attribute("oiio:ColorSpace"), "sRGB"))
@@ -242,7 +241,8 @@ JpgOutput::open(const std::string& name, const ImageSpec& newspec,
     exif.push_back(0);
     exif.push_back(0);
     encode_exif(m_spec, exif);
-    jpeg_write_marker(&m_cinfo, JPEG_APP0 + 1, (JOCTET*)&exif[0], exif.size());
+    jpeg_write_marker(&m_cinfo, JPEG_APP0 + 1, (JOCTET*)exif.data(),
+                      exif.size());
 
     // Write IPTC IIM metadata tags, if we have anything
     std::vector<char> iptc;
@@ -261,7 +261,7 @@ JpgOutput::open(const std::string& name, const ImageSpec& newspec,
         head.push_back((char)(iptc.size() >> 8));  // size of block
         head.push_back((char)(iptc.size() & 0xff));
         iptc.insert(iptc.begin(), head.begin(), head.end());
-        jpeg_write_marker(&m_cinfo, JPEG_APP0 + 13, (JOCTET*)&iptc[0],
+        jpeg_write_marker(&m_cinfo, JPEG_APP0 + 13, (JOCTET*)iptc.data(),
                           iptc.size());
     }
 

--- a/src/libOpenImageIO/exif.cpp
+++ b/src/libOpenImageIO/exif.cpp
@@ -944,9 +944,11 @@ encode_exif_entry(const ParamValue& p, int tag, std::vector<TIFFDirEntry>& dirs,
     case TIFF_ASCII:
         if (p.type() == TypeDesc::STRING) {
             const char* s = *(const char**)p.data();
-            int len       = strlen(s) + 1;
-            append_tiff_dir_entry(dirs, data, tag, type, len, s,
-                                  offset_correction, 0, endianreq);
+            if (s) {
+                int len = strlen(s) + 1;
+                append_tiff_dir_entry(dirs, data, tag, type, len, s,
+                                      offset_correction, 0, endianreq);
+            }
             return;
         }
         break;

--- a/src/libOpenImageIO/iptc.cpp
+++ b/src/libOpenImageIO/iptc.cpp
@@ -170,11 +170,13 @@ encode_iptc_iim_one_tag(int tag, const char* /*name*/, TypeDesc type,
         iptc.push_back((char)0x02);
         iptc.push_back((char)tag);
         const char* str = ((const char**)data)[0];
-        int tagsize     = strlen(str);
-        tagsize = std::min(tagsize, 0xffff - 1);  // Prevent 16 bit overflow
-        iptc.push_back((char)(tagsize >> 8));
-        iptc.push_back((char)(tagsize & 0xff));
-        iptc.insert(iptc.end(), str, str + tagsize);
+        if (str) {
+            int tagsize = strlen(str);
+            tagsize = std::min(tagsize, 0xffff - 1);  // Prevent 16 bit overflow
+            iptc.push_back((char)(tagsize >> 8));
+            iptc.push_back((char)(tagsize & 0xff));
+            iptc.insert(iptc.end(), str, str + tagsize);
+        }
     }
 }
 

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -638,11 +638,13 @@ OpenEXRInput::PartInfo::parse_header(OpenEXRInput* in,
         const Imf::Attribute& attrib = hit.attribute();
         std::string type             = attrib.typeName();
         if (type == "string"
-            && (sattr = header->findTypedAttribute<Imf::StringAttribute>(name)))
-            spec.attribute(oname, sattr->value().c_str());
-        else if (type == "int"
-                 && (iattr = header->findTypedAttribute<Imf::IntAttribute>(
-                         name)))
+            && (sattr = header->findTypedAttribute<Imf::StringAttribute>(
+                    name))) {
+            if (sattr->value().size())
+                spec.attribute(oname, sattr->value().c_str());
+        } else if (type == "int"
+                   && (iattr = header->findTypedAttribute<Imf::IntAttribute>(
+                           name)))
             spec.attribute(oname, iattr->value());
         else if (type == "float"
                  && (fattr = header->findTypedAttribute<Imf::FloatAttribute>(

--- a/src/openexr.imageio/exrinput_c.cpp
+++ b/src/openexr.imageio/exrinput_c.cpp
@@ -679,7 +679,10 @@ OpenEXRCoreInput::PartInfo::parse_header(OpenEXRCoreInput* in,
             break;
         }
 
-        case EXR_ATTR_STRING: spec.attribute(oname, attr->string->str); break;
+        case EXR_ATTR_STRING:
+            if (attr->string && attr->string->str && attr->string->str[0])
+                spec.attribute(oname, attr->string->str);
+            break;
         case EXR_ATTR_STRING_VECTOR: {
             std::vector<ustring> ustrvec(attr->stringvector->n_strings);
             for (int32_t i = 0, e = attr->stringvector->n_strings; i < e; ++i)

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -1045,7 +1045,7 @@ OpenEXROutput::put_parameter(const std::string& name, TypeDesc type,
                                   Imf::FloatAttribute((float)*(half*)data));
                     return true;
                 }
-                if (type == TypeString) {
+                if (type == TypeString && data && *(char**)data) {
                     header.insert(xname.c_str(),
                                   Imf::StringAttribute(*(char**)data));
                     return true;

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -309,9 +309,10 @@ private:
     {
         string_view s;
         if (tiff_get_string_field(tag, name, s)) {
-            m_spec.attribute(name, s);
-            // TODO: If the length is 0, erase the attrib rather than
-            // setting it to the empty string.
+            if (s.size())
+                m_spec.attribute(name, s);
+            else
+                m_spec.erase_attribute(name);
         }
     }
 

--- a/testsuite/oiiotool/ref/out.txt
+++ b/testsuite/oiiotool/ref/out.txt
@@ -11,7 +11,6 @@ chname.exr           :   38 x   38, 5 channel, float openexr
     full/display size: 40 x 40
     full/display origin: 0, 0
     compression: "zips"
-    nuke/node_hash: ""
     Orientation: 1 (normal)
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
@@ -25,7 +24,6 @@ allhalf.exr          :   38 x   38, 5 channel, half openexr
     full/display size: 40 x 40
     full/display origin: 0, 0
     compression: "zips"
-    nuke/node_hash: ""
     Orientation: 1 (normal)
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0
@@ -39,7 +37,6 @@ rgbahalf-zfloat.exr  :   38 x   38, 5 channel, half/half/half/half/float openexr
     full/display size: 40 x 40
     full/display origin: 0, 0
     compression: "zips"
-    nuke/node_hash: ""
     Orientation: 1 (normal)
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0


### PR DESCRIPTION
Files that have string metadata with length 0 can cause trouble
if we aren't careful. Put in a number of protections.
