### PR TITLE
Build/security: Try FORTIFY_SOURCE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,6 +271,7 @@ jobs:
                             PUGIXML_VERSION=master
                             USE_OPENVDB=0
                             WEBP_VERSION=master
+                            OIIO_CMAKE_FLAGS="-DFORTIFY_SOURCE=2"
                             # The installed OpenVDB has a TLS conflict with Python 3.8
           - desc: clang14 C++20 avx2 exr3.1 ocio2.1
             nametag: linux-clang14

--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -433,6 +433,29 @@ endif ()
 
 
 ###########################################################################
+# Fortification and hardening options
+#
+# In modern gcc and clang, FORTIFY_SOURCE provides buffer overflow checks
+# (with some compiler-assisted deduction of buffer lengths) for the following
+# functions: memcpy, mempcpy, memmove, memset, strcpy, stpcpy, strncpy,
+# strcat, strncat, sprintf, vsprintf, snprintf, vsnprintf, gets.
+#
+# We try to avoid these unsafe functions anyway, but it's good to have the
+# extra protection, at least as an extra set of checks during CI. Some users
+# may also wish to enable it at some level if they are deploying it in a
+# security-sensitive environment. FORTIFY_SOURCE=3 may have minor performance
+# impact, though FORTIFY_SOURCE=2 should not have a measurable effect on
+# performance versus not doing any fortification. All fortification levels are
+# not available in all compilers.
+
+set (FORTIFY_SOURCE "0" CACHE STRING "Turn on Fortification level (0, 1, 2, 3)")
+if (FORTIFY_SOURCE AND (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG))
+    message (STATUS "Compiling with _FORTIFY_SOURCE=${FORTIFY_SOURCE}")
+    add_compile_options (-D_FORTIFY_SOURCE=${FORTIFY_SOURCE})
+endif ()
+
+
+###########################################################################
 # clang-tidy options
 #
 # clang-tidy is a static analyzer that is part of the LLVM tools. It has a


### PR DESCRIPTION
Add a new build-time cmake cache variable: FORTIFY_SOURCE

Default to empty, but can be set to 1, 2, or 3, corresponding to setting the _FORTIFY_SOURCE macro available in recent versions of clang and gcc. (I'm not sure exactly which minimum compiler version is needed for each fortification level, except that for level 3, gcc must be 12+.)

Fortification involves replacing several "unsafe" memory-related functions such as memcpy, memset, strcpy, etc, with special versions that do bounds checking, aided by some compiler smarts for understanding the likely bounds of different buffers. If I understand correctly, at level 2 it can figure out bounds of constant-sized arrays, and at level 3 it can figure out certain dynamic cases as well.

There are two use cases for this:

1. For our own CI, this is yet another bit of static and dynamic anslysis to enable (currently, just in the gcc12 test) to possibly catch bugs.

2. Users who are building OIIO to deploy it in security-sensitive environment may wish to build with some fortification level enabled to help prevent certain memory errors or security issues, understanding that it may slightly impact performance.
