### PR TITLE
oiiotool: work around static destruction order issue (#3295)

### DIFF
--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -7018,6 +7018,14 @@ main(int argc, char* argv[])
         std::cout << "\n" << ot.imagecache->getstats(2) << "\n";
     }
 
+    // Release references of images that might hold onto a shared
+    // image cache. Otherwise they would get released at static destruction
+    // time, at which point due to undefined destruction order the shared
+    // cache might be already gone.
+    ot.curimg = nullptr;
+    ot.image_stack.clear();
+    ot.image_labels.clear();
+
     // Force the OpenEXR threadpool to shutdown because their destruction
     // might cause us to hang on Windows when it tries to communicate with
     // threads that would have already been terminated without releasing any


### PR DESCRIPTION
## Description

In some cases (at least on Windows, with static linking) the oiiotool main returns zero, but the full process returns 3 error code due to abort() being called. And that is called because a global shared image cache is already destroyed, but the image references from another global (Oiiotool itself) try to use it, get a call into a "pure virtual function" stub that is put by MSVC C runtime into a destroyed object vtable, and that ends up in an abort().

Work around that by making sure various member variables holding ImageRecRef are cleared before main() finishes and global destructors are called.

## Tests

N/A -- but it does make running OIIO test suite locally much easier for me. Previously python runners that were launching oiiotool were getting exit code 3 when "everything was fine", so I had to resort to running their final command lines manually. Which is quite cumbersome!

## Checklist:

- [x] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

