### PR TITLE
cmake: fix ffmpeg 5.1 detection

### DIFF
--- a/src/cmake/modules/FindFFmpeg.cmake
+++ b/src/cmake/modules/FindFFmpeg.cmake
@@ -59,7 +59,11 @@ else ()
 endif ()
 
 if (FFMPEG_INCLUDES)
-  file(STRINGS "${FFMPEG_INCLUDES}/libavcodec/version.h" TMP
+  set (_libavcodec_version_major_h "${FFMPEG_INCLUDES}/libavcodec/version_major.h")
+  if (NOT EXISTS "${_libavcodec_version_major_h}")
+    set (_libavcodec_version_major_h "${FFMPEG_INCLUDES}/libavcodec/version.h")
+  endif()
+  file(STRINGS "${_libavcodec_version_major_h}" TMP
        REGEX "^#define LIBAVCODEC_VERSION_MAJOR .*$")
   string (REGEX MATCHALL "[0-9]+[.0-9]+" LIBAVCODEC_VERSION_MAJOR "${TMP}")
   file(STRINGS "${FFMPEG_INCLUDES}/libavcodec/version.h" TMP
@@ -69,7 +73,9 @@ if (FFMPEG_INCLUDES)
        REGEX "^#define LIBAVCODEC_VERSION_MICRO .*$")
   string (REGEX MATCHALL "[0-9]+[.0-9]+" LIBAVCODEC_VERSION_MICRO "${TMP}")
   set (LIBAVCODEC_VERSION "${LIBAVCODEC_VERSION_MAJOR}.${LIBAVCODEC_VERSION_MINOR}.${LIBAVCODEC_VERSION_MICRO}")
-  if (LIBAVCODEC_VERSION VERSION_GREATER_EQUAL 59.18.100)
+  if (LIBAVCODEC_VERSION VERSION_GREATER_EQUAL 59.37.100)
+      set (FFMPEG_VERSION 5.1)
+  elseif (LIBAVCODEC_VERSION VERSION_GREATER_EQUAL 59.18.100)
       set (FFMPEG_VERSION 5.0)
   elseif (LIBAVCODEC_VERSION VERSION_GREATER_EQUAL 58.134.100)
       set (FFMPEG_VERSION 4.4)


### PR DESCRIPTION
## Description

Fix CMake detection of FFmpeg 5.1, which refactored location of libavcodec major version in https://github.com/FFmpeg/FFmpeg/commit/f2da2e1458b76a1d6c068673430b46cf2850bc51. Seen in Homebrew https://github.com/Homebrew/homebrew-core/pull/107244

Only fixes detection and I confirmed successful build. Not sure if any breaking changes in API, but at least still compiles with newer FFmpeg.

Original cmake output for master branch with FFmpeg 5.1:
```console
❯ PKG_CONFIG_PATH=/usr/local/opt/ffmpeg/lib/pkgconfig cmake -S. -Bmaster 2>/dev/null | grep -i ffmpeg
-- FFmpeg 1.0 is outside the required range 3.0...
-- FFmpeg library not found
--     Try setting FFmpeg_ROOT ?
-- FFmpeg not found: ffmpeg plugin will not be built
```

And same with changes:
```console
❯ PKG_CONFIG_PATH=/usr/local/opt/ffmpeg/lib/pkgconfig cmake -S. -Bfix 2>/dev/null | grep -i ffmpeg
-- Found FFmpeg 5.1
```

And confirming FFmpeg 4 is still detected:
```console
❯ PKG_CONFIG_PATH=/usr/local/opt/ffmpeg@4/lib/pkgconfig cmake -S. -Bfix2 2>/dev/null | grep -i ffmpeg
-- Found FFmpeg 4.4
```

## Tests


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

