### PR TITLE
Added checks in PNG_pvt::write_info (fix SEGFAULT after "PCS illuminant is not D50" libpng error)

### DIFF
--- a/src/png.imageio/pngoutput.cpp
+++ b/src/png.imageio/pngoutput.cpp
@@ -197,8 +197,14 @@ PNGOutput::open(const std::string& name, const ImageSpec& userspec,
     png_set_option(m_png, PNG_SKIP_sRGB_CHECK_PROFILE, PNG_OPTION_ON);
 #endif
 
-    PNG_pvt::write_info(m_png, m_info, m_color_type, m_spec, m_pngtext,
-                        m_convert_alpha, m_gamma);
+    s = PNG_pvt::write_info(m_png, m_info, m_color_type, m_spec, m_pngtext,
+                            m_convert_alpha, m_gamma);
+
+    if (s.length()) {
+        close();
+        errorfmt("{}", s);
+        return false;
+    }
 
     m_dither = (m_spec.format == TypeDesc::UINT8)
                    ? m_spec.get_int_attribute("oiio:dither", 0)


### PR DESCRIPTION
## Description

My change consist of additional `setjmp()` that catch errors on each step of PNG metadata writing to generate an accurate error message and avoid a `longjmp()` that lead to undefined behaviors and the following buggy behavior.

### The bug
A project of mine read images and write a resized version back in PNG reusing the `OIIO::ImageSpec` of the loaded image. The image below (https://www.furaffinity.net/view/31141327/) have an ICC profile that libpng dislike and it generates an error in [`png_set_iCCP` called from `PNG_pvt::write_info`](https://github.com/OpenImageIO/oiio/blob/a14523e9b754beb8e4a71e466791b429f6f3d233/src/png.imageio/png_pvt.h#L597) that perform a `longjmp()` inside the [previous call of `PNG_pvt::create_write_struct`](https://github.com/OpenImageIO/oiio/blob/a14523e9b754beb8e4a71e466791b429f6f3d233/src/png.imageio/png_pvt.h#L464) that result in a SEGFAULT. 
!["Acidity" by Alnix](https://d.furaffinity.net/art/alnix/1554932404/1554932404.alnix_apple_causticwyvernfinal2rowres.jpg)

I can reproduce the bug with `oiiotool` : 

```sh
curl 'https://d.furaffinity.net/art/alnix/1554932404/1554932404.alnix_apple_causticwyvernfinal2rowres.jpg' -o '/tmp/segfaulting-icc.jpg'
oiiotool -i '/tmp/segfaulting-icc.jpg' -o '/tmp/segfaulting-icc.png' # <-- Crash with the following output:
```
Output before my fix:
```
libpng error: profile 'Embedded Profile': 0h: PCS illuminant is not D50
 0# OpenImageIO_v2_3::Sysutil::stacktrace[abi:cxx11]() in /usr/lib/libOpenImageIO_Util.so.2.3
 1# 0x00007F6E4D94D031 in /usr/lib/libOpenImageIO_Util.so.2.3
 2# 0x00007F6E4D3A2A40 in /usr/lib/libc.so.6
 3# 0x00007F6E4E713A92 in /usr/lib/libOpenImageIO.so.2.3
 4# 0x00007F6E4E61ADE4 in /usr/lib/libOpenImageIO.so.2.3
 5# OpenImageIO_v2_3::PNGOutput::open(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, OpenImageIO_v2_3::ImageSpec const&, OpenImageIO_v2_3::ImageOutput::OpenMode) in /usr/lib/libOpenImageIO.so.2.3
 0# OpenImageIO_v2_3::Sysutil::stacktrace[abi:cxx11]() in /usr/lib/libOpenImageIO_Util.so.2.3
 1# 0x00007F6E4D94D031 in /usr/lib/libOpenImageIO_Util.so.2.3
 2# 0x00007F6E4D3A2A40 in /usr/lib/libc.so.6
 3# 0x00007F6E4D3F24DC in /usr/lib/libc.so.6
 4# gsignal in /usr/lib/libc.so.6
 5# 0x00007F6E4D3A2A40 in /usr/lib/libc.so.6
 6# 0x00007F6E4E713A92 in /usr/lib/libOpenImageIO.so.2.3
 7# 0x00007F6E4E61ADE4 in /usr/lib/libOpenImageIO.so.2.3
 8# OpenImageIO_v2_3::PNGOutput::open(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, OpenImageIO_v2_3::ImageSpec const&, OpenImageIO_v2_3::ImageOutput::OpenMode) in /usr/lib/libOpenImageIO.so.2.3
Abandon (core dumped)
```
Output after my fix:
```
libpng error: profile 'Embedded Profile': 0h: PCS illuminant is not D50
libpng error: No IDATs written into file
oiiotool ERROR: -o : PNG write error: profile 'Embedded Profile': 0h: PCS illuminant is not D50
PNG write error: No IDATs written into file
Could not set PNG iCCP chunk
Full command line was:
> oiiotool -i '/tmp/segfaulting-icc.jpg' -o '/tmp/segfaulting-icc.png'
```

## Tests

My changes **did not** changed tests or tests results on my system (ArchLinux with `-DUSE_OPENVBD=0` because of build errors already on master).

## Checklist:
- [x] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-CORPORATE)).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

