### PR TITLE
Add --version to all the things

### DIFF
--- a/src/doc/idiff.rst
+++ b/src/doc/idiff.rst
@@ -120,6 +120,10 @@ General options
 
     Prints usage information to the terminal.
 
+.. option:: --version
+
+    Prints the version designation of the OIIO library.
+
 .. describe:: -v
 
     Verbose output --- more detail about what it finds when comparing

--- a/src/doc/igrep.rst
+++ b/src/doc/igrep.rst
@@ -36,6 +36,10 @@ Example::
 
     Prints usage information to the terminal.
 
+.. option:: --version
+
+    Prints the version designation of the OIIO library.
+
 .. describe:: -d
 
     Print directory names as it recurses.  This only happens if the `-r`

--- a/src/doc/iinfo.rst
+++ b/src/doc/iinfo.rst
@@ -138,6 +138,10 @@ subimages::
 
     Prints usage information to the terminal.
 
+.. option:: --version
+
+    Prints the version designation of the OIIO library.
+
 .. describe:: -v
 
     Verbose output --- prints all metadata of the image files.

--- a/src/doc/maketx.rst
+++ b/src/doc/maketx.rst
@@ -59,6 +59,10 @@ Command-line arguments are:
 
     Prints usage information to the terminal.
 
+.. option:: --version
+
+    Prints the version designation of the OIIO library.
+
 .. option:: -v
 
     Verbose status messages, including runtime statistics and timing.

--- a/src/doc/oiiotool.rst
+++ b/src/doc/oiiotool.rst
@@ -835,6 +835,10 @@ output each one to a different file, with names `sub0001.tif`,
     about image formats supported, known color spaces, filters, OIIO build
     options and library dependencies.
 
+.. option:: --version
+
+    Prints the version designation of the OIIO library.
+
 .. option:: -v
 
     Verbose status messages --- print out more information about what

--- a/src/idiff/idiff.cpp
+++ b/src/idiff/idiff.cpp
@@ -44,6 +44,7 @@ getargs(int argc, char* argv[])
     ap.intro("idiff -- compare two images\n"
              OIIO_INTRO_STRING)
       .usage("idiff [options] image1 image2")
+      .add_version(OIIO_VERSION_STRING)
       .print_defaults(true);
 
     ap.arg("filename")

--- a/src/igrep/igrep.cpp
+++ b/src/igrep/igrep.cpp
@@ -134,7 +134,8 @@ main(int argc, const char* argv[])
     ArgParse ap;
     ap.intro("igrep -- search images for matching metadata\n"
              OIIO_INTRO_STRING)
-      .usage("igrep [options] pattern filename...");
+      .usage("igrep [options] pattern filename...")
+      .add_version(OIIO_VERSION_STRING);
     ap.arg("filename")
       .hidden()
       .action(parse_files);

--- a/src/iinfo/iinfo.cpp
+++ b/src/iinfo/iinfo.cpp
@@ -624,9 +624,9 @@ main(int argc, const char* argv[])
     Filesystem::convert_native_arguments(argc, (const char**)argv);
     ArgParse ap;
     // clang-format off
-    ap.intro("iinfo -- print information about images\n"
-             OIIO_INTRO_STRING);
-    ap.usage("iinfo [options] filename...");
+    ap.intro("iinfo -- print information about images\n" OIIO_INTRO_STRING)
+      .usage("iinfo [options] filename...")
+      .add_version(OIIO_VERSION_STRING);
     ap.arg("filename")
       .hidden()
       .action([&](cspan<const char*> argv){ filenames.emplace_back(argv[0]); });

--- a/src/include/OpenImageIO/argparse.h
+++ b/src/include/OpenImageIO/argparse.h
@@ -236,6 +236,10 @@ public:
     /// like any other argument.
     ArgParse& add_help(bool add_help);
 
+    /// Calling `add_version()` adds a `--version` argument, which will print
+    /// the version string supplied.
+    ArgParse& add_version(string_view version_string);
+
     /// By default, if the command line arguments do not conform to what is
     /// declared to ArgParse (for example, if unknown commands are
     /// encountered, required arguments are not found, etc.), the ArgParse

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -2817,6 +2817,10 @@ inline bool attribute (string_view name, string_view val) {
 /// documented as settable by the `OIIO::attribute()` call, `getattribute()`
 /// can also retrieve the following read-only attributes:
 ///
+/// - `string version`
+///
+///   The version designation of the OpenImageIO library, as a string.
+///
 /// - `string format_list`
 /// - `string input_format_list`
 /// - `string output_format_list`

--- a/src/include/OpenImageIO/oiioversion.h.in
+++ b/src/include/OpenImageIO/oiioversion.h.in
@@ -82,6 +82,12 @@
                              OIIO_VERSION_TWEAK, OIIO_VERSION_RELEASE_TYPE)
 #define OIIO_INTRO_STRING "OpenImageIO " OIIO_VERSION_STRING " http://www.openimageio.org"
 
