### PR TITLE
PNG fixes

### DIFF
--- a/src/cmake/testing.cmake
+++ b/src/cmake/testing.cmake
@@ -287,7 +287,7 @@ macro (oiio_add_all_tests)
     endif ()
     oiio_add_tests (openvdb texture-texture3d
                     FOUNDVAR OpenVDB_FOUND ENABLEVAR ENABLE_OpenVDB)
-    oiio_add_tests (png
+    oiio_add_tests (png png-damaged
                     ENABLEVAR ENABLE_PNG
                     IMAGEDIR oiio-images)
     oiio_add_tests (pnm

--- a/src/ico.imageio/icooutput.cpp
+++ b/src/ico.imageio/icooutput.cpp
@@ -419,7 +419,11 @@ ICOOutput::close()
     }
 
     if (m_png) {
-        PNG_pvt::finish_image(m_png, m_info);
+        PNG_pvt::write_end(m_png, m_info);
+        if (m_png || m_info)
+            PNG_pvt::destroy_write_struct(m_png, m_info);
+        m_png  = nullptr;
+        m_info = nullptr;
     }
     fclose(m_file);
     m_file = NULL;

--- a/src/png.imageio/png_pvt.h
+++ b/src/png.imageio/png_pvt.h
@@ -266,27 +266,22 @@ read_info(png_structp& sp, png_infop& ip, int& bit_depth, int& color_type,
 
     png_textp text_ptr;
     int num_comments = png_get_text(sp, ip, &text_ptr, NULL);
-    if (num_comments) {
-        std::string comments;
-        for (int i = 0; i < num_comments; ++i) {
-            if (Strutil::iequals(text_ptr[i].key, "Description"))
-                spec.attribute("ImageDescription", text_ptr[i].text);
-            else if (Strutil::iequals(text_ptr[i].key, "Author"))
-                spec.attribute("Artist", text_ptr[i].text);
-            else if (Strutil::iequals(text_ptr[i].key, "Title"))
-                spec.attribute("DocumentName", text_ptr[i].text);
-            else if (Strutil::iequals(text_ptr[i].key, "XML:com.adobe.xmp"))
-                decode_xmp(text_ptr[i].text, spec);
-            else if (Strutil::iequals(text_ptr[i].key,
-                                      "Raw profile type exif")) {
-                // Most PNG files seem to encode Exif by cramming it into a
-                // text field, with the key "Raw profile type exif" and then
-                // a special text encoding that we handle with the following
-                // function:
-                decode_png_text_exif(text_ptr[i].text, spec);
-            } else {
-                spec.attribute(text_ptr[i].key, text_ptr[i].text);
-            }
+    for (int i = 0; i < num_comments; ++i) {
+        if (Strutil::iequals(text_ptr[i].key, "Description"))
+            spec.attribute("ImageDescription", text_ptr[i].text);
+        else if (Strutil::iequals(text_ptr[i].key, "Author"))
+            spec.attribute("Artist", text_ptr[i].text);
+        else if (Strutil::iequals(text_ptr[i].key, "Title"))
+            spec.attribute("DocumentName", text_ptr[i].text);
+        else if (Strutil::iequals(text_ptr[i].key, "XML:com.adobe.xmp"))
+            decode_xmp(text_ptr[i].text, spec);
+        else if (Strutil::iequals(text_ptr[i].key, "Raw profile type exif")) {
+            // Most PNG files seem to encode Exif by cramming it into a text
+            // field, with the key "Raw profile type exif" and then a special
+            // text encoding that we handle with the following function:
+            decode_png_text_exif(text_ptr[i].text, spec);
+        } else {
+            spec.attribute(text_ptr[i].key, text_ptr[i].text);
         }
     }
     spec.x = png_get_x_offset_pixels(sp, ip);
@@ -709,20 +704,27 @@ write_row(png_structp& sp, png_byte* data)
 
 
 
-/// Helper function - finalizes writing the image and destroy the write
-/// struct.
+/// Helper function - error-catching wrapper for png_write_end
 inline void
-finish_image(png_structp& sp, png_infop& ip)
+write_end(png_structp& sp, png_infop& ip)
 {
     // Must call this setjmp in every function that does PNG writes
     if (setjmp(png_jmpbuf(sp))) {  // NOLINT(cert-err52-cpp)
-        //error ("PNG library error");
         return;
     }
     png_write_end(sp, ip);
+}
+
+
+/// Helper function - error-catching wrapper for png_destroy_write_struct
+inline void
+destroy_write_struct(png_structp& sp, png_infop& ip)
+{
+    // Must call this setjmp in every function that does PNG writes
+    if (setjmp(png_jmpbuf(sp))) {  // NOLINT(cert-err52-cpp)
+        return;
+    }
     png_destroy_write_struct(&sp, &ip);
-    sp = nullptr;
-    ip = nullptr;
 }
 
 

--- a/src/png.imageio/pngoutput.cpp
+++ b/src/png.imageio/pngoutput.cpp
@@ -241,7 +241,11 @@ PNGOutput::close()
     }
 
     if (m_png) {
-        PNG_pvt::finish_image(m_png, m_info);
+        PNG_pvt::write_end(m_png, m_info);
+        if (m_png || m_info)
+            PNG_pvt::destroy_write_struct(m_png, m_info);
+        m_png  = nullptr;
+        m_info = nullptr;
     }
 
     init();  // re-initialize

--- a/testsuite/png-damaged/ref/out.txt
+++ b/testsuite/png-damaged/ref/out.txt
@@ -1,0 +1,11 @@
+libpng error: IDAT: Read error: hit end of file
+iconvert ERROR copying "../oiio-images/png/broken/invalid_gray_alpha_sbit.png" to "invalid_gray_alpha_sbit.png" :
+	Read error: hit end of file
+PNG read error: IDAT: Read error: hit end of file
+libpng error: No IDATs written into file
+Comparing "../oiio-images/png/broken/invalid_gray_alpha_sbit.png" and "invalid_gray_alpha_sbit.png"
+libpng error: tEXt: Read error: hit end of file
+libpng error: tEXt: Read error: hit end of file
+idiff ERROR: Could not read invalid_gray_alpha_sbit.png:
+	Invalid image file "invalid_gray_alpha_sbit.png": Read error: hit end of file
+PNG read error: tEXt: Read error: hit end of file

--- a/testsuite/png-damaged/run.py
+++ b/testsuite/png-damaged/run.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+
+# save the error output
+redirect = " >> out.txt 2>&1 "
+failureok = 1
+
+command += rw_command (OIIO_TESTSUITE_IMAGEDIR + "/png/broken",
+                       "invalid_gray_alpha_sbit.png",
+                       printinfo=False)

--- a/testsuite/png/ref/out.txt
+++ b/testsuite/png/ref/out.txt
@@ -22,14 +22,3 @@ Reading ../oiio-images/oiio-logo-with-alpha.png
     oiio:ColorSpace: "sRGB"
 Comparing "../oiio-images/oiio-logo-with-alpha.png" and "oiio-logo-with-alpha.png"
 PASS
-libpng error: IDAT: Read error: hit end of file
-iconvert ERROR copying "../oiio-images/png/broken/invalid_gray_alpha_sbit.png" to "invalid_gray_alpha_sbit.png" :
-	Read error: hit end of file
-PNG read error: IDAT: Read error: hit end of file
-libpng error: No IDATs written into file
-Comparing "../oiio-images/png/broken/invalid_gray_alpha_sbit.png" and "invalid_gray_alpha_sbit.png"
-libpng error: tEXt: Read error: hit end of file
-libpng error: tEXt: Read error: hit end of file
-idiff ERROR: Could not read invalid_gray_alpha_sbit.png:
-	Invalid image file "invalid_gray_alpha_sbit.png": Read error: hit end of file
-PNG read error: tEXt: Read error: hit end of file

--- a/testsuite/png/run.py
+++ b/testsuite/png/run.py
@@ -2,12 +2,7 @@
 
 # save the error output
 redirect = " >> out.txt 2>&1 "
-failureok = 1
 
 files = [ "oiio-logo-no-alpha.png",  "oiio-logo-with-alpha.png" ]
 for f in files:
         command += rw_command (OIIO_TESTSUITE_IMAGEDIR,  f)
-
-command += rw_command (OIIO_TESTSUITE_IMAGEDIR + "/png/broken",
-                       "invalid_gray_alpha_sbit.png",
-                       printinfo=False)


### PR DESCRIPTION
* Minor png refactoring to fix some memory leaks for broken png files.

* Remove unused string variable from read_info() and simplify the
  surrounding "if"

* Split png test into png and png-damaged, because I just can't seem
  to squash some very minor memory leaks for broken png files, I think
  it's not worth worrying about and I'll just exclude the broken case
  from testing for the address sanitizer.

