### PR TITLE
Use imath .xyz rather than [] to fix static analysis warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,9 @@ jobs:
             # icc MUST use this older FMT version
             pybind11_ver: v2.9.0
             setenvs: export USE_ICC=1 USE_OPENVDB=0
+                            OIIO_EXTRA_CPP_ARGS="-fp-model=precise"
+            # For icc, use fp-model precise to eliminate needless LSB errors
+            # that make test results differ from other platforms.
           - desc: icx/C++17 py3.9 boost1.76 exr3.1 ocio2.1 qt5.15
             nametag: linux-vfx2022-icx
             os: ubuntu-latest

--- a/src/build-scripts/ci-build.bash
+++ b/src/build-scripts/ci-build.bash
@@ -26,6 +26,7 @@ cmake .. -G "$CMAKE_GENERATOR" \
         -DCMAKE_INSTALL_LIBDIR="$OpenImageIO_ROOT/lib" \
         -DCMAKE_CXX_STANDARD="$CMAKE_CXX_STANDARD" \
         -DOIIO_DOWNLOAD_MISSING_TESTDATA=ON \
+        -DEXTRA_CPP_ARGS="${OIIO_EXTRA_CPP_ARGS}" \
         $MY_CMAKE_FLAGS -DVERBOSE=1
 
 # Save a copy of the generated files for debugging broken CI builds.

--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -543,7 +543,7 @@ endif ()
 set (EXTRA_CPP_ARGS "" CACHE STRING "Extra C++ command line definitions")
 if (EXTRA_CPP_ARGS)
     message (STATUS "Extra C++ args: ${EXTRA_CPP_ARGS}")
-    add_compile_options ("${EXTRA_CPP_ARGS}")
+    add_compile_options (${EXTRA_CPP_ARGS})
 endif()
 set (EXTRA_DSO_LINK_ARGS "" CACHE STRING "Extra command line definitions when building DSOs")
 

