### PR TITLE
Fix heap overflow in DDS input

### DIFF
--- a/src/dds.imageio/ddsinput.cpp
+++ b/src/dds.imageio/ddsinput.cpp
@@ -682,8 +682,9 @@ DDSInput::internal_readimg(unsigned char* dst, int w, int h, int d)
                     return false;
                 size_t k = (z * h * w + y * w) * m_spec.nchannels;
                 for (int x = 0; x < w; x++, k += m_spec.nchannels) {
-                    uint32_t pixel;
-                    memcpy(&pixel, tmp.data() + x * m_Bpp, 4);
+                    uint32_t pixel = 0;
+                    OIIO_DASSERT(tmp.size() >= size_t(x * m_Bpp + m_Bpp));
+                    memcpy(&pixel, tmp.data() + x * m_Bpp, m_Bpp);
                     dst[k + 0] = ((pixel & m_dds.fmt.rmask) >> m_redR)
                                  << m_redL;
                     dst[k + 1] = ((pixel & m_dds.fmt.gmask) >> m_greenR)


### PR DESCRIPTION
Reading uncompressed scanlines would copy 4 bytes from each pixel into
an int and then decode the bits, incrementing where it was reading
from by Bpp bytes each time.  But when Bpp == 3, the last pixel of
every row would therefore read an extra byte past the end of the heap
storage. Allocation padding would in practice keep it from crashing,
and that meaningless extra byte was not used in the decode because it
knew it only needed the first 3 of the integer. But found by address
sanitizer!
