### PR TITLE
Fix vector-subscript-out-of-range on MSVC Debug builds

### DIFF
--- a/src/hdr.imageio/hdrinput.cpp
+++ b/src/hdr.imageio/hdrinput.cpp
@@ -324,7 +324,7 @@ HdrInput::RGBE_ReadPixels_RLE(float* data, int y, uint64_t scanline_width,
         return RGBE_ReadPixels(data, y, scanline_width * num_scanlines);
 
     unsigned char rgbe[4], *ptr, *ptr_end;
-    int i, count;
+    int count;
     unsigned char buf[2];
     std::vector<unsigned char> scanline_buffer;
     Filesystem::IOProxy* m_io = ioproxy();
@@ -342,7 +342,7 @@ HdrInput::RGBE_ReadPixels_RLE(float* data, int y, uint64_t scanline_width,
             data += 3;
             return RGBE_ReadPixels(data, y, scanline_width * num_scanlines - 1);
         }
-        if ((((int)rgbe[2]) << 8 | rgbe[3]) != scanline_width) {
+        if ((((uint64_t)rgbe[2]) << 8 | rgbe[3]) != scanline_width) {
             errorfmt("wrong scanline width for scanline {}", y);
             return false;
         }
@@ -350,7 +350,7 @@ HdrInput::RGBE_ReadPixels_RLE(float* data, int y, uint64_t scanline_width,
 
         ptr = scanline_buffer.data();
         /* read each of the four channels for the scanline into the buffer */
-        for (i = 0; i < 4; i++) {
+        for (int i = 0; i < 4; i++) {
             ptr_end = scanline_buffer.data() + (i + 1) * scanline_width;
             while (ptr < ptr_end) {
                 if (m_io->pread(buf, 2, m_io_pos) < 2) {
@@ -388,7 +388,7 @@ HdrInput::RGBE_ReadPixels_RLE(float* data, int y, uint64_t scanline_width,
             }
         }
         /* now convert data from buffer into floats */
-        for (i = 0; i < scanline_width; i++) {
+        for (uint64_t i = 0; i < scanline_width; i++) {
             rgbe[0] = scanline_buffer[i];
             rgbe[1] = scanline_buffer[i + scanline_width];
             rgbe[2] = scanline_buffer[i + 2 * scanline_width];

--- a/src/hdr.imageio/hdrinput.cpp
+++ b/src/hdr.imageio/hdrinput.cpp
@@ -67,7 +67,7 @@ private:
 
     bool RGBE_ReadHeader();
     bool RGBE_ReadPixels(float* data, int y, uint64_t numpixels);
-    bool RGBE_ReadPixels_RLE(float* data, int y, int scanline_width,
+    bool RGBE_ReadPixels_RLE(float* data, int y, uint64_t scanline_width,
                              int num_scanlines);
 
     // helper: fgets reads a "line" from the proxy, akin to std fgets. The
@@ -316,12 +316,12 @@ HdrInput::RGBE_ReadPixels(float* data, int y, uint64_t numpixels)
 
 
 bool
-HdrInput::RGBE_ReadPixels_RLE(float* data, int y, int scanline_width,
+HdrInput::RGBE_ReadPixels_RLE(float* data, int y, uint64_t scanline_width,
                               int num_scanlines)
 {
     if ((scanline_width < 8) || (scanline_width > 0x7fff))
         /* run length encoding is not allowed so read flat*/
-        return RGBE_ReadPixels(data, y, (uint64_t)scanline_width * num_scanlines);
+        return RGBE_ReadPixels(data, y, scanline_width * num_scanlines);
 
     unsigned char rgbe[4], *ptr, *ptr_end;
     int i, count;
@@ -340,18 +340,18 @@ HdrInput::RGBE_ReadPixels_RLE(float* data, int y, int scanline_width,
             /* this file is not run length encoded */
             rgbe2float(data[0], data[1], data[2], rgbe);
             data += 3;
-            return RGBE_ReadPixels(data, y, (uint64_t)scanline_width * num_scanlines - 1);
+            return RGBE_ReadPixels(data, y, scanline_width * num_scanlines - 1);
         }
         if ((((int)rgbe[2]) << 8 | rgbe[3]) != scanline_width) {
             errorfmt("wrong scanline width for scanline {}", y);
             return false;
         }
-        scanline_buffer.resize(4 * (uint64_t)scanline_width);
+        scanline_buffer.resize(4 * scanline_width);
 
         ptr = scanline_buffer.data();
         /* read each of the four channels for the scanline into the buffer */
         for (i = 0; i < 4; i++) {
-            ptr_end = scanline_buffer.data() + (i + 1) * (uint64_t)scanline_width;
+            ptr_end = scanline_buffer.data() + (i + 1) * scanline_width;
             while (ptr < ptr_end) {
                 if (m_io->pread(buf, 2, m_io_pos) < 2) {
                     errorfmt("Read error on scanline {}", y);
@@ -390,9 +390,9 @@ HdrInput::RGBE_ReadPixels_RLE(float* data, int y, int scanline_width,
         /* now convert data from buffer into floats */
         for (i = 0; i < scanline_width; i++) {
             rgbe[0] = scanline_buffer[i];
-            rgbe[1] = scanline_buffer[i + (uint64_t)scanline_width];
-            rgbe[2] = scanline_buffer[i + 2 * (uint64_t)scanline_width];
-            rgbe[3] = scanline_buffer[i + 3 * (uint64_t)scanline_width];
+            rgbe[1] = scanline_buffer[i + scanline_width];
+            rgbe[2] = scanline_buffer[i + 2 * scanline_width];
+            rgbe[3] = scanline_buffer[i + 3 * scanline_width];
             rgbe2float(data[0], data[1], data[2], rgbe);
             data += 3;
         }


### PR DESCRIPTION
## Description

Fix vector-subscript-out-of-range on MSVC Debug builds
Also fixes potential problems with >31bit pixelsizes

## Tests

Verified in our own testsuites. Happens on every .hdr file that is being read

## Checklist:

- [X ] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [X ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-CORPORATE)).
- [X ] I have updated the documentation, if applicable.
- [X ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [X ] My code follows the prevailing code style of this project.
