### PR TITLE
Build: Fix cross-compiling on Android failing due to -latomic check

### DIFF
--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -347,7 +347,7 @@ include (CheckLibraryExists)
 # Check if we need libatomic on this platform.  We shouldn't on mainstream
 # x86/x86_64, but might on some other platforms.
 #
-if (NOT MSVC AND NOT APPLE)
+if (NOT MSVC AND NOT APPLE AND NOT ANDROID)
     cmake_push_check_state ()
     check_cxx_source_runs(
        "#include <atomic>


### PR DESCRIPTION
Currently when cross-compiling for Android build fails due to usage of TRY_RUN(). In the particular case it tries to figure out whether atomics can be used without the libatomic library.

Fortunately we don't need this check because on Android NDK atomics are built-in and libatomic.so is not present. Only static dummy libatomic.a exists for compatibility with -latomic flag.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-CORPORATE)).
- [not needed] I have updated the documentation, if applicable.
- [not needed] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [not needed] My code follows the prevailing code style of this project.

