### PR TITLE
Relative image compare

### DIFF
--- a/src/doc/idiff.rst
+++ b/src/doc/idiff.rst
@@ -142,22 +142,27 @@ Thresholds and comparison options
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. describe:: -fail A
-              -failpercent B
-              -hardfail C
+              -failrelative R
+              -failpercent P
+              -hardfail H
 
-    Sets the threshold for FAILURE: if more than *B* % of pixels (on a 0-100
-    floating point scale) are greater than *A* different, or if *any* pixels
-    are more than *C* different.  The defaults are to fail if more than 0%
-    (any) pixels differ by more than 0.00001 (1e-6), and *C* is infinite.
+    Sets the threshold for FAILURE: if more than *P* % of pixels (on a 0-100
+    floating point scale) are greater than *A* different absolutely or *R*
+    relatively (to the mean of the two values), or if *any* pixels are more
+    than *H* different absolutely.  The defaults are to fail if more than 0%
+    (any) pixels differ by more than 0.00001 (1e-6), and *H* is infinite.
 
 .. describe:: -warn A
-              -warnpercent B
-              -hardwarn C
+              -warnrelative R
+              -warnpercent P
+              -hardwarn H
 
-    Sets the threshold for WARNING: if more than *B* % of pixels (on a 0-100
-    floating point scale) are greater than *A* different, or if *any* pixels
-    are more than *C* different.  The defaults are to warn if more than 0%
-    (any) pixels differ by more than 0.00001 (1e-6), and *C* is infinite.
+    Sets the threshold for WARNING: if more than *P* % of pixels (on a 0-100
+    floating point scale) are greater than *A* different absolutely or *R*
+    different relatively (to the mean of the two values), or if *any* pixels
+    are more than *H* different absolutely.  The defaults are to warn if more
+    than 0% (any) pixels differ by more than 0.00001 (1e-6), and *H* is
+    infinite.
 
 .. describe:: -p
 

--- a/src/doc/pythonbindings.rst
+++ b/src/doc/pythonbindings.rst
@@ -3171,12 +3171,14 @@ Image comparison and statistics
 
 
 
-.. py:method:: CompareResults ImageBufAlgo.compare (A, B, failthresh, warnthresh, roi=ROI.All, nthreads=0)
+.. py:method:: CompareResults ImageBufAlgo.compare (A, B, failthresh, warnthresh, failrelative=0.0, warnrelative=0.0, roi=ROI.All, nthreads=0)
 
     Numerically compare two ImageBuf's, `A` and `B`. The `failthresh` and
-    `warnthresh` supply failure and warning difference thresholds. The
-    return value is a `CompareResults` object, which is defined as a class
-    having the following members:
+    `warnthresh` supply absolute failure and warning difference thresholds,
+    and `failrelative` and `warnrelative` supply failure and warning
+    thresholds relative to the values in each image. The return value is a
+    `CompareResults` object, which is defined as a class having the following
+    members:
 
     .. code-block:: python
 

--- a/src/idiff/idiff.cpp
+++ b/src/idiff/idiff.cpp
@@ -58,9 +58,13 @@ getargs(int argc, char* argv[])
 
     ap.separator("Thresholding and comparison options");
     ap.arg("-fail")
-      .help("Failure threshold difference")
+      .help("Failure absolute difference threshold")
       .metavar("VAL")
       .defaultval(1.0e-6f);
+    ap.arg("-failrelative")
+      .help("Failure relative threshold")
+      .metavar("VAL")
+      .defaultval(0.0f);
     ap.arg("-failpercent")
       .help("Allow this percentage of failures")
       .metavar("PERCENT")
@@ -74,9 +78,13 @@ getargs(int argc, char* argv[])
       .metavar("N")
       .defaultval(0);
     ap.arg("-warn")
-      .help("Warning threshold difference")
+      .help("Warning absolute difference threshold")
       .metavar("VAL")
       .defaultval(1.0e-6f);
+    ap.arg("-warnrelative")
+      .help("Warning relative threshold")
+      .metavar("VAL")
+      .defaultval(0.0f);
     ap.arg("-warnpercent")
       .help("Allow this percentage of warnings")
       .metavar("PERCENT")
