### PR TITLE
Make Filesystem::extension work identically for C++14 and 17

### DIFF
--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -109,6 +109,15 @@ std::string
 Filesystem::extension(string_view filepath, bool include_dot) noexcept
 {
     std::string s;
+#if !defined(USE_STD_FILESYSTEM)
+    if (filepath.find('.') == 0 && filepath.rfind('.') == 0) {
+        // Work around bug in boost::filesystem::path::extension(), where
+        // ".foo" thinks the extension is foo. But we know, and
+        // std::filesystem::path::extension() knows, that a file called ".foo"
+        // has no extension, that's just the base filename.
+        return s;
+    }
+#endif
     try {
         s = pathstr(u8path(filepath).extension());
     } catch (...) {

--- a/src/libutil/filesystem_test.cpp
+++ b/src/libutil/filesystem_test.cpp
@@ -35,6 +35,13 @@ test_filename_decomposition()
                      ".ext");
     OIIO_CHECK_EQUAL(Filesystem::extension("/directory/filename"), "");
     OIIO_CHECK_EQUAL(Filesystem::extension("/directory/filename."), ".");
+    OIIO_CHECK_EQUAL(Filesystem::extension("a.foo"), ".foo");
+    OIIO_CHECK_EQUAL(Filesystem::extension("a.foo", false), "foo");
+    OIIO_CHECK_EQUAL(Filesystem::extension("foo"), "");
+    OIIO_CHECK_EQUAL(Filesystem::extension("foo", false), "");
+    OIIO_CHECK_EQUAL(Filesystem::extension(".foo"), "");
+    OIIO_CHECK_EQUAL(Filesystem::extension(".foo", false), "");
+
     OIIO_CHECK_EQUAL(Filesystem::parent_path(test), "/directoryA/directory");
 
     std::cout << "Testing path_is_absolute\n";


### PR DESCRIPTION
The implementation of boost::filesystem::path::extension() and the
equivalent for std::filesystem disagreed about the result of
extension(".foo"). C++17 correctly considers ".foo" to have no
extension.
