### PR TITLE
cmake: Find TBB dependency in Config.cmake.in when building static lib

### DIFF
--- a/src/cmake/Config.cmake.in
+++ b/src/cmake/Config.cmake.in
@@ -28,6 +28,11 @@ if (NOT @BUILD_SHARED_LIBS@)
     if (@PNG_FOUND@)
         find_dependency(PNG)
     endif()
+    # The following have the same problem except that INTERFACE_LINK_LIBRARIES use
+    # TARGET_NAME_IF_EXISTS, so the error only happens on link time.
+    if (@OIIO_TBB@)
+        find_dependency(TBB)
+    endif ()
 endif ()
 
 # Compute the installation prefix relative to this file. Note that cmake files are installed


### PR DESCRIPTION
TBB::tbb is added as a library dependency via TARGET_NAME_IF_EXISTS. Therefore if an executable links OpenImageIO static library without the executable itself depending on TBB, then TBB will not be linked in and result in link time errors.

## Checklist:

- [x] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-CORPORATE)).
- [not needed] I have updated the documentation, if applicable.
- [not needed] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