@@ -187,9 +195,11 @@ main(int argc, char* argv[])
     std::string diffimage = ap["o"].get();
     float diffscale       = ap["scale"].get<float>();
     float failthresh      = ap["fail"].get<float>();
+    float failrelative    = ap["failrelative"].get<float>();
     float failpercent     = ap["failpercent"].get<float>();
     float hardfail        = ap["hardfail"].get<float>();
     float warnthresh      = ap["warn"].get<float>();
+    float warnrelative    = ap["warnrelative"].get<float>();
     float warnpercent     = ap["warnpercent"].get<float>();
     float hardwarn        = ap["hardwarn"].get<float>();
     int allowfailures     = ap["allowfailures"].get<int>();
@@ -265,7 +275,8 @@ main(int argc, char* argv[])
 
             // Compare the two images.
             //
-            auto cr = ImageBufAlgo::compare(img0, img1, failthresh, warnthresh);
+            auto cr = ImageBufAlgo::compare(img0, img1, failthresh, warnthresh,
+                                            failrelative, warnrelative);
 
             int yee_failures = 0;
             if (perceptual && !img0.deep()) {

--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -1296,6 +1296,27 @@ struct CompareResults {
 };
 
 /// Numerically compare two images.  The difference threshold (for any
+/// individual color channel in any pixel) for a "failure" is `failthresh`,
+/// and for a "warning" is `warnthresh`.  If nonzero, then `failrelative` and
+/// `warnrelative` are alternate thresholds as a portion the mean of the
+/// absolute values of the two images. It only warns or fails if both criteria
+/// are met. More formally, a value comparison will fail if
+///
+///     abs(A-B) > failthresh && abs(A-B)/((abs(A)+abs(B))/2) > failrelative
+///
+/// and analogously for warning.
+///
+/// The results are stored in `result`.  If `roi` is defined, pixels will be
+/// compared for the pixel and channel range that is specified.  If `roi` is
+/// not defined, the comparison will be for all channels, on the union of the
+/// defined pixel windows of the two images (for either image, undefined
+/// pixels will be assumed to be black).
+CompareResults OIIO_API compare (const ImageBuf &A, const ImageBuf &B,
+                                 float failthresh, float warnthresh,
+                                 float failrelative, float warnrelative,
+                                 ROI roi={}, int nthreads=0);
+
+/// Numerically compare two images.  The difference threshold (for any
 /// individual color channel in any pixel) for a "failure" is
 /// failthresh, and for a "warning" is warnthresh.  The results are
 /// stored in result.  If roi is defined, pixels will be compared for

--- a/src/libOpenImageIO/imagebufalgo_test.cpp
+++ b/src/libOpenImageIO/imagebufalgo_test.cpp
@@ -584,6 +584,32 @@ test_compare()
     OIIO_CHECK_EQUAL(comp.maxx, 9);
     OIIO_CHECK_EQUAL(comp.maxy, 0);
     OIIO_CHECK_EQUAL_THRESH(comp.meanerror, 0.0045f, 1.0e-8f);
+
+    // Relative comparison: warn at 5% of the difference, fail at 10% of the
+    // difference. In row 0, we have:
+    //    A:  0.50  0.50  0.50  0.50  0.50  0.50  0.50  0.50  0.50  0.50
+    //    B:  0.50  0.51  0.52  0.53  0.54  0.55  0.56  0.57  0.58  0.59
+    // mean:  0.50  0.505 0.51  0.515 0.52  0.525 0.53  0.535 0.54  0.545
+    // diff:  0.0   0.01  0.02  0.03  0.04  0.05  0.06  0.07  0.08  0.09
+    // fail?                                       x     x     x     x
+    // warn?                     x     x     x     x     x     x     x
+    comp = ImageBufAlgo::compare(A, B, 0.0f, 0.0f, 0.1f, 0.05f);
+    // We expect 4 pixels to exceed the fail threshold, 7 pixels to
+    // exceed the warn threshold, the maximum difference to be 0.09,
+    // and the maximally different pixel to be (9,0).
+    // The total error should be 3 chans * sum{0.01,...,0.09} / (pixels*chans)
+    //   = 3 * 0.45 / (100*3) = 0.0045
+    std::cout << "Testing relative comparison: " << comp.nfail << " failed, "
+              << comp.nwarn << " warned, max diff = " << comp.maxerror << " @ ("
+              << comp.maxx << ',' << comp.maxy << ")\n";
+    std::cout << "   mean err " << comp.meanerror << ", RMS err "
+              << comp.rms_error << ", PSNR = " << comp.PSNR << "\n";
+    OIIO_CHECK_EQUAL(comp.nfail, 4);
+    OIIO_CHECK_EQUAL(comp.nwarn, 7);
+    OIIO_CHECK_EQUAL_THRESH(comp.maxerror, 0.09f, 1e-6f);
+    OIIO_CHECK_EQUAL(comp.maxx, 9);
+    OIIO_CHECK_EQUAL(comp.maxy, 0);
+    OIIO_CHECK_EQUAL_THRESH(comp.meanerror, 0.0045f, 1.0e-8f);
 }
 
 

