### PR TITLE
JPEG: Fix a race condition in read_native_scanline()

### DIFF
--- a/src/jpeg.imageio/jpeginput.cpp
+++ b/src/jpeg.imageio/jpeginput.cpp
@@ -431,6 +431,7 @@ bool
 JpgInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
                                void* data)
 {
+    lock_guard lock(*this);
     if (!seek_subimage(subimage, miplevel))
         return false;
     if (m_raw)


### PR DESCRIPTION
## Description

All read_native_* methods of ImageInput are required to be thread-safe with any other read_native_* call or with the varieties of read_tiles() that take an explicit subimage and miplevel parameter.

JpgInput::read_native_scanline() does a seek_subimage() call internally, so it's obviously not thread safe without additional locking.

## Tests

It's not possible to write a test that reliably reproduces race conditions, so there are no new tests for this PR.

## Checklist:

- [x] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-CORPORATE)).
- [not needed] I have updated the documentation, if applicable.
- [not needed] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

