### PR TITLE
cmake: Add library dependencies in Config.cmake.in when building static libs

### DIFF
--- a/src/cmake/Config.cmake.in
+++ b/src/cmake/Config.cmake.in
@@ -17,6 +17,19 @@ if (NOT @OPENIMAGEIO_CONFIG_DO_NOT_FIND_IMATH@ AND NOT OPENIMAGEIO_CONFIG_DO_NOT
     endif ()
 endif ()
 
+if (NOT @BUILD_SHARED_LIBS@)
+    # This is required in static library builds, as e.g. PNG::PNG appears among
+    # INTERFACE_LINK_LIBRARIES. If the project does not know about PNG target, it will cause
+    # configuration error about unknown targets being linked in.
+    find_dependency(TIFF)
+    if (@JPEG_FOUND@)
+        find_dependency(JPEG)
+    endif()
+    if (@PNG_FOUND@)
+        find_dependency(PNG)
+    endif()
+endif ()
+
 # Compute the installation prefix relative to this file. Note that cmake files are installed
 # to ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME} (see OIIO_CONFIG_INSTALL_DIR)
 get_filename_component(_CURR_INSTALL_LIBDIR "${CMAKE_CURRENT_LIST_DIR}/../../" ABSOLUTE)


### PR DESCRIPTION
This fixes builds in projects that compile OpenImageIO as static libraries and don't themselves depend on the image libraries used by OpenImageIO such as PNG, JPEG or TIFF.

When OpenImageIO is built as a static library its targets have e.g. PNG::PNG among INTERFACE_LINK_LIBRARIES. If the including project does not itself depend on PNG, the following error would be observed:

```
Target "<...>" links to target "PNG::PNG" but the target was not found.
Perhaps a find_package() call is missing for an IMPORTED target, 
or an ALIAS target is missing?
```

## Checklist:

- [x] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-CORPORATE)).
- [not needed] I have updated the documentation, if applicable.
- [not needed] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

