### PR TITLE
ustring improvements: ustringHasher and ustring ctr from ustringhash

### DIFF
--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -473,10 +473,10 @@ typedef intrusive_ptr<ImageCacheFile> ImageCacheFileRef;
 
 /// Map file names to file references
 typedef unordered_map_concurrent<
-    ustring, ImageCacheFileRef, ustringHash, std::equal_to<ustring>,
-    FILE_CACHE_SHARDS, tsl::robin_map<ustring, ImageCacheFileRef, ustringHash>>
+    ustring, ImageCacheFileRef, ustringHasher, std::equal_to<ustring>,
+    FILE_CACHE_SHARDS, tsl::robin_map<ustring, ImageCacheFileRef, ustringHasher>>
     FilenameMap;
-typedef tsl::robin_map<ustring, ImageCacheFileRef, ustringHash> FingerprintMap;
+typedef tsl::robin_map<ustring, ImageCacheFileRef, ustringHasher> FingerprintMap;
 
 
 
@@ -741,7 +741,7 @@ public:
     // This is safe because no ImageCacheFile is ever truly deleted from
     // the shared map, so this map isn't the owner.
     using ThreadFilenameMap
-        = tsl::robin_map<ustring, ImageCacheFile*, ustringHash>;
+        = tsl::robin_map<ustring, ImageCacheFile*, ustringHasher>;
     ThreadFilenameMap m_thread_files;
 
     // We have a two-tile "microcache", storing the last two tiles needed.

--- a/src/libutil/ustring_test.cpp
+++ b/src/libutil/ustring_test.cpp
@@ -178,6 +178,9 @@ test_ustringhash()
     // Ask a ustring for its ustringhash
     OIIO_CHECK_EQUAL(hfoo, foo.uhash());
 
+    // ustring constructed from a ustringhash
+    OIIO_CHECK_EQUAL(hfoo_from_foo, foo);
+
     // string_view and string from ustringhash
     string_view foo_sv = hfoo;
     OIIO_CHECK_EQUAL(foo_sv, "foo");


### PR DESCRIPTION
I realized that the ustringhash class (recently added) is confusingly similr to the hashing functor ustringHash (been there so long I'd forgotten about it). To clear this up, make ustringHasher for clarty. Get on a path of eventually deprecating and removing ustringHash.

I also noticed that there's no directly ustringhash -> ustring conversion. Add it.
