### PR TITLE
Remove incorrect OIIO_API from inline method declaration

### DIFF
--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -1299,7 +1299,7 @@ public:
             pos(m_x, m_y, m_z);
         }
         /// Increment to the next pixel in the region.
-        void OIIO_API operator++(int) { ++(*this); }
+        void operator++(int) { ++(*this); }
 
         /// Return the iteration range
         ROI range() const


### PR DESCRIPTION
This was causing build issues on MinGW.

Fixes #3576 
