### PR TITLE
Fix PSD import on ARM

### DIFF
--- a/src/psd.imageio/psdinput.cpp
+++ b/src/psd.imageio/psdinput.cpp
@@ -2013,7 +2013,8 @@ PSDInput::decompress_packbits(const char* src, char* dst,
     int length;
 
     while (src_remaining > 0 && dst_remaining > 0) {
-        header = *src++;
+        header = *reinterpret_cast<const signed char*>(src);
+        src++;
         src_remaining--;
 
         if (header == 128)


### PR DESCRIPTION
The code assumes "char" is "signed char" (as on x86), but on ARM "char" is "unsigned char". The local cast was the least intrusive solution, one could also change the signature of that function and cast in the caller ...

Verified with a proprietary test image. I'd guess that the OIIO testsuite should uncover the problem when run on ARM.

- [x] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