+// Only major.minor.patch.tweak, omit any release type
+#define OIIO_VERSION_STRING_MMPT \
+    OIIO_MAKE_VERSION_STRING(OIIO_VERSION_MAJOR, \
+                             OIIO_VERSION_MINOR, OIIO_VERSION_PATCH, \
+                             OIIO_VERSION_TWEAK, "")
+
 
 // Establish the name spaces
 namespace @PROJ_NAMESPACE_V@ { }

--- a/src/iv/ivmain.cpp
+++ b/src/iv/ivmain.cpp
@@ -39,7 +39,8 @@ getargs(int argc, char* argv[])
     // clang-format off
     ap.intro("iv -- image viewer\n"
              OIIO_INTRO_STRING)
-      .usage("iv [options] [filename...]");
+      .usage("iv [options] [filename...]")
+      .add_version(OIIO_VERSION_STRING);
 
     ap.arg("filename")
       .action(ArgParse::append())

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -366,6 +366,10 @@ getattribute(string_view name, TypeDesc type, void* val)
         *(int*)val = oiio_threads;
         return true;
     }
+    if (name == "version" && type == TypeString) {
+        *(ustring*)val = ustring(OIIO_VERSION_STRING);
+        return true;
+    }
     spin_lock lock(attrib_mutex);
     if (name == "read_chunk" && type == TypeInt) {
         *(int*)val = oiio_read_chunk;

--- a/src/libutil/argparse.cpp
+++ b/src/libutil/argparse.cpp
@@ -145,6 +145,7 @@ public:
     callback_t m_preoption_help  = [](const ArgParse&, std::ostream&) {};
     callback_t m_postoption_help = [](const ArgParse&, std::ostream&) {};
     ParamValueList m_params;
+    std::string m_version;
 
     Impl(ArgParse& parent, int argc, const char** argv)
         : m_argparse(parent)
@@ -444,6 +445,22 @@ ArgParse::Impl::parse_args(int xargc, const char** xargv)
     m_argc    = xargc;
     m_argv    = xargv;
     m_running = true;
+
+    // Add version option if requested
+    if (m_version.size() && !find_option("--version")) {
+        m_option.emplace(m_option.begin(),
+                         new ArgOption(m_argparse, "--version"));
+        m_option[0]->m_help   = "Print version and exit";
+        m_option[0]->m_action = [&](Arg& arg, cspan<const char*> myarg) {
+            Strutil::print("{}\n", m_version);
+            if (m_exit_on_error)
+                exit(EXIT_SUCCESS);
+            else {
+                m_argparse.abort();
+            }
+        };
+        m_option[0]->initialize();
+    }
 
     // Add help option if requested
     if (m_add_help && !find_option("--help")) {
@@ -934,6 +951,15 @@ ArgParse&
 ArgParse::add_help(bool add_help)
 {
     m_impl->m_add_help = add_help;
+    return *this;
+}
+
+
+
+ArgParse&
+ArgParse::add_version(string_view version)
+{
+    m_impl->m_version = version;
     return *this;
 }
 

--- a/src/maketx/maketx.cpp
+++ b/src/maketx/maketx.cpp
@@ -194,8 +194,9 @@ getargs(int argc, char* argv[], ImageSpec& configspec)
     // clang-format off
     ArgParse ap;
     ap.intro("maketx -- convert images to tiled, MIP-mapped textures\n"
-             OIIO_INTRO_STRING);
-    ap.usage("maketx [options] file...");
+             OIIO_INTRO_STRING)
+      .usage("maketx [options] file...")
+      .add_version(OIIO_VERSION_STRING);
 
     ap.arg("filename")
       .hidden()

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -5988,6 +5988,12 @@ Oiiotool::getargs(int argc, char* argv[])
     ap.separator("Options (general flags):");
     ap.arg("--help", &help)
       .help("Print help message");
+    ap.arg("--version")
+      .help("Print version")
+      .action([](cspan<const char*>){
+            Strutil::print("{}\n", OIIO_VERSION_STRING);
+            ot.printed_info = true;
+        });
     ap.arg("-v", &ot.verbose)
       .help("Verbose status messages");
     ap.arg("-q %!", &ot.verbose)


### PR DESCRIPTION
* ArgParse::add_version(str) tells ArgParse the version string, and
  automatically adds an option --version that prints the version string
  and exits.

* Add this to oiiotool, iinfo, igrep, iv, maketx.

* OIIO::getattribute("version") retrieves the version string.

