### PR TITLE
Bug fix: posible null pointer dereference in inventory_udim

### DIFF
--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -3671,10 +3671,11 @@ ImageCacheImpl::inventory_udim(ImageCacheFile* udimfile, Perthread* thread_info,
                                std::vector<ustring>& filenames, int& nutiles,
                                int& nvtiles)
 {
-    filenames.clear();
     if (!udimfile || !udimfile->is_udim()) {
+        filenames.clear();
         nutiles = 0;
         nvtiles = 0;
+        return;
     }
     nutiles = udimfile->m_udim_nutiles;
     nvtiles = udimfile->m_udim_nvtiles;

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -894,13 +894,11 @@ public:
     imagespec(ImageCacheFile* file, ImageCachePerThreadInfo* thread_info = NULL,
               int subimage = 0, int miplevel = 0, bool native = false) override;
 
-    virtual ImageCacheFile* resolve_udim(ImageCacheFile* udimfile,
-                                         Perthread* thread_info, int utile,
-                                         int vtile);
-    virtual void inventory_udim(ImageCacheFile* udimfile,
-                                Perthread* thread_info,
-                                std::vector<ustring>& filenames, int& nutiles,
-                                int& nvtiles);
+    ImageCacheFile* resolve_udim(ImageCacheFile* udimfile,
+                                 Perthread* thread_info, int utile, int vtile);
+    void inventory_udim(ImageCacheFile* udimfile, Perthread* thread_info,
+                        std::vector<ustring>& filenames, int& nutiles,
+                        int& nvtiles);
 
     virtual bool get_thumbnail(ustring filename, ImageBuf& thumbnail,
                                int subimage = 0) override;


### PR DESCRIPTION
If udimfile is null, it would get dereferenced anyway. Was missing
a `return` in that case.

While I was there, I realized that ImageCacheImpl::inventory_udim and
resolve_udim had no reason to be virtual, so I removed that
qualifier. (It was probably a cut/paste error, as the
identically-named methods in TextureSystem are virtual, on
purpose. But they don't need to be for this class.)
