### PR TITLE
CI: For Mac, test python 3.9 for MacOS11, and 3.10 for MacOS12.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,21 +360,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Deprecating
-          # - desc: MacOS-10.15
-          #   os: macos-10.15
-          #   cxx_std: 14
-          #   python_ver: 3.8
-          #   aclang: 12
           - desc: MacOS-11
             os: macos-11
             cxx_std: 17
-            python_ver: 3.9
+            python_ver: "3.9"
             aclang: 13
           - desc: MacOS-12
             os: macos-12
             cxx_std: 20
-            python_ver: 3.9
+            python_ver: "3.10"
             aclang: 13
             setenvs: export CTEST_TEST_TIMEOUT=300
     runs-on: ${{ matrix.os }}

--- a/src/build-scripts/install_homebrew_deps.bash
+++ b/src/build-scripts/install_homebrew_deps.bash
@@ -24,9 +24,11 @@ brew list --versions
 # All cases except for clang-format target, we need the dependencies.
 brew install --display-times -q gcc ccache cmake ninja boost || true
 brew link --overwrite gcc
+brew install --display-times -q python@${PYTHON_VERSION} || true
 brew unlink python@2.7 || true
-brew unlink python@3.9 || true
 brew unlink python@3.8 || true
+brew unlink python@3.9 || true
+brew unlink python@3.10 || true
 brew link --overwrite --force python@${PYTHON_VERSION} || true
 #brew upgrade --display-times -q cmake || true
 #brew install --display-times -q libtiff


### PR DESCRIPTION
Homebrew recently upgraded its default python to 3.10, which broke our Mac CI
