### PR TITLE
DDS: various improvements

### DIFF
--- a/src/dds.imageio/dds_pvt.h
+++ b/src/dds.imageio/dds_pvt.h
@@ -19,6 +19,10 @@ namespace DDS_pvt {
 #define DDS_4CC_ATI1 DDS_MAKE4CC('A', 'T', 'I', '1')
 #define DDS_4CC_ATI2 DDS_MAKE4CC('A', 'T', 'I', '2')
 #define DDS_4CC_DX10 DDS_MAKE4CC('D', 'X', '1', '0')
+#define DDS_4CC_RXGB DDS_MAKE4CC('R', 'X', 'G', 'B')
+#define DDS_4CC_BC4U DDS_MAKE4CC('B', 'C', '4', 'U')
+#define DDS_4CC_BC5U DDS_MAKE4CC('B', 'C', '5', 'U')
+
 #define DDS_FORMAT_BC4_UNORM 80
 #define DDS_FORMAT_BC5_UNORM 83
 #define DDS_FORMAT_BC6H_UF16 95
@@ -43,24 +47,23 @@ enum class Compression {
 /// images.
 ///
 enum {
-    DDS_PF_ALPHA     = 0x00000001,  ///< image has alpha channel
-    DDS_PF_FOURCC    = 0x00000004,  ///< image is compressed
-    DDS_PF_LUMINANCE = 0x00020000,  ///< image has luminance data
-    DDS_PF_RGB       = 0x00000040,  ///< image has RGB data
-    DDS_PF_YUV       = 0x00000200   ///< image has YUV data
+    DDS_PF_ALPHA     = 0x00000001,   ///< image has alpha channel
+    DDS_PF_ALPHAONLY = 0x00000002,   ///< image has only the alpha channel
+    DDS_PF_FOURCC    = 0x00000004,   ///< image is compressed
+    DDS_PF_LUMINANCE = 0x00020000,   ///< image has luminance data
+    DDS_PF_RGB       = 0x00000040,   ///< image has RGB data
+    DDS_PF_YUV       = 0x00000200,   ///< image has YUV data
+    DDS_PF_NORMAL    = 0x80000000u,  ///< image is a tangent space normal map
 };
 
 /// DDS pixel format structure.
 ///
 typedef struct {
-    uint32_t size;    ///< structure size, must be 32
-    uint32_t flags;   ///< flags to indicate valid fields
-    uint32_t fourCC;  ///< compression four-character code
-    uint32_t bpp;     ///< bits per pixel
-    uint32_t rmask;   ///< bitmask for the red channel
-    uint32_t gmask;   ///< bitmask for the green channel
-    uint32_t bmask;   ///< bitmask for the blue channel
-    uint32_t amask;   ///< bitmask for the alpha channel
+    uint32_t size;      ///< structure size, must be 32
+    uint32_t flags;     ///< flags to indicate valid fields
+    uint32_t fourCC;    ///< compression four-character code
+    uint32_t bpp;       ///< bits per pixel
+    uint32_t masks[4];  ///< bitmasks for the r,g,b,a channels
 } dds_pixformat;
 
 /// DDS caps flags, field 1.

--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -141,12 +141,21 @@ DDS
 DDS (Direct Draw Surface) is an image file format designed by Microsoft
 for use in Direct3D graphics.  DDS files use the extension :file:`.dds`.
 
-DDS is an awful format, with several compression modes that are all so
-lossy as to be completely useless for high-end graphics.  Nevertheless,
-they are widely used in games and graphics hardware directly supports
-these compression modes.  Alas.
+DDS is primarily meant for images that are directly usable by the GPU.
+It supports 2D, cube and volume images with or without MIPmaps; using
+either uncompressed pixel formats or one of the lossy compression
+schemes supported by the graphics hardware (BC1-BC7).
 
 OpenImageIO currently only supports reading DDS files, not writing them.
+
+DDS files containing a "normal map" (`0x80000000`) pixel format flag
+will be interpreted as a tangent space normal map. When reading such files,
+the resulting image will be a 3-channel image with red & green channels
+coming from file data, and the blue channel computed as if it were the
+Z component of a normal map. This applies to images using DXT5 compression
+(normal X & Y components are assumed to be in alpha & green channels)
+and images using BC5/ATI2 compression (normal X & Y components are in
+red & green channels).
 
 .. list-table::
    :widths: 30 10 65
@@ -187,7 +196,14 @@ attributes are supported:
    * - ``oiio:ioproxy``
      - ptr
      - Pointer to a ``Filesystem::IOProxy`` that will handle the I/O, for
-       example by reading from memory rather than the file system.
+       example by reading from memory rather than the file system.    
+
+Additionally, an integer ``dds:bc5normal`` global attribute is supported
+to control behaviour of images compressed in BC5/ATI2 compression format.
+When the attribute value is set to non-zero (default is zero), any input
+image using BC5/ATI2 compression format is assumed to be a normal map,
+even if pixel format "normal map" flag is not set.
+
 
 **Configuration settings for DDS output**
 

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -2750,6 +2750,11 @@ OIIO_API std::string geterror(bool clear = true);
 ///    may not read these correctly, but OIIO will. That's why the default
 ///    is not to support it.
 ///
+/// - `int dds:bc5normal`
+///
+///    When nonzero, treats BC5/ATI2 format files as normal maps (loads as
+///    3 channels, computes blue from red and green). Default is 0.
+///
 /// - `int openexr:core`
 ///
 ///    When nonzero, use the new "OpenEXR core C library" when available,

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -43,6 +43,7 @@ atomic_int oiio_try_all_readers(1);
 int openexr_core(0);  // Should we use "Exr core C library"?
 int tiff_half(0);
 int tiff_multithread(1);
+int dds_bc5normal(0);
 int limit_channels(1024);
 int limit_imagesize_MB(32 * 1024);
 ustring font_searchpath;
@@ -317,6 +318,10 @@ attribute(string_view name, TypeDesc type, const void* val)
         tiff_multithread = *(const int*)val;
         return true;
     }
+    if (name == "dds:bc5normal" && type == TypeInt) {
+        dds_bc5normal = *(const int*)val;
+        return true;
+    }
     if (name == "limits:channels" && type == TypeInt) {
         limit_channels = *(const int*)val;
         return true;
@@ -427,6 +432,10 @@ getattribute(string_view name, TypeDesc type, void* val)
     }
     if (name == "tiff:multithread" && type == TypeInt) {
         *(int*)val = tiff_multithread;
+        return true;
+    }
+    if (name == "dds:bc5normal" && type == TypeInt) {
+        *(int*)val = dds_bc5normal;
         return true;
     }
     if (name == "use_tbb" && type == TypeInt) {

--- a/testsuite/dds/ref/out.txt
+++ b/testsuite/dds/ref/out.txt
@@ -95,7 +95,7 @@ Reading ../oiio-images/dds/dds_npot_rgba8_mips.dds
     oiio:BitsPerSample: 32
 Reading ../oiio-images/dds/dds_r5g6b5.dds
 ../oiio-images/dds/dds_r5g6b5.dds :   16 x    8, 3 channel, uint8 dds
-    SHA-1: 40E37C4CC12C783830F4BAB614E9CD294D614A9D
+    SHA-1: 37A3BFD2B8A52006B4F07065A90BE774F276B751
     channel list: R, G, B
     textureformat: "Plain Texture"
     oiio:BitsPerSample: 16
@@ -107,7 +107,7 @@ Reading ../oiio-images/dds/dds_rgb8.dds
     oiio:BitsPerSample: 24
 Reading ../oiio-images/dds/dds_rgba4.dds
 ../oiio-images/dds/dds_rgba4.dds :   16 x    8, 4 channel, uint8 dds
-    SHA-1: 913C5D7FE99BAF1950475406D2BE94ABA5BA010D
+    SHA-1: E49AB2BCE799274DE4E12DCDF1B93363F34E0FA1
     channel list: R, G, B, A
     textureformat: "Plain Texture"
     oiio:BitsPerSample: 16


### PR DESCRIPTION
## Description

- If a DDS pixel format header contains "this is a normal map" flag set, then handle that properly (#3525):
  - For a DXT5, this means it's a "DXT5nm" format. Normal X & Y components are in green and alpha channel respectively. Compute Z component from those, and the result is a 3-channel tangent space normal map.
  - For ATI2/BC5 format that also has a "normal map" flag set, compute the Z component automatically too, and result is a 3-channel image. However a bunch of ATI2/BC5 normal maps out there in the wild do not have that bit set, so also have a global "dds:bc5normal" attribute to optionally turn this on.
- Fix support of R10G10B10A2 format - was producing garbage data due to code assumption that truncation down to 8 bits never needs to happen.
- Fix bit expansion ("too dark") of very low-bit formats, e.g. R3G3B2. Code was simply shifting the bits, instead of properly repeating the high bits into new low bit positions (i.e. a 3-bit "111" needs to become an 8-bit "11111111" and not a "11100000").
- Support "RXGB" (DXT5, with red & alpha swapped) as well as "BC4U" and "BC5U" formats (the latter two are just BC4 and BC5, produced by some older tools).
- Support alpha-only (e.g. A8) formats.

All this mostly prompted by doing DDS improvements in Blender, and wanting to get Cycles renderer (which uses OIIO) to the same feature parity. See https://developer.blender.org/T101405 and https://developer.blender.org/D16087.

## Tests

⚠️ Not yet! I should probably add a bunch of new images to oiio-images test suite, but first wanted to check if these suggested improvements even make sense.

## Checklist:

- [x] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-CORPORATE)).
- [x] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

