### PR TITLE
filesystem.h: Improve documentation of pread() and pwrite()

### DIFF
--- a/src/include/OpenImageIO/filesystem.h
+++ b/src/include/OpenImageIO/filesystem.h
@@ -410,10 +410,21 @@ public:
     // Write `size` bytes from `buf[]` at the current position, returning the
     // number of bytes successfully written.
     virtual size_t write (const void *buf, size_t size);
-    // pread(), pwrite() are stateless, do not alter the current file
-    // position, and are thread-safe (against each other).
+
+    /// Read `size` bytes starting at the `offset` position into `buf[]`,
+    /// returning the number of bytes successfully read. This function does
+    /// not alter the current file position. This function is thread-safe against
+    /// all other concurrent calls to pread() and pwrite(), but not against any
+    /// other function of IOProxy.
     virtual size_t pread (void *buf, size_t size, int64_t offset);
+
+    /// Write `size` bytes from `buf[]` to file starting at the `offset` position,
+    /// returning the number of bytes successfully written. This function does
+    /// not alter the current file position. This function is thread-safe against
+    /// all other concurrent calls to pread() and pwrite(), but not against any
+    /// other function of IOProxy.
     virtual size_t pwrite (const void *buf, size_t size, int64_t offset);
+
     // Return the total size of the proxy data, in bytes.
     virtual size_t size () const { return 0; }
     virtual void flush () const { }


### PR DESCRIPTION
## Description

The current description of IOProxy::pread() and IOProxy::pwrite() is alittle ambiguous. This commit expands the description to explicitly tell what the functions are and are not required to do.

## Tests

Comment-only change, no tests are needed.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-CORPORATE)).
- [n/a] I have updated the documentation, if applicable.
- [n/a] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

