### PR TITLE
ustring hashing improvements

### DIFF
--- a/src/include/OpenImageIO/strutil.h
+++ b/src/include/OpenImageIO/strutil.h
@@ -349,7 +349,7 @@ std::string OIIO_UTIL_API wordwrap (string_view src, int columns = 80,
 
 /// Our favorite "string" hash of a length of bytes. Currently, it is just
 /// a wrapper for an inlined, constexpr (if C++ >= 14), Cuda-safe farmhash.
-inline OIIO_CONSTEXPR14 size_t
+inline constexpr size_t
 strhash (size_t len, const char *s)
 {
     return OIIO::farmhash::inlined::Hash(s, len);
@@ -361,7 +361,7 @@ strhash (size_t len, const char *s)
 /// Cuda. This is rigged, though, so that empty strings hash always hash to
 /// 0 (that isn't what a raw farmhash would give you, but it's a useful
 /// property, especially for trivial initialization).
-inline OIIO_CONSTEXPR14 size_t
+inline constexpr size_t
 strhash (string_view s)
 {
     return s.length() ? strhash(s.length(), s.data()) : 0;

--- a/src/include/OpenImageIO/ustring.h
+++ b/src/include/OpenImageIO/ustring.h
@@ -124,14 +124,15 @@ class ustringhash;  // forward declaration
 ///
 class OIIO_UTIL_API ustring {
 public:
-    typedef char value_type;
-    typedef value_type* pointer;
-    typedef value_type& reference;
-    typedef const value_type& const_reference;
-    typedef size_t size_type;
-    static const size_type npos = static_cast<size_type>(-1);
-    typedef std::string::const_iterator const_iterator;
-    typedef std::string::const_reverse_iterator const_reverse_iterator;
+    using rep_t      = const char*;  ///< The underlying representation type
+    using value_type = char;
+    using pointer    = value_type*;
+    using reference  = value_type&;
+    using const_reference        = const value_type&;
+    using size_type              = size_t;
+    static const size_type npos  = static_cast<size_type>(-1);
+    using const_iterator         = std::string::const_iterator;
+    using const_reverse_iterator = std::string::const_reverse_iterator;
 
     /// Default ctr for ustring -- make an empty string.
     constexpr ustring() noexcept
@@ -744,7 +745,7 @@ public:
 private:
     // Individual ustring internal representation -- the unique characters.
     //
-    const char* m_chars;
+    rep_t m_chars;
 
 public:
     // Representation within the hidden string table -- DON'T EVER CREATE
@@ -787,6 +788,8 @@ private:
 ///
 class OIIO_UTIL_API ustringhash {
 public:
+    using rep_t = size_t;  ///< The underlying representation type
+
     // Default constructor
     OIIO_HOSTDEVICE constexpr ustringhash() noexcept
         : m_hash(0)
@@ -966,7 +969,7 @@ public:
 
 private:
     // Individual ustringhash internal representation -- the hash value.
-    size_t m_hash;
+    rep_t m_hash;
 
     // Construct from a raw hash value. It's protected so that it's only
     // callable by its friend, ustring.
@@ -977,6 +980,13 @@ private:
 
     friend class ustring;
 };
+
+
+
+static_assert(sizeof(ustringhash) == sizeof(size_t),
+              "ustringhash should be the same size as a size_t");
+static_assert(sizeof(ustring) == sizeof(const char*),
+              "ustring should be the same size as a const char*");
 
 
 

--- a/src/include/OpenImageIO/ustring.h
+++ b/src/include/OpenImageIO/ustring.h
@@ -1094,7 +1094,8 @@ template<> struct hash<OIIO::ustring> {
 
 // std::hash specialization for ustringhash
 template<> struct hash<OIIO::ustringhash> {
-    std::size_t operator()(OIIO::ustringhash u) const noexcept
+    OIIO_HOSTDEVICE constexpr std::size_t
+    operator()(OIIO::ustringhash u) const noexcept
     {
         return u.hash();
     }

--- a/src/include/OpenImageIO/ustring.h
+++ b/src/include/OpenImageIO/ustring.h
@@ -912,13 +912,13 @@ public:
     }
 
     /// Test for equality with a char*.
-    bool operator==(const char* str) const noexcept
+    OIIO_CONSTEXPR17 bool operator==(const char* str) const noexcept
     {
         return m_hash == Strutil::strhash(str);
     }
 
     /// Test for inequality with a char*.
-    bool operator!=(const char* str) const noexcept
+    OIIO_CONSTEXPR17 bool operator!=(const char* str) const noexcept
     {
         return m_hash != Strutil::strhash(str);
     }

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -472,11 +472,11 @@ typedef intrusive_ptr<ImageCacheFile> ImageCacheFileRef;
 
 
 /// Map file names to file references
-typedef unordered_map_concurrent<
-    ustring, ImageCacheFileRef, ustringHash, std::equal_to<ustring>,
-    FILE_CACHE_SHARDS, tsl::robin_map<ustring, ImageCacheFileRef, ustringHash>>
+typedef unordered_map_concurrent<ustring, ImageCacheFileRef, std::hash<ustring>,
+                                 std::equal_to<ustring>, FILE_CACHE_SHARDS,
+                                 tsl::robin_map<ustring, ImageCacheFileRef>>
     FilenameMap;
-typedef tsl::robin_map<ustring, ImageCacheFileRef, ustringHash> FingerprintMap;
+typedef tsl::robin_map<ustring, ImageCacheFileRef> FingerprintMap;
 
 
 
@@ -740,8 +740,7 @@ public:
     // Fall back to the shared map only when not found locally.
     // This is safe because no ImageCacheFile is ever truly deleted from
     // the shared map, so this map isn't the owner.
-    using ThreadFilenameMap
-        = tsl::robin_map<ustring, ImageCacheFile*, ustringHash>;
+    using ThreadFilenameMap = tsl::robin_map<ustring, ImageCacheFile*>;
     ThreadFilenameMap m_thread_files;
 
     // We have a two-tile "microcache", storing the last two tiles needed.

--- a/src/libutil/ustring_test.cpp
+++ b/src/libutil/ustring_test.cpp
@@ -146,6 +146,9 @@ test_ustring()
     OIIO_CHECK_EQUAL(ustring::is_unique(foostr), true);
     OIIO_CHECK_EQUAL(ustring::is_unique("foo"), false);
     OIIO_CHECK_EQUAL(ustring::from_unique(foostr), foo);
+
+    // std::hash
+    OIIO_CHECK_EQUAL(std::hash<ustring> {}(foo), foo.hash());
 }
 
 
@@ -178,6 +181,9 @@ test_ustringhash()
     // Ask a ustring for its ustringhash
     OIIO_CHECK_EQUAL(hfoo, foo.uhash());
 
+    // ustring constructed from a ustringhash
+    OIIO_CHECK_EQUAL(hfoo_from_foo, foo);
+
     // string_view and string from ustringhash
     string_view foo_sv = hfoo;
     OIIO_CHECK_EQUAL(foo_sv, "foo");
@@ -203,6 +209,12 @@ test_ustringhash()
 
     // Conversion to string
     OIIO_CHECK_EQUAL(Strutil::to_string(hfoo), "foo");
+
+    // from_hash
+    OIIO_CHECK_EQUAL(ustringhash::from_hash(hfoo.hash()), hfoo);
+
+    // std::hash
+    OIIO_CHECK_EQUAL(std::hash<ustringhash> {}(hfoo), hfoo.hash());
 }
 
 


### PR DESCRIPTION
I realized that the recently added ustringhash class is confusingly similar to the (obscure, barely used, mostly forgotten) ustringHash functor. But also ustringHash doesn't need to exist, because it's equivalent to `std::hash<ustring>`, if we define it. So now we do define it, and also `std::hash<ustringhash>`, and deprecate ustringHash, to be removed entirely for 3.0.

Also, add a ustring ctr from ustringhash (explicit only for now), and `operator<` for ustringhash.

Finally, modernize a few places we still used `(void)` to just `()`.
