### PR TITLE
Extract metadata from embedded ICC profiles.

### DIFF
--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -929,7 +929,8 @@ anywhere near the acceptance of the original JPEG/JFIF format.
        meaning lossless.
    * - ``ICCProfile``
      - uint8[]
-     - The ICC color profile
+     - The ICC color profile. A variety of other ``ICCProfile:*`` attributes
+       may also be present, extracted from the main profile.
    * - ``jpeg:subsampling``
      - string
      - Describes the chroma subsampling, e.g., ``"4:2:0"`` (the default),
@@ -1039,7 +1040,8 @@ metadata robustly.
      - Color space (see Section :ref:`sec-metadata-color`).
    * - ``ICCProfile``
      - uint8[]
-     - The ICC color profile
+     - The ICC color profile. A variety of other ``ICCProfile:*`` attributes
+       may also be present, extracted from the main profile.
 
 
 **Configuration settings for JPEG-2000 input**
@@ -1474,7 +1476,8 @@ files use the file extension :file:`.png`.
      - the gamma correction value (if specified).
    * - ``ICCProfile``
      - uint8[]
-     - The ICC color profile
+     - The ICC color profile. A variety of other ``ICCProfile:*`` attributes
+       may also be present, extracted from the main profile.
 
 **Configuration settings for PNG input**
 
@@ -1660,6 +1663,20 @@ PSD is the file format used for storing Adobe PhotoShop images. OpenImageIO
 provides limited read abilities for PSD, but not currently the ability to
 write PSD files.
 
