### PR TITLE
DDS improvements

### DIFF
--- a/src/dds.imageio/dds_pvt.h
+++ b/src/dds.imageio/dds_pvt.h
@@ -46,7 +46,8 @@ enum {
     DDS_PF_ALPHA     = 0x00000001,  ///< image has alpha channel
     DDS_PF_FOURCC    = 0x00000004,  ///< image is compressed
     DDS_PF_LUMINANCE = 0x00020000,  ///< image has luminance data
-    DDS_PF_RGB       = 0x00000040   ///< image has RGB data
+    DDS_PF_RGB       = 0x00000040,  ///< image has RGB data
+    DDS_PF_YUV       = 0x00000200   ///< image has YUV data
 };
 
 /// DDS pixel format structure.


### PR DESCRIPTION
* For 2-channel DDS files, label them as Y,A if the flags indicate
  luminance and/or alpha, otherwise label them as R,G.

* Do not set "oiio:BitsPerSample" for cases where the dds.fmt.bpp field
  is not assumed to be valid. MS docs say it's valid only if the flags
  field indicates RGB, LUMINANCE, or YUV types.