--- a/src/libtexture/environment.cpp
+++ b/src/libtexture/environment.cpp
@@ -266,11 +266,11 @@ inline void
 vector_to_latlong(const Imath::V3f& R, bool y_is_up, float& s, float& t)
 {
     if (y_is_up) {
-        s = atan2f(-R[0], R[2]) / (2.0f * (float)M_PI) + 0.5f;
-        t = 0.5f - atan2f(R[1], hypotf(R[2], -R[0])) / (float)M_PI;
+        s = atan2f(-R.x, R.z) / (2.0f * (float)M_PI) + 0.5f;
+        t = 0.5f - atan2f(R.y, hypotf(R.z, -R.x)) / (float)M_PI;
     } else {
-        s = atan2f(R[1], R[0]) / (2.0f * (float)M_PI) + 0.5f;
-        t = 0.5f - atan2f(R[2], hypotf(R[0], R[1])) / (float)M_PI;
+        s = atan2f(R.y, R.x) / (2.0f * (float)M_PI) + 0.5f;
+        t = 0.5f - atan2f(R.z, hypotf(R.x, R.y)) / (float)M_PI;
     }
     // learned from experience, beware NaNs
     if (isnan(s))

--- a/src/libtexture/texture3d.cpp
+++ b/src/libtexture/texture3d.cpp
@@ -304,9 +304,9 @@ TextureSystemImpl::accum3d_sample_closest(
         texturefile.levelinfo(options.subimage, miplevel));
     TypeDesc::BASETYPE pixeltype = texturefile.pixeltype(options.subimage);
     // As passed in, (s,t) map the texture to (0,1).  Remap to texel coords.
-    float s = P[0] * spec.full_width + spec.full_x;
-    float t = P[1] * spec.full_height + spec.full_y;
-    float r = P[2] * spec.full_depth + spec.full_z;
+    float s = P.x * spec.full_width + spec.full_x;
+    float t = P.y * spec.full_height + spec.full_y;
+    float r = P.z * spec.full_depth + spec.full_z;
     int stex, ttex, rtex;       // Texel coordinates
     (void)floorfrac(s, &stex);  // don't need fractional result
     (void)floorfrac(t, &ttex);
@@ -405,9 +405,9 @@ TextureSystemImpl::accum3d_sample_bilinear(
     TypeDesc::BASETYPE pixeltype = texturefile.pixeltype(options.subimage);
     // As passed in, (s,t) map the texture to (0,1).  Remap to texel coords
     // and subtract 0.5 because samples are at texel centers.
-    float s = P[0] * spec.full_width + spec.full_x - 0.5f;
-    float t = P[1] * spec.full_height + spec.full_y - 0.5f;
-    float r = P[2] * spec.full_depth + spec.full_z - 0.5f;
+    float s = P.x * spec.full_width + spec.full_x - 0.5f;
+    float t = P.y * spec.full_height + spec.full_y - 0.5f;
+    float r = P.z * spec.full_depth + spec.full_z - 0.5f;
     int sint, tint, rint;
     float sfrac = floorfrac(s, &sint);
     float tfrac = floorfrac(t, &tint);

--- a/src/testtex/testtex.cpp
+++ b/src/testtex/testtex.cpp
@@ -193,7 +193,7 @@ getargs(int argc, const char* argv[])
       .help("Test TextureSystem::get_imagespec");
     ap.arg("--gettextureinfo %s:NAME", &gtiname)
       .help("Test gettextureinfo, retrieving attrib 'NAME'");
-    ap.arg("--offset %f:SOFF %f:TOFF %f:ROFF", &texoffset[0], &texoffset[1], &texoffset[2])
+    ap.arg("--offset %f:SOFF %f:TOFF %f:ROFF", &texoffset.x, &texoffset.y, &texoffset.z)
       .help("Offset texture coordinates");
     ap.arg("--scalest %f:SSCALE %f:TSCALE", &sscale, &tscale)
       .help("Scale texture lookups (s, t)");
@@ -408,8 +408,8 @@ void
 map_default(const Int& x, const Int& y, Float& s, Float& t, Float& dsdx,
             Float& dtdx, Float& dsdy, Float& dtdy)
 {
-    s    = (Float(x) + 0.5f) / output_xres * sscale + texoffset[0];
-    t    = (Float(y) + 0.5f) / output_yres * tscale + texoffset[1];
+    s    = (Float(x) + 0.5f) / output_xres * sscale + texoffset.x;
+    t    = (Float(y) + 0.5f) / output_yres * tscale + texoffset.y;
     dsdx = 1.0f / output_xres * sscale;
     dtdx = 0.0f;
     dsdy = 0.0f;
@@ -423,19 +423,18 @@ static void
 map_warp(const Int& x, const Int& y, Float& s, Float& t, Float& dsdx,
          Float& dtdx, Float& dsdy, Float& dtdy)
 {
-    const Imath::Vec2<Float> coord  = warp_coord(Float(x) + 0.5f,
-                                                Float(y) + 0.5f);
-    const Imath::Vec2<Float> coordx = warp_coord(Float(x) + 1.5f,
-                                                 Float(y) + 0.5f);
-    const Imath::Vec2<Float> coordy = warp_coord(Float(x) + 0.5f,
-                                                 Float(y) + 1.5f);
+    Imath::Vec2<Float> coord  = warp_coord(Float(x) + 0.5f, Float(y) + 0.5f);
+    Imath::Vec2<Float> coordx = warp_coord(Float(x) + 1.5f, Float(y) + 0.5f)
+                                - coord;
+    Imath::Vec2<Float> coordy = warp_coord(Float(x) + 0.5f, Float(y) + 1.5f)
+                                - coord;
 
-    s    = coord[0];
-    t    = coord[1];
-    dsdx = coordx[0] - coord[0];
-    dtdx = coordx[1] - coord[1];
-    dsdy = coordy[0] - coord[0];
-    dtdy = coordy[1] - coord[1];
+    s    = coord.x;
+    t    = coord.y;
+    dsdx = coordx.x;
+    dtdx = coordx.y;
+    dsdy = coordy.x;
+    dtdy = coordy.y;
 }
 
 
@@ -536,16 +535,16 @@ map_default_3D(const Int& x, const Int& y, Imath::Vec3<Float>& P,
                Imath::Vec3<Float>& dPdx, Imath::Vec3<Float>& dPdy,
                Imath::Vec3<Float>& dPdz)
 {
-    P[0] = (Float(x) + 0.5f) / output_xres * sscale;
-    P[1] = (Float(y) + 0.5f) / output_yres * tscale;
-    P[2] = 0.5f * sscale;
+    P.x = (Float(x) + 0.5f) / output_xres * sscale;
+    P.y = (Float(y) + 0.5f) / output_yres * tscale;
+    P.z = 0.5f * sscale;
     P += texoffset;
-    dPdx[0] = 1.0f / output_xres * sscale;
-    dPdx[1] = 0;
-    dPdx[2] = 0;
-    dPdy[0] = 0;
-    dPdy[1] = 1.0f / output_yres * tscale;
-    dPdy[2] = 0;
+    dPdx.x = 1.0f / output_xres * sscale;
+    dPdx.y = 0;
+    dPdx.z = 0;
+    dPdy.x = 0;
+    dPdy.y = 1.0f / output_yres * tscale;
+    dPdy.z = 0;
     dPdz.setValue(0, 0, 0);
 }
 
@@ -1059,7 +1058,7 @@ test_getimagespec_gettexels(ustring filename)
     for (int i = 0; i < iters; ++i) {
         bool ok = texsys->get_texels(filename, opt, miplevel, x, x + w, y,
                                      y + h, 0, 1, 0, nchannels,
-                                     postagespec.format, &tmp[0]);
+                                     postagespec.format, tmp.data());
         if (!ok)
             Strutil::print(std::cerr, "ERROR: {}\n", texsys->geterror());
     }


### PR DESCRIPTION
Stranely, this made slightly numerically different texture test
results on icc.  Switching its math mode to precise brings it back in
line with the other compilers. The differences aren't visible, so this
isn't an issue in practice, but for tests it made it hard to compare
to reference images.