+**Attributes**
+
+.. list-table::
+   :widths: 30 10 65
+   :header-rows: 1
+
+   * - ImageSpec Attribute
+     - Type
+     - JPEG header data or explanation
+   * - ``ICCProfile``
+     - uint8[]
+     - The ICC color profile. A variety of other ``ICCProfile:*`` attributes
+       may also be present, extracted from the main profile.
+
 **Configuration settings for PSD input**
 
 When opening an ImageInput with a *configuration* (see
@@ -1678,6 +1695,11 @@ options are supported:
      - If nonzero, reading images with non-RGB color models (such as YCbCr
        or CMYK) will return unaltered pixel values (versus the default OIIO
        behavior of automatically converting to RGB).
+   * - ``oiio:UnassociatedAlpha``
+     - int
+     - If nonzero, will leave alpha unassociated (versus the default of
+       premultiplying color channels by alpha if the alpha channel is
+       unassociated).
    * - ``oiio:ioproxy``
      - ptr
      - Pointer to a ``Filesystem::IOProxy`` that will handle the I/O, for
@@ -2495,7 +2517,8 @@ aware of:
      - Orientation
    * - ``ICCProfile``
      - uint8[]
-     - The ICC color profile
+     - The ICC color profile. A variety of other ``ICCProfile:*`` attributes
+       may also be present, extracted from the main profile.
    * - ``textureformat``
      - string
      - PIXAR_TEXTUREFORMAT

--- a/src/doc/stdmetadata.rst
+++ b/src/doc/stdmetadata.rst
@@ -163,9 +163,19 @@ Color information
     the default is black (0 in all channels).
 
 .. option:: "ICCProfile" : uint8[]
+            "ICCProfile:...various..." : ...various types...
 
-    The ICC color profile takes the form of an array of bytes (unsigned 8
-    bit chars). The length of the array is the length of the profile blob.
+    The ICC color profile takes the form of an array of bytes (unsigned 8 bit
+    chars) whose contents and format is as dictated by the ICC specification.
+    The length of the array is the length of the profile blob.
+
+    When reading images containing ICC profiles, there may be a number of
+    other attributes extracted from the ICC profile (such as
+    `ICCProfile:device_class`). These are for informational convenience only,
+    as they replicate information which is also in the ICCProfile byte array.
+    Be aware that *setting* these attributes will not result in modifying the
+    ICC profile byte array (`"ICCProfile"`), which is considered the sole
+    piece of durable ICC profile information.
 
 
 

--- a/src/include/OpenImageIO/tiffutils.h
+++ b/src/include/OpenImageIO/tiffutils.h
@@ -218,6 +218,16 @@ OIIO_API bool decode_xmp (const std::string& xml, ImageSpec &spec);
 OIIO_API std::string encode_xmp (const ImageSpec &spec, bool minimal=false);
 
 
+/// Add metadata to spec based on ICC data in a byte array.  Return true if
+/// all is ok, false if the ICC was somehow malformed (and in that case, set
+/// the contents of `error` to something useful).  This is a utility function
+/// to make it easy for multiple format plugins to support embedding ICC
+/// metadata without having to duplicate functionality within each plugin.
+OIIO_API bool decode_icc_profile(cspan<uint8_t> iccdata, ImageSpec& spec,
+                                 std::string& error);
+
+
+
 /// Handy structure to hold information mapping TIFF/EXIF tags to their
 /// names and actions.
 struct TagInfo {

--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -57,7 +57,8 @@ set (libOpenImageIO_srcs
                           imagebufalgo_xform.cpp
                           imagebufalgo_yee.cpp imagebufalgo_opencv.cpp
                           deepdata.cpp exif.cpp exif-canon.cpp
-                          formatspec.cpp imagebuf.cpp
+                          formatspec.cpp
+                          icc.cpp imagebuf.cpp
                           imageinput.cpp imageio.cpp imageioplugin.cpp
                           imageoutput.cpp
                           iptc.cpp xmp.cpp

--- a/src/libOpenImageIO/icc.cpp
+++ b/src/libOpenImageIO/icc.cpp
@@ -1,0 +1,350 @@
+// Copyright 2008-present Contributors to the OpenImageIO project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/OpenImageIO/oiio
+
+
+#include <string>
+#include <unordered_map>
+
+#include <OpenImageIO/fmath.h>
+#include <OpenImageIO/imageio.h>
+#include <OpenImageIO/platform.h>
+#include <OpenImageIO/tiffutils.h>
+
+OIIO_NAMESPACE_BEGIN
+
+using namespace pvt;
+
+
+namespace {
+
+struct ICCDateTime {
+    uint16_t year;
+    uint16_t month;
+    uint16_t day;
+    uint16_t hours;
+    uint16_t minutes;
+    uint16_t seconds;
+
+    void swap_endian()
+    {
+        if (littleendian()) {
+            OIIO::swap_endian(&year);
+            OIIO::swap_endian(&month);
+            OIIO::swap_endian(&day);
+            OIIO::swap_endian(&hours);
+            OIIO::swap_endian(&minutes);
+            OIIO::swap_endian(&seconds);
+        }
+    }
+};
+
+static_assert(sizeof(ICCDateTime) == 12, "ICCDateTime is not 12 bytes");
+
+
+
+// In-memory representation of an ICC profile
+struct ICCHeader {
+    uint32_t profile_size;
+    uint32_t cmm_type;
+    uint8_t profile_version[4];  // major, (minor << 4 + patch), then unused
+    char device_class[4];
+    char color_space[4];
+    char pcs[4];  // profile connection space
+    ICCDateTime creation_date;
+    uint32_t magic;  // should be 'acsp' or 0x61637370
+    char platform_signature[4];
+    uint32_t flags;
+    uint32_t manufacturer;
+    uint32_t model;
+    uint32_t attributes[2];
+    uint32_t rendering_intent;
+    unsigned char illuminant[12];  // XYZNumber
+    uint32_t creator_signature;
+    unsigned char profile_id[16];
+    unsigned char reserved[28];
+
+    void swap_endian()
+    {
+        if (littleendian()) {
+            OIIO::swap_endian(&profile_size);
+            OIIO::swap_endian(&cmm_type);
+            OIIO::swap_endian(&magic);
+            creation_date.swap_endian();
+            OIIO::swap_endian(&flags);
+            OIIO::swap_endian(&manufacturer);
+            OIIO::swap_endian(&model);
+            OIIO::swap_endian(&attributes[0]);
+            OIIO::swap_endian(&attributes[1]);
+            OIIO::swap_endian(&rendering_intent);
+            OIIO::swap_endian(&creator_signature);
+        }
+    }
+};
+
+static_assert(sizeof(ICCHeader) == 128, "ICCHeader is not 128 bytes");
+
+
+
+struct ICCTag {
+    char signature[4];
+    uint32_t offset;
+    uint32_t size;
+
+    void swap_endian()
+    {
+        if (littleendian()) {
+            OIIO::swap_endian(&offset);
+            OIIO::swap_endian(&size);
+        }
+    }
+};
+
+
+
+static const char*
+icc_device_class_name(const std::string& device_class)
+{
+    static std::unordered_map<std::string, const char*> device_class_names = {
+        { "scnr", "Input device profile" },
+        { "mntr", "Display device profile" },
+        { "prtr", "Output device profile" },
+        { "link", "DeviceLink profile" },
+        { "spac", "ColorSpace profile" },
+        { "abst", "Abstract profile" },
+        { "nmcl", "NamedColor profile" },
+    };
+    return device_class_names[device_class];
+}
+
+static const char*
+icc_color_space_name(string_view color_space)
+{
+    static std::unordered_map<std::string, const char*> color_space_names = {
+        { "XYZ ", "XYZ" },      { "Lab ", "CIELAB" },   { "Luv ", "CIELUV" },
+        { "YCbr", "YCbCr" },    { "Yxy ", "CIEYxy" },   { "RGB ", "RGB" },
+        { "GRAY", "Gray" },     { "HSV ", "HSV" },      { "HLS ", "HLS" },
+        { "CMYK", "CMYK" },     { "CMY ", "CMY" },      { "2CLR", "2 color" },
+        { "3CLR", "3 color" },  { "4CLR", "4 color" },  { "5CLR", "5 color" },
+        { "6CLR", "6 color" },  { "7CLR", "7 color" },  { "8CLR", "8 color" },
+        { "9CLR", "9 color" },  { "ACLR", "10 color" }, { "BCLR", "11 color" },
+        { "BCLR", "12 color" }, { "CCLR", "13 color" }, { "DCLR", "14 color" },
+        { "ECLR", "15 color" }, { "FCLR", "16 color" },
+    };
+    return color_space_names[color_space];
+}
+
+static const char*
+icc_primary_platform_name(const std::string& platform)
+{
+    static std::unordered_map<std::string, const char*> primary_platforms = {
+        { "APPL", "Apple Computer, Inc." },
+        { "MSFT", "Microsoft Corporation" },
+        { "SGI ", "Silicon Graphics, Inc." },
+        { "SUNW", "Sun Microsystems, Inc." },
+    };
+    return primary_platforms[platform];
+}
+
+static const char*
+icc_rendering_intent_name(uint32_t intent)
+{
+    static const char* rendering_intents[]
+        = { "Perceptual", "Media-relative colorimetric", "Saturation",
+            "ICC-absolute colorimetric" };
+    return intent < 4 ? rendering_intents[intent] : "Unknown";
+}
+
+static std::string
+icc_tag_name(const std::string& tag)
+{
+    static std::unordered_map<std::string, std::string> tagnames = {
+        { "targ", "characterization_target" },
+        { "cprt", "copyright" },
+        { "desc", "profile_description" },
+        { "dmdd", "device_model_description" },
+        { "dmnd", "device_manufacturer_description" },
+        { "vued", "viewing_conditions_description" },
+    };
+    return tagnames[tag];
+}
+
+
+
+template<typename T>
+bool
+extract(cspan<uint8_t> iccdata, size_t& offset, T& result, std::string& error)
+{
+    if (offset + sizeof(T) > std::size(iccdata)) {
+        error = "ICC profile too small";
+        return false;
+    }
+    result = *(const T*)(iccdata.data() + offset);
+    offset += sizeof(T);
+    if (littleendian())
+        swap_endian(&result);
+    return true;
+}
+
+template<>
+bool
+extract(cspan<uint8_t> iccdata, size_t& offset, ICCTag& result,
+        std::string& error)
+{
+    if (offset + sizeof(result) > std::size(iccdata)) {
+        error = "ICC profile too small";
+        return false;
+    }
+    result = *(const ICCTag*)(iccdata.data() + offset);
+    offset += sizeof(ICCTag);
+    if (littleendian())
+        result.swap_endian();
+    return true;
+}
+
+}  // namespace
+
+
+
+bool
+decode_icc_profile(cspan<uint8_t> iccdata, ImageSpec& spec, std::string& error)
+{
+    using Strutil::fmt::format;
+    if (std::size(iccdata) < sizeof(ICCHeader)) {
+        error = "ICC profile too small";
+        return false;
+    }
+    ICCHeader header = *(const ICCHeader*)iccdata.data();
+    header.swap_endian();
+    if (header.magic != 0x61637370) {
+        error = "ICC profile has bad magic number";
+        return false;
+    }
+    if (header.profile_size != iccdata.size()) {
+        error = "ICC profile size mismatch";
+        return false;
+    }
+
+    spec.attribute("ICCProfile:profile_size", header.profile_size);
+    spec.attribute("ICCProfile:cmm_type", header.cmm_type);
+    spec.attribute("ICCProfile:profile_version",
+                   format("{:d}.{:d}.{}", header.profile_version[0],
+                          header.profile_version[1] >> 4,
+                          header.profile_version[1] & 0xf));
+    spec.attribute("ICCProfile:device_class",
+                   icc_device_class_name(string_view(header.device_class, 4)));
+    spec.attribute("ICCProfile:color_space",
+                   icc_color_space_name(string_view(header.color_space, 4)));
+    spec.attribute("ICCProfile:profile_connection_space",
+                   icc_color_space_name(string_view(header.pcs, 4)));
+    spec.attribute("ICCProfile:platform_signature",
+                   icc_primary_platform_name(
+                       string_view(header.platform_signature, 4)));
+    spec.attribute("ICCProfile:creation_date",
+                   format("{:02d}:{:02d}:{:02d} {:02d}:{:02d}:{:02d}",
+                          header.creation_date.year, header.creation_date.month,
+                          header.creation_date.day, header.creation_date.hours,
+                          header.creation_date.minutes,
+                          header.creation_date.seconds));
+    spec.attribute("ICCProfile:flags",
+                   format("{}, {}",
+                          header.flags & 1 ? "Embedded " : "Not Embedded",
+                          header.flags & 2 ? "Dependent" : "Independent"));
+    spec.attribute("ICCProfile:manufacturer",
+                   format("{:x}", header.manufacturer));
+    spec.attribute("ICCProfile:model", format("{:x}", header.model));
+    spec.attribute("ICCProfile:attributes",
+                   format("{}, {}, {}, {}",
+                          header.attributes[1] & 1 ? "Transparency "
+                                                   : "Reflective",
+                          header.attributes[1] & 2 ? "Matte" : "Glossy",
+                          header.attributes[1] & 4 ? "Negative" : "Positive",
+                          header.attributes[1] & 8 ? "Black & White" : "Color"));
+    spec.attribute("ICCProfile:rendering_intent",
+                   icc_rendering_intent_name(header.rendering_intent));
+    // spec.attribute("ICCProfile:illuminant", header.illuminant);
+    spec.attribute("ICCProfile:creator_signature",
+                   format("{:x}", header.creator_signature));
+
+
+    size_t offset = 128;
+    uint32_t tag_count;
+    if (!extract(iccdata, offset, tag_count, error))
+        return false;
+    for (uint32_t i = 0; i < tag_count; ++i) {
+        ICCTag tag;
+        if (!extract(iccdata, offset, tag, error))
+            return false;
+        string_view signature(tag.signature, 4);
+        if (tag.offset + tag.size > iccdata.size()) {
+            error = format("ICC profile tag {} extends past end", signature);
+            return false;
+        }
+
+        string_view typesignature((const char*)iccdata.data() + tag.offset, 4);
+        // Strutil::print("   tag {} type {} offset {} size {}\n", signature,
+        //                typesignature, tag.offset, tag.size);
+        std::string tagname = icc_tag_name(signature);
+        if (tagname.empty())
+            tagname = signature;
+        tagname = format("ICCProfile:{}", tagname);
+        if (typesignature == "text") {
+            // For text, the first 4 bytes are "text", the next 4 are 0, then
+            // byte 8-end are the zero-terminated string itself.
+            spec.attribute(tagname, string_view((const char*)iccdata.data()
+                                                    + tag.offset + 8,
+                                                tag.size - 8));
+        } else if (typesignature == "desc") {
+            // I don't see this in the spec, but I've seen it in practice:
+            // first 4 bytes are "desc", next 8 are unknown, then 12-end are
+            // zero-terminated string itself.
+            spec.attribute(tagname, string_view((const char*)iccdata.data()
+                                                    + tag.offset + 12,
+                                                tag.size - 12));
+        } else if (typesignature == "mluc") {
+            // Multi-localized unicode text.  First 4 bytes are "mluc", next 4
+            // are 0, next 4 are the number of records, then 12-end are the
+            // 12-byte records which each consist of a 2-byte language code,
+            // 2-byte country code, 4-byte length of the string (in bytes) and
+            // 4-byte offset (from the tag start, not from the ICC start!) to
+            // a zero-terminated big endian utf-16 string. We're just going to
+            // grab the english language version for now.
+            size_t where = tag.offset + 4;  // we already read the "mluc"
+            where += 4;                     // skip zero bytes
+            uint32_t nrecords   = 0;
+            uint32_t recordsize = 0;
+            if (!extract(iccdata, where, nrecords, error)
+                || !extract(iccdata, where, recordsize, error)
+                || recordsize != 12) {
+                return false;
+            }
+            for (uint32_t r = 0; r < nrecords; ++r) {
+                uint16_t language = 0, country = 0;
+                uint32_t len = 0, stroffset = 0;
+                if (!extract(iccdata, where, language, error)
+                    || !extract(iccdata, where, country, error)
+                    || !extract(iccdata, where, len, error)
+                    || !extract(iccdata, where, stroffset, error)) {
+                    return false;
+                }
+                if (language == ('e' << 8) + 'n') {
+                    // English
+                    // Strutil::print(
+                    //     "eng len={} stfoffset={} ({:x}) wcharsize={}\n", len,
+                    //     stroffset, tag.offset + stroffset, sizeof(wchar_t));
+                    const char* start = (const char*)iccdata.data() + tag.offset
+                                        + stroffset;
+                    // The actual data is UTF-16
+                    std::u16string wstr((const char16_t*)start, len / 2);
+                    if (littleendian())
+                        swap_endian(wstr.data(), int(wstr.size()));
+                    spec.attribute(tagname, Strutil::utf16_to_utf8(wstr));
+                    break;
+                }
+            }
+        }
+    }
+    return true;
+}
+
+OIIO_NAMESPACE_END

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -988,6 +988,13 @@ OpenEXROutput::put_parameter(const std::string& name, TypeDesc type,
             return false;
     }
 
+    // The main "ICCProfile" byte array should translate, but the individual
+    // "ICCProfile:*" attributes are suppressed because they merely duplicate
+    // what's in the byte array.
+    if (Strutil::istarts_with(xname, "ICCProfile:")) {
+        return false;
+    }
+
     if (!xname.length())
         return false;  // Skip suppressed names
 

--- a/src/png.imageio/png_pvt.h
+++ b/src/png.imageio/png_pvt.h
@@ -249,10 +249,20 @@ read_info(png_structp& sp, png_infop& ip, int& bit_depth, int& color_type,
         int compression_type;
         png_get_iCCP(sp, ip, &profile_name, &compression_type, &profile_data,
                      &profile_length);
-        if (profile_length && profile_data)
-            spec.attribute(ICC_PROFILE_ATTR,
+        if (profile_length && profile_data) {
+            spec.attribute("ICCProfile",
                            TypeDesc(TypeDesc::UINT8, profile_length),
                            profile_data);
+            std::string errormsg;
+            bool ok = decode_icc_profile(
+                cspan<uint8_t>((const uint8_t*)profile_data, profile_length),
+                spec, errormsg);
+            if (!ok) {
+                // errorfmt("Could not decode ICC profile: {}\n", errormsg);
+                // return false;
+                // Nah, just skip an ICC specific error?
+            }
+        }
     }
 
     png_timep mod_time;

--- a/src/psd.imageio/psdinput.cpp
+++ b/src/psd.imageio/psdinput.cpp
@@ -1103,7 +1103,6 @@ bool PSDInput::load_resource_1005(uint32_t /*length*/)
         return false;
     }
     common_attribute("XResolution", resinfo.hRes);
-    common_attribute("XResolution", resinfo.hRes);
     common_attribute("YResolution", resinfo.vRes);
     switch (resinfo.hResUnit) {
     case ResolutionInfo::PixelsPerInch:
@@ -1167,12 +1166,15 @@ PSDInput::load_resource_1036(uint32_t length)
 bool
 PSDInput::load_resource_1039(uint32_t length)
 {
-    std::unique_ptr<char[]> icc_buf(new char[length]);
+    std::unique_ptr<uint8_t[]> icc_buf(new uint8_t[length]);
     if (!ioread(icc_buf.get(), length))
         return false;
 
     TypeDesc type(TypeDesc::UINT8, length);
     common_attribute("ICCProfile", type, icc_buf.get());
+    std::string errormsg;
+    decode_icc_profile(cspan<uint8_t>(icc_buf.get(), length), m_common_attribs,
+                       errormsg);
     return true;
 }
 

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -1179,11 +1179,15 @@ TIFFInput::readspec(bool read_meta)
 
     /// read color profile
     unsigned int icc_datasize = 0;
-    unsigned char* icc_buf    = NULL;
+    uint8_t* icc_buf          = NULL;
     TIFFGetField(m_tif, TIFFTAG_ICCPROFILE, &icc_datasize, &icc_buf);
-    if (icc_datasize && icc_buf)
+    if (icc_datasize && icc_buf) {
         m_spec.attribute(ICC_PROFILE_ATTR,
                          TypeDesc(TypeDesc::UINT8, icc_datasize), icc_buf);
+        std::string errormsg;
+        decode_icc_profile(cspan<uint8_t>(icc_buf, icc_datasize), m_spec,
+                           errormsg);
+    }
 
 #if TIFFLIB_VERSION > 20050912 /* compat with old TIFF libs - skip Exif */
     // Search for an EXIF IFD in the TIFF file, and if found, rummage

--- a/testsuite/jpeg2000-j2kp4files/ref/out-alt.txt
+++ b/testsuite/jpeg2000-j2kp4files/ref/out-alt.txt
@@ -34,6 +34,23 @@ Reading ../j2kp4files_v1_5/testfiles_jp2/file5.jp2
 ../j2kp4files_v1_5/testfiles_jp2/file5.jp2 :  768 x  512, 3 channel, uint8 jpeg2000
     SHA-1: FEF67669AB05A25F8A42455206B64C789CFCA38F
     channel list: R, G, B
+    ICCProfile: 0, 0, 2, 34, 0, 0, 0, 0, 2, 32, 0, 0, 115, 99, 110, 114, ... [546 x uint8]
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 0
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright 2001 EKC-RICC Reference"
+    ICCProfile:creation_date: "2001:08:30 13:32:37"
+    ICCProfile:creator_signature: "4a504547"
+    ICCProfile:device_class: "Input device profile"
+    ICCProfile:flags: "Embedded , Independent"
+    ICCProfile:manufacturer: "4b4f4441"
+    ICCProfile:model: "524f4d4d"
+    ICCProfile:platform_signature: ""
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "Restricted ICC profile describing ROMM-RGB"
+    ICCProfile:profile_size: 546
+    ICCProfile:profile_version: "2.2.0"
+    ICCProfile:rendering_intent: "Perceptual"
     oiio:BitsPerSample: 8
     oiio:ColorSpace: "sRGB"
 Comparing "../j2kp4files_v1_5/testfiles_jp2/file5.jp2" and "file5.jp2"
@@ -50,6 +67,25 @@ Reading ../j2kp4files_v1_5/testfiles_jp2/file7.jp2
 ../j2kp4files_v1_5/testfiles_jp2/file7.jp2 :  480 x  640, 3 channel, uint16 jpeg2000
     SHA-1: C1110501C2784B4AB29B98B2C6EC05C0C6C16F77
     channel list: R, G, B
+    ICCProfile: 0, 0, 52, 20, 65, 80, 80, 76, 2, 16, 0, 0, 115, 99, 110, 114, ... [13332 x uint8]
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1095782476
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 2001 Hewlett-Packard Company "
+    ICCProfile:creation_date: "2001:08:31 09:58:55"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Input device profile"
+    ICCProfile:device_manufacturer_description: "Hewlett-Packard"
+    ICCProfile:device_model_description: "16-bit e-sRGB JP2 restricted to sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "48502020"
+    ICCProfile:model: "65524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "16-bit e-sRGB JP2 restricted (to sRGB) profile"
+    ICCProfile:profile_size: 13332
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Perceptual"
     oiio:BitsPerSample: 16
     oiio:ColorSpace: "sRGB"
 Comparing "../j2kp4files_v1_5/testfiles_jp2/file7.jp2" and "file7.jp2"
@@ -58,6 +94,23 @@ Reading ../j2kp4files_v1_5/testfiles_jp2/file8.jp2
 ../j2kp4files_v1_5/testfiles_jp2/file8.jp2 :  700 x  400, 1 channel, uint8 jpeg2000
     SHA-1: 593D82DE9935FC3F7963CABAAD5ACB7F8134E39A
     channel list: Y
+    ICCProfile: 0, 0, 1, 158, 0, 0, 0, 0, 2, 32, 0, 0, 115, 99, 110, 114, ... [414 x uint8]
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 0
+    ICCProfile:color_space: "Gray"
+    ICCProfile:copyright: "Copyright 2001 EKC-RICC Reference"
+    ICCProfile:creation_date: "2002:01:23 09:26:16"
+    ICCProfile:creator_signature: "4a504547"
+    ICCProfile:device_class: "Input device profile"
+    ICCProfile:flags: "Embedded , Independent"
+    ICCProfile:manufacturer: "4b4f4441"
+    ICCProfile:model: "47524559"
+    ICCProfile:platform_signature: ""
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "Restricted ICC profile describing greyscale version of ROMM-RGB"
+    ICCProfile:profile_size: 414
+    ICCProfile:profile_version: "2.2.0"
+    ICCProfile:rendering_intent: "Perceptual"
     oiio:BitsPerSample: 8
     oiio:ColorSpace: "sRGB"
 Comparing "../j2kp4files_v1_5/testfiles_jp2/file8.jp2" and "file8.jp2"

--- a/testsuite/jpeg2000-j2kp4files/ref/out-spinux.txt
+++ b/testsuite/jpeg2000-j2kp4files/ref/out-spinux.txt
@@ -34,6 +34,23 @@ Reading ../j2kp4files_v1_5/testfiles_jp2/file5.jp2
 ../j2kp4files_v1_5/testfiles_jp2/file5.jp2 :  768 x  512, 3 channel, uint8 jpeg2000
     SHA-1: FEF67669AB05A25F8A42455206B64C789CFCA38F
     channel list: R, G, B
+    ICCProfile: 0, 0, 2, 34, 0, 0, 0, 0, 2, 32, 0, 0, 115, 99, 110, 114, ... [546 x uint8]
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 0
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright 2001 EKC-RICC Reference"
+    ICCProfile:creation_date: "2001:08:30 13:32:37"
+    ICCProfile:creator_signature: "4a504547"
+    ICCProfile:device_class: "Input device profile"
+    ICCProfile:flags: "Embedded , Independent"
+    ICCProfile:manufacturer: "4b4f4441"
+    ICCProfile:model: "524f4d4d"
+    ICCProfile:platform_signature: ""
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "Restricted ICC profile describing ROMM-RGB"
+    ICCProfile:profile_size: 546
+    ICCProfile:profile_version: "2.2.0"
+    ICCProfile:rendering_intent: "Perceptual"
     oiio:BitsPerSample: 8
     oiio:ColorSpace: "sRGB"
 Comparing "../j2kp4files_v1_5/testfiles_jp2/file5.jp2" and "file5.jp2"
@@ -50,6 +67,25 @@ Reading ../j2kp4files_v1_5/testfiles_jp2/file7.jp2
 ../j2kp4files_v1_5/testfiles_jp2/file7.jp2 :  480 x  640, 3 channel, uint16 jpeg2000
     SHA-1: C1110501C2784B4AB29B98B2C6EC05C0C6C16F77
     channel list: R, G, B
+    ICCProfile: 0, 0, 52, 20, 65, 80, 80, 76, 2, 16, 0, 0, 115, 99, 110, 114, ... [13332 x uint8]
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1095782476
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 2001 Hewlett-Packard Company "
+    ICCProfile:creation_date: "2001:08:31 09:58:55"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Input device profile"
+    ICCProfile:device_manufacturer_description: "Hewlett-Packard"
+    ICCProfile:device_model_description: "16-bit e-sRGB JP2 restricted to sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "48502020"
+    ICCProfile:model: "65524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "16-bit e-sRGB JP2 restricted (to sRGB) profile"
+    ICCProfile:profile_size: 13332
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Perceptual"
     oiio:BitsPerSample: 16
     oiio:ColorSpace: "sRGB"
 Comparing "../j2kp4files_v1_5/testfiles_jp2/file7.jp2" and "file7.jp2"
@@ -58,6 +94,23 @@ Reading ../j2kp4files_v1_5/testfiles_jp2/file8.jp2
 ../j2kp4files_v1_5/testfiles_jp2/file8.jp2 :  700 x  400, 1 channel, uint8 jpeg2000
     SHA-1: 593D82DE9935FC3F7963CABAAD5ACB7F8134E39A
     channel list: Y
+    ICCProfile: 0, 0, 1, 158, 0, 0, 0, 0, 2, 32, 0, 0, 115, 99, 110, 114, ... [414 x uint8]
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 0
+    ICCProfile:color_space: "Gray"
+    ICCProfile:copyright: "Copyright 2001 EKC-RICC Reference"
+    ICCProfile:creation_date: "2002:01:23 09:26:16"
+    ICCProfile:creator_signature: "4a504547"
+    ICCProfile:device_class: "Input device profile"
+    ICCProfile:flags: "Embedded , Independent"
+    ICCProfile:manufacturer: "4b4f4441"
+    ICCProfile:model: "47524559"
+    ICCProfile:platform_signature: ""
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "Restricted ICC profile describing greyscale version of ROMM-RGB"
+    ICCProfile:profile_size: 414
+    ICCProfile:profile_version: "2.2.0"
+    ICCProfile:rendering_intent: "Perceptual"
     oiio:BitsPerSample: 8
     oiio:ColorSpace: "sRGB"
 Comparing "../j2kp4files_v1_5/testfiles_jp2/file8.jp2" and "file8.jp2"

--- a/testsuite/jpeg2000-j2kp4files/ref/out.txt
+++ b/testsuite/jpeg2000-j2kp4files/ref/out.txt
@@ -35,6 +35,22 @@ Reading ../j2kp4files_v1_5/testfiles_jp2/file5.jp2
     SHA-1: FEF67669AB05A25F8A42455206B64C789CFCA38F
     channel list: R, G, B
     ICCProfile: 0, 0, 2, 34, 0, 0, 0, 0, 2, 32, 0, 0, 115, 99, 110, 114, ... [546 x uint8]
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 0
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright 2001 EKC-RICC Reference"
+    ICCProfile:creation_date: "2001:08:30 13:32:37"
+    ICCProfile:creator_signature: "4a504547"
+    ICCProfile:device_class: "Input device profile"
+    ICCProfile:flags: "Embedded , Independent"
+    ICCProfile:manufacturer: "4b4f4441"
+    ICCProfile:model: "524f4d4d"
+    ICCProfile:platform_signature: ""
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "Restricted ICC profile describing ROMM-RGB"
+    ICCProfile:profile_size: 546
+    ICCProfile:profile_version: "2.2.0"
+    ICCProfile:rendering_intent: "Perceptual"
     oiio:BitsPerSample: 8
     oiio:ColorSpace: "sRGB"
 Comparing "../j2kp4files_v1_5/testfiles_jp2/file5.jp2" and "file5.jp2"
@@ -52,6 +68,24 @@ Reading ../j2kp4files_v1_5/testfiles_jp2/file7.jp2
     SHA-1: C1110501C2784B4AB29B98B2C6EC05C0C6C16F77
     channel list: R, G, B
     ICCProfile: 0, 0, 52, 20, 65, 80, 80, 76, 2, 16, 0, 0, 115, 99, 110, 114, ... [13332 x uint8]
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1095782476
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 2001 Hewlett-Packard Company "
+    ICCProfile:creation_date: "2001:08:31 09:58:55"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Input device profile"
+    ICCProfile:device_manufacturer_description: "Hewlett-Packard"
+    ICCProfile:device_model_description: "16-bit e-sRGB JP2 restricted to sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "48502020"
+    ICCProfile:model: "65524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "16-bit e-sRGB JP2 restricted (to sRGB) profile"
+    ICCProfile:profile_size: 13332
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Perceptual"
     oiio:BitsPerSample: 16
     oiio:ColorSpace: "sRGB"
 Comparing "../j2kp4files_v1_5/testfiles_jp2/file7.jp2" and "file7.jp2"
@@ -61,6 +95,22 @@ Reading ../j2kp4files_v1_5/testfiles_jp2/file8.jp2
     SHA-1: 593D82DE9935FC3F7963CABAAD5ACB7F8134E39A
     channel list: Y
     ICCProfile: 0, 0, 1, 158, 0, 0, 0, 0, 2, 32, 0, 0, 115, 99, 110, 114, ... [414 x uint8]
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 0
+    ICCProfile:color_space: "Gray"
+    ICCProfile:copyright: "Copyright 2001 EKC-RICC Reference"
+    ICCProfile:creation_date: "2002:01:23 09:26:16"
+    ICCProfile:creator_signature: "4a504547"
+    ICCProfile:device_class: "Input device profile"
+    ICCProfile:flags: "Embedded , Independent"
+    ICCProfile:manufacturer: "4b4f4441"
+    ICCProfile:model: "47524559"
+    ICCProfile:platform_signature: ""
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "Restricted ICC profile describing greyscale version of ROMM-RGB"
+    ICCProfile:profile_size: 414
+    ICCProfile:profile_version: "2.2.0"
+    ICCProfile:rendering_intent: "Perceptual"
     oiio:BitsPerSample: 8
     oiio:ColorSpace: "sRGB"
 Comparing "../j2kp4files_v1_5/testfiles_jp2/file8.jp2" and "file8.jp2"

--- a/testsuite/oiiotool-attribs/ref/out-jpeg9d.txt
+++ b/testsuite/oiiotool-attribs/ref/out-jpeg9d.txt
@@ -120,5 +120,21 @@ tahoe-icc.jpg        :  128 x   96, 3 channel, uint8 jpeg
     YResolution: 72
     Exif:ExifVersion: "0230"
     Exif:FlashPixVersion: "0100"
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1094992453
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright 1999 Adobe Systems Incorporated"
+    ICCProfile:creation_date: "1999:06:03 00:00:00"
+    ICCProfile:creator_signature: "41444245"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "6e6f6e65"
+    ICCProfile:model: "0"
+    ICCProfile:platform_signature: "Apple Computer, Inc."
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "Adobe RGB (1998)"
+    ICCProfile:profile_size: 560
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Perceptual"
     jpeg:subsampling: "4:2:0"
     oiio:ColorSpace: "sRGB"

--- a/testsuite/oiiotool-attribs/ref/out.txt
+++ b/testsuite/oiiotool-attribs/ref/out.txt
@@ -120,5 +120,21 @@ tahoe-icc.jpg        :  128 x   96, 3 channel, uint8 jpeg
     YResolution: 72
     Exif:ExifVersion: "0230"
     Exif:FlashPixVersion: "0100"
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1094992453
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright 1999 Adobe Systems Incorporated"
+    ICCProfile:creation_date: "1999:06:03 00:00:00"
+    ICCProfile:creator_signature: "41444245"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "6e6f6e65"
+    ICCProfile:model: "0"
+    ICCProfile:platform_signature: "Apple Computer, Inc."
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "Adobe RGB (1998)"
+    ICCProfile:profile_size: 560
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Perceptual"
     jpeg:subsampling: "4:2:0"
     oiio:ColorSpace: "sRGB"

--- a/testsuite/psd/ref/out.txt
+++ b/testsuite/psd/ref/out.txt
@@ -48,6 +48,25 @@ Reading ../oiio-images/psd_123.psd
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 257
     Exif:PixelYDimension: 126
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Media-relative colorimetric"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
     IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
     IPTC:InstanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
     IPTC:MetadataDate: "2011-08-22T22:14:43-04:00"
@@ -79,6 +98,25 @@ Reading ../oiio-images/psd_123.psd
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 257
     Exif:PixelYDimension: 126
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Media-relative colorimetric"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
     IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
     IPTC:InstanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
     IPTC:MetadataDate: "2011-08-22T22:14:43-04:00"
@@ -110,6 +148,25 @@ Reading ../oiio-images/psd_123.psd
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 257
     Exif:PixelYDimension: 126
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Media-relative colorimetric"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
     IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
     IPTC:InstanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
     IPTC:MetadataDate: "2011-08-22T22:14:43-04:00"
@@ -177,6 +234,25 @@ Reading ../oiio-images/psd_123_nomaxcompat.psd
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 257
     Exif:PixelYDimension: 126
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Media-relative colorimetric"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
     IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
     IPTC:InstanceID: "xmp.iid:F5BDDC0457D2E011BF419187EAB8EBB9"
     IPTC:MetadataDate: "2011-08-29T12:10:28-04:00"
@@ -209,6 +285,25 @@ Reading ../oiio-images/psd_123_nomaxcompat.psd
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 257
     Exif:PixelYDimension: 126
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Media-relative colorimetric"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
     IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
     IPTC:InstanceID: "xmp.iid:F5BDDC0457D2E011BF419187EAB8EBB9"
     IPTC:MetadataDate: "2011-08-29T12:10:28-04:00"
@@ -241,6 +336,25 @@ Reading ../oiio-images/psd_123_nomaxcompat.psd
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 257
     Exif:PixelYDimension: 126
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Media-relative colorimetric"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
     IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
     IPTC:InstanceID: "xmp.iid:F5BDDC0457D2E011BF419187EAB8EBB9"
     IPTC:MetadataDate: "2011-08-29T12:10:28-04:00"
@@ -657,6 +771,25 @@ Reading ../oiio-images/psd_rgba_8.psd
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 320
     Exif:PixelYDimension: 240
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Media-relative colorimetric"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
     IPTC:DocumentID: "xmp.did:037A91A22BCDE011A998CBE7B5CCEB92"
     IPTC:InstanceID: "xmp.iid:2793235262CFE011B8B8C52D9599FB9E"
     IPTC:MetadataDate: "2011-08-25T17:39:28-04:00"
@@ -717,6 +850,25 @@ src/different-mask-size.psd :   30 x   90, 3 channel, uint8 psd
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 30
     Exif:PixelYDimension: 90
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Perceptual"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
     IPTC:DocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
     IPTC:InstanceID: "xmp.iid:278c5b86-91a4-c144-b1bb-3f925cc9425d"
     IPTC:MetadataDate: "2017-01-10T17:55:32+09:00"
@@ -747,6 +899,25 @@ src/different-mask-size.psd :   30 x   90, 3 channel, uint8 psd
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 30
     Exif:PixelYDimension: 90
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Perceptual"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
     IPTC:DocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
     IPTC:InstanceID: "xmp.iid:278c5b86-91a4-c144-b1bb-3f925cc9425d"
     IPTC:MetadataDate: "2017-01-10T17:55:32+09:00"
@@ -777,6 +948,25 @@ src/different-mask-size.psd :   30 x   90, 3 channel, uint8 psd
     Exif:ColorSpace: 1
     Exif:PixelXDimension: 30
     Exif:PixelYDimension: 90
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Perceptual"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
     IPTC:DocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
     IPTC:InstanceID: "xmp.iid:278c5b86-91a4-c144-b1bb-3f925cc9425d"
     IPTC:MetadataDate: "2017-01-10T17:55:32+09:00"


### PR DESCRIPTION
For a while, we have found embedded ICC profiles in TIFF, JPEG, JPEG-2000, PNG, and PSD (PhotoShop) files and store them in the metadata as a byte array with the name "ICCProfile".

With this patch, we further add the facility of parsing the binary ICC profile data to extract a number of other fields that we add to the ImageSpec metadata so that "oiiotool -info -v" or "iinfo 'v" will print this info.

Important caveat: You can read this for informational purposes, but changing it (e.g. with spec.attribute()) does not change the contents of the ICCProfile byte array, which is still the canonical ground truth of the profile. You have to replace the "ICCProfile" byte array to actually change the profile.
