### PR TITLE
Python: add ability to getattribute of int64 and uint64 data

### DIFF
--- a/src/cmake/testing.cmake
+++ b/src/cmake/testing.cmake
@@ -215,6 +215,7 @@ macro (oiio_add_all_tests)
             python-colorconfig
             python-deep 
             python-imagebuf
+            python-imagecache
             python-imageoutput
             python-imagespec
             python-paramlist

--- a/src/python/py_oiio.h
+++ b/src/python/py_oiio.h
@@ -136,6 +136,7 @@ template<> struct PyTypeForCType<unsigned short> { typedef py::int_ type; };
 template<> struct PyTypeForCType<char> { typedef py::int_ type; };
 template<> struct PyTypeForCType<unsigned char> { typedef py::int_ type; };
 template<> struct PyTypeForCType<int64_t> { typedef py::int_ type; };
+template<> struct PyTypeForCType<uint64_t> { typedef py::int_ type; };
 template<> struct PyTypeForCType<float> { typedef py::float_ type; };
 template<> struct PyTypeForCType<half> { typedef py::float_ type; };
 template<> struct PyTypeForCType<double> { typedef py::float_ type; };
@@ -536,6 +537,10 @@ getattribute_typed(const T& obj, const std::string& name,
         return C_to_val_or_tuple((const half*)data, type);
     if (type.basetype == TypeDesc::STRING)
         return C_to_val_or_tuple((const char**)data, type);
+    if (type.basetype == TypeDesc::INT64)
+        return C_to_val_or_tuple((const int64_t*)data, type);
+    if (type.basetype == TypeDesc::UINT64)
+        return C_to_val_or_tuple((const uint64_t*)data, type);
     return py::none();
 }
 

--- a/testsuite/python-imagecache/ref/out.txt
+++ b/testsuite/python-imagecache/ref/out.txt
@@ -1,0 +1,6 @@
+stat:cache_memory_used 0
+stat:image_size 4036864
+total_files 2
+all_filenames ('../common/grid.tif', '../common/tahoe-tiny.tif')
+
+Done.

--- a/testsuite/python-imagecache/run.py
+++ b/testsuite/python-imagecache/run.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python 
+
+# Run the script 
+command += pythonbin + " src/test_imagecache.py > out.txt ;"
+
+# compare the outputs
+outputs = [ "out.txt" ]
+

--- a/testsuite/python-imagecache/src/test_imagecache.py
+++ b/testsuite/python-imagecache/src/test_imagecache.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+from __future__ import absolute_import
+import array
+import numpy
+import OpenImageIO as oiio
+
+
+
+######################################################################
+# main test starts here
+
+try:
+    ic = oiio.ImageCache()
+
+    # Force a file to be touched by the IC
+    ib = oiio.ImageBuf("../common/tahoe-tiny.tif")
+    ib = oiio.ImageBuf("../common/grid.tif")
+
+    print ("stat:cache_memory_used", ic.getattribute("stat:cache_memory_used", 'int64'))
+    print ("stat:image_size", ic.getattribute("stat:image_size", 'int64'))
+    total_files = ic.getattribute("total_files", 'int')
+    print ("total_files", ic.getattribute("total_files", 'int'))
+    print ("all_filenames", ic.getattribute("all_filenames", 'string[{}]'.format(total_files)))
+
+    print ("\nDone.")
+except Exception as detail:
+    print ("Unknown exception:", detail)
+


### PR DESCRIPTION
Just a couple missing pieces were preventing getattribute() from retrieving attributes that were stored as int64 or uint64. That doesn't come up very often, but one place is retrieving certain statistics that use 64 bit counters. (This comes up in ImageCache, among other places.)

While we're at it, there was no existing test dedicated to the python binding of ImageCache. So to add these getattribute calls, I made one.

There is an important caveat about ImageCache.getattribute(): In this process, I discovered that the flavor of IC.getattribute(name) where you only pass the name is BROKEN, and will always return None. You MUST use the form where you pass the type, like

    x = ic.getattribute("foo", "int")

This is unfortunate and not very Pythonic, but it is the workaround for now. I will addess getting the name-only form working in a separate PR.

Closes #3537
