### PR TITLE
Fix aspect ratio logic in jpeg

### DIFF
--- a/src/jpeg.imageio/jpegoutput.cpp
+++ b/src/jpeg.imageio/jpegoutput.cpp
@@ -390,7 +390,7 @@ JpgOutput::resmeta_to_density()
         // written by OIIO and vice versa. In other words, we must reverse
         // the sense of how aspect ratio relates to density, contradicting
         // the JFIF spec but conforming to Nuke/etc's behavior. Sigh.
-        if (XRes <= 0.0f && XRes <= 0.0f) {
+        if (XRes <= 0.0f && YRes <= 0.0f) {
             // resolutions were not set
             if (aspect >= 1.0f) {
                 XRes = 72.0f;


### PR DESCRIPTION
Typo, was checking XRes twice instead of XRes and YRes.
