### PR TITLE
CI/build: build_libtiff.bash should be sure to build shared library

### DIFF
--- a/src/build-scripts/build_libtiff.bash
+++ b/src/build-scripts/build_libtiff.bash
@@ -39,6 +39,7 @@ if [[ -z $DEP_DOWNLOAD_ONLY ]]; then
     time cmake -DCMAKE_BUILD_TYPE=${LIBTIFF_BUILD_TYPE} \
                -DCMAKE_INSTALL_PREFIX=${LIBTIFF_INSTALL_DIR} \
                -DCMAKE_CXX_FLAGS="${LIBTIFF_CXX_FLAGS}" \
+               -DBUILD_SHARED_LIBS=${LIBTIFF_BUILD_SHARED_LIBS:-ON} \
                ${LIBTIFF_BUILDOPTS} ..
     time cmake --build . --target install
 fi


### PR DESCRIPTION
Something changed in libtiff master and it doesn't build shared libs by default, breaking our "bleeding edge" CI test. So when we build it, be sure to ask for it. It can be overridden in build_libtiff by invoking it with env variable `LIBTIFF_BUILD_SHARED_LIBS=OFF`.