--- a/src/python/py_imagebufalgo.cpp
+++ b/src/python/py_imagebufalgo.cpp
@@ -1462,7 +1462,17 @@ IBA_computePixelStats(const ImageBuf& src, ImageBufAlgo::PixelStats& stats,
 
 ImageBufAlgo::CompareResults
 IBA_compare_ret(const ImageBuf& A, const ImageBuf& B, float failthresh,
-                float warnthresh, ROI roi, int nthreads)
+                float warnthresh, float failrelative, float warnrelative,
+                ROI roi, int nthreads)
+{
+    py::gil_scoped_release gil;
+    return ImageBufAlgo::compare(A, B, failthresh, warnthresh, failrelative,
+                                 warnrelative, roi, nthreads);
+}
+
+ImageBufAlgo::CompareResults
+IBA_compare_ret_old(const ImageBuf& A, const ImageBuf& B, float failthresh,
+                    float warnthresh, ROI roi, int nthreads)
 {
     py::gil_scoped_release gil;
     return ImageBufAlgo::compare(A, B, failthresh, warnthresh, roi, nthreads);
@@ -2888,7 +2898,12 @@ declare_imagebufalgo(py::module& m)
                     "warnthresh"_a, "result"_a, "roi"_a = ROI::All(),
                     "nthreads"_a = 0)
         .def_static("compare", &IBA_compare_ret, "A"_a, "B"_a, "failthresh"_a,
-                    "warnthresh"_a, "roi"_a = ROI::All(), "nthreads"_a = 0)
+                    "warnthresh"_a, "failrelative"_a = 0.0f,
+                    "warnrelative"_a = 0.0f, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
+        .def_static("compare", &IBA_compare_ret_old, "A"_a, "B"_a,
+                    "failthresh"_a, "warnthresh"_a, "roi"_a = ROI::All(),
+                    "nthreads"_a = 0)
 
         .def_static("compare_Yee", &IBA_compare_Yee, "A"_a, "B"_a, "result"_a,
                     "luminance"_a = 100, "fov"_a = 45, "roi"_a = ROI::All(),

--- a/testsuite/python-imagebufalgo/ref/out-freetype2.4.11-py2.7-pybind2.3.txt
+++ b/testsuite/python-imagebufalgo/ref/out-freetype2.4.11-py2.7-pybind2.3.txt
@@ -23,6 +23,8 @@ Comparison: of flip.tif and flop.tif
   max  = 0.45098
   max @ (214, 88, 0, 0)
   warns 2034 fails 2034
+Relative comparison: of flip.tif and flop.tif
+  warns 1946 fails 1896
 isConstantColor on pink image is (1 0.50196 0.50196)
 isConstantColor on checker is  None
 Is cmul1.exr monochrome?  True

--- a/testsuite/python-imagebufalgo/ref/out-freetype2.4.11.txt
+++ b/testsuite/python-imagebufalgo/ref/out-freetype2.4.11.txt
@@ -23,6 +23,8 @@ Comparison: of flip.tif and flop.tif
   max  = 0.45098
   max @ (214L, 88L, 0L, 0L)
   warns 2034 fails 2034
+Relative comparison: of flip.tif and flop.tif
+  warns 1946 fails 1896
 isConstantColor on pink image is (1 0.50196 0.50196)
 isConstantColor on checker is  None
 Is cmul1.exr monochrome?  True

--- a/testsuite/python-imagebufalgo/ref/out-python2-alt.txt
+++ b/testsuite/python-imagebufalgo/ref/out-python2-alt.txt
@@ -23,6 +23,8 @@ Comparison: of flip.tif and flop.tif
   max  = 0.45098
   max @ (214, 88, 0, 0)
   warns 2034 fails 2034
+Relative comparison: of flip.tif and flop.tif
+  warns 1946 fails 1896
 isConstantColor on pink image is (1 0.50196 0.50196)
 isConstantColor on checker is  None
 Is cmul1.exr monochrome?  True

--- a/testsuite/python-imagebufalgo/ref/out-python3-freetype2.4.11.txt
+++ b/testsuite/python-imagebufalgo/ref/out-python3-freetype2.4.11.txt
@@ -23,6 +23,8 @@ Comparison: of flip.tif and flop.tif
   max  = 0.45098
   max @ (214, 88, 0, 0)
   warns 2034 fails 2034
+Relative comparison: of flip.tif and flop.tif
+  warns 1946 fails 1896
 isConstantColor on pink image is (1 0.50196 0.50196)
 isConstantColor on checker is  None
 Is cmul1.exr monochrome?  True

--- a/testsuite/python-imagebufalgo/ref/out-python3.txt
+++ b/testsuite/python-imagebufalgo/ref/out-python3.txt
@@ -23,6 +23,8 @@ Comparison: of flip.tif and flop.tif
   max  = 0.45098
   max @ (214, 88, 0, 0)
   warns 2034 fails 2034
+Relative comparison: of flip.tif and flop.tif
+  warns 1946 fails 1896
 isConstantColor on pink image is (1 0.50196 0.50196)
 isConstantColor on checker is  None
 Is cmul1.exr monochrome?  True

--- a/testsuite/python-imagebufalgo/ref/out.txt
+++ b/testsuite/python-imagebufalgo/ref/out.txt
@@ -23,6 +23,8 @@ Comparison: of flip.tif and flop.tif
   max  = 0.45098
   max @ (214L, 88L, 0L, 0L)
   warns 2034 fails 2034
+Relative comparison: of flip.tif and flop.tif
+  warns 1946 fails 1896
 isConstantColor on pink image is (1 0.50196 0.50196)
 isConstantColor on checker is  None
 Is cmul1.exr monochrome?  True

--- a/testsuite/python-imagebufalgo/src/test_imagebufalgo.py
+++ b/testsuite/python-imagebufalgo/src/test_imagebufalgo.py
@@ -326,6 +326,7 @@ try:
     print ("  infcount    = ", stats.infcount)
     print ("  finitecount = ", stats.finitecount)
 
+    # Absolute compare
     compresults = ImageBufAlgo.compare (ImageBuf("flip.tif"), ImageBuf("flop.tif"),
                                         1.0e-6, 1.0e-6)
     print ("Comparison: of flip.tif and flop.tif")
@@ -334,6 +335,12 @@ try:
     print ("  PSNR = %.5g" % compresults.PSNR)
     print ("  max  = %.5g" % compresults.maxerror)
     print ("  max @", (compresults.maxx, compresults.maxy, compresults.maxz, compresults.maxc))
+    print ("  warns", compresults.nwarn, "fails", compresults.nfail)
+
+    # Relative compare
+    compresults = ImageBufAlgo.compare (ImageBuf("flip.tif"), ImageBuf("flop.tif"),
+                                        0.0, 0.0, 0.1, 0.05)
+    print ("Relative comparison: of flip.tif and flop.tif")
     print ("  warns", compresults.nwarn, "fails", compresults.nfail)
 
     # compare_Yee,


### PR DESCRIPTION
Extend ImageBufAlgo::compare() to take relative metrics, which if
nonzero check the symmetric mean relative error, in addition to the
current absolute error. To be formal, this means that a value
comparison will fail if

    abs(A-B) > failthresh && abs(A-B)/((abs(A)+abs(B))/2) > failrelative

Setting the failthresh to 0 is equivalent to only checking relative
error, and setting failrelative to 0 is equivalent to the (previous
behavior) of checking only absolute error.

The idiff utility is extended to take new `-failrelative` and
`-warnrelative` command line arguments.

The hope is that there are various kinds of image comparisons within
tolerances -- like we frequenty use for unit tests, shader
verification, etc. -- where this metric is more helpful than absolute
error.

