### PR TITLE
Subimage compression

### DIFF
--- a/src/doc/oiiotool.rst
+++ b/src/doc/oiiotool.rst
@@ -1535,10 +1535,22 @@ Writing images
     Sets the compression method, and optionally a quality setting, for the
     output image.  Each ImageOutput plugin will have its own set of methods
     that it supports.
+
+    Optional appended modifiers include:
+
+      `:subimages=` *indices-or-names*
+        Include/exclude subimages (see :ref:`sec-oiiotool-subimage-modifier`).
+        Only included subimages will have the attribute changed. If subimages
+        are not set, only the first subimage will be changed, or all subimages
+        if the `-a` command line flag was used.
+
+    Examples::
+
+        # Set the EXR compression to piz
+        oiiotool in.exr --compression piz -o out.exr
     
-    Sets the compression method, and optionally a quality setting, for the
-    output image.  Each ImageOutput plugin will have its own set of methods
-    that it supports.
+        # Set the compression to zip only in subimage 1
+        oiiotool in.exr --compression:subimages=1 zip -o out.exr
 
 .. option:: --quality <q>
 

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -129,7 +129,6 @@ public:
     // Output options
     TypeDesc output_dataformat;  // Requested output data format
     std::map<std::string, std::string> output_channelformats;
-    std::string output_compression;
     std::string output_planarconfig;
     int output_bitspersample;
     int output_tilewidth, output_tileheight;


### PR DESCRIPTION
## Description

This PR enables oiiotool's --compression flag to work on a per subimage basis. As OpenEXR files allow multipart files to use different compression schemes, this seemed to be the best way to enable this functionality.

## Tests

    oiiotool -a -i multipart.exr --compression:subimages=1 zip -o out.exr

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [X] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [X] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-CORPORATE)).
- [X] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [X] My code follows the prevailing code style of this project.