### PR TITLE
Build: Make the version number be a cmake cache variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,9 @@
 # https://github.com/OpenImageIO/oiio
 
 cmake_minimum_required (VERSION 3.12)
-project (OpenImageIO VERSION 2.5.0.0
+
+set (OpenImageIO_VERSION "2.5.0.0" CACHE STRING "Version")
+project (OpenImageIO VERSION ${OpenImageIO_VERSION}
          HOMEPAGE_URL "https://openimageio.org"
          LANGUAGES CXX C)
 set (PROJ_NAME OIIO)    # short name, caps


### PR DESCRIPTION
Rather than specify the version in the usual project() statement,

    project (OpenImageIO VERSION 2.5.0.0 ...)

this patch decouples it

    set (OpenImageIO_VERSION "2.5.0.0" CACHE STRING "Version")
    project (OpenImageIO VERSION ${OpenImageIO_VERSION} ...)

thus allowing the possibility of overriding the version number at build confuguration time (`cmake -DOpenImageIO_VERSION=3.1.4.1`).

This should be used with extreme caution. Probably never used by most people. I don't need to describe all the ways that things can go sideways if you make your build of x.y.z.w actually be arbitrarily different from the x.y.z.w that everyone else uses and that is documented.

That said, there are two scenarios I have in mind for which this ability is very useful:

1. Sometimes, we add or deprecate API features "in advance" by having an `#if` enable or disable code based on the version, essentially putting in place changes that can't be enabled yet because they would break compatibility rules, but we want to integrate the code now and have it become active upon reaching a particular future version in which that incompatibility will be allowed. The version number override makes it easy to test this by quickly doing a build "as if" we had already bumped the version number to see what will happen when we actually do.

2. Every once in a while we need to do an internal build that, to conform to version compatibility rules, needs to appear to still be part of a past version family. This lets individual sites play some games with version number overrides rather than have to create new branches and tags for certain one-off internal releases.
