### PR TITLE
oiiotool protect against OpenEXR thread deadlock on Windows

### DIFF
--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -19,6 +19,7 @@
 
 #include "oiiotool.h"
 
+#include <OpenEXR/IlmThreadPool.h>
 #include <OpenEXR/ImfTimeCode.h>
 #include <OpenImageIO/Imath.h>
 
@@ -7016,6 +7017,12 @@ main(int argc, char* argv[])
                   << Strutil::memformat(Sysutil::memory_used()) << "\n";
         std::cout << "\n" << ot.imagecache->getstats(2) << "\n";
     }
+
+    // Force the OpenEXR threadpool to shutdown because their destruction
+    // might cause us to hang on Windows when it tries to communicate with
+    // threads that would have already been terminated without releasing any
+    // held mutexes.
+    IlmThread::ThreadPool::globalThreadPool().setNumThreads(0);
 
     return ot.return_value;
 }


### PR DESCRIPTION
Suggested by SideFX: explicitly shut down the OpenEXR thread pool before exiting oiiotool, because sometimes on Windows it seems to hang otherwise. A better solution is probably possible on the OpenEXR side, but I don't know what it would be. (And in any case, we'd still need to do this be be well behaved when using OpenEXR versions earlier than where a fix might land.)

Solution tracked down by Edward Lam.
