### PR TITLE
BMP: fix reading 16bpp images (#2808)

### DIFF
--- a/src/bmp.imageio/bmp_pvt.cpp
+++ b/src/bmp.imageio/bmp_pvt.cpp
@@ -101,7 +101,8 @@ DibInformationHeader::read_header(Filesystem::IOProxy* fd)
             return false;
         }
 
-        if (size == WINDOWS_V4 || size == WINDOWS_V5 || size == UNDOCHEADER52
+        if ((size == WINDOWS_V3 && bpp == 16 && compression == 3)
+            || size == WINDOWS_V4 || size == WINDOWS_V5 || size == UNDOCHEADER52
             || size == UNDOCHEADER56) {
             if (!fread(fd, &red_mask) || !fread(fd, &green_mask)
                 || !fread(fd, &blue_mask)) {

--- a/src/bmp.imageio/bmp_pvt.h
+++ b/src/bmp.imageio/bmp_pvt.h
@@ -85,10 +85,10 @@ public:
                               // in most cases ignored
 
     // added in Version 4 of the format
-    int32_t red_mask;
-    int32_t blue_mask;
-    int32_t green_mask;
-    int32_t alpha_mask;
+    int32_t red_mask   = 0;
+    int32_t blue_mask  = 0;
+    int32_t green_mask = 0;
+    int32_t alpha_mask = 0;
     int32_t cs_type;  //color space type
     int32_t red_x;
     int32_t red_y;

--- a/testsuite/bmp/ref/out.txt
+++ b/testsuite/bmp/ref/out.txt
@@ -206,12 +206,32 @@ Reading ../oiio-images/bmpsuite/g32def.bmp
     bmp:version: 3
 Comparing "../oiio-images/bmpsuite/g32def.bmp" and "g32def.bmp"
 PASS
-Reading ../oiio-images/bmpsuite/g32bf.bmp
-../oiio-images/bmpsuite/g32bf.bmp :  127 x   64, 4 channel, uint8 bmp
-    SHA-1: D8807C680B17C70CB33B43AC072E0A9121C551B4
-    channel list: R, G, B, A
+Reading ../oiio-images/bmpsuite/g16bf555.bmp
+../oiio-images/bmpsuite/g16bf555.bmp :  127 x   64, 3 channel, uint5 bmp
+    SHA-1: F040412A98C1F9B55F377BA74418D79FEA149DD5
+    channel list: R, G, B
+    bmp:bitsperpixel: 16
     bmp:version: 3
-Comparing "../oiio-images/bmpsuite/g32bf.bmp" and "g32bf.bmp"
+    oiio:BitsPerSample: 5
+Comparing "../oiio-images/bmpsuite/g16bf555.bmp" and "g16bf555.bmp"
+PASS
+Reading ../oiio-images/bmpsuite/g16bf565.bmp
+../oiio-images/bmpsuite/g16bf565.bmp :  127 x   64, 3 channel, uint5 bmp
+    SHA-1: 61E14F82A64F3E6A57A7CABC61FD47E52E031B16
+    channel list: R, G, B
+    bmp:bitsperpixel: 16
+    bmp:version: 3
+    oiio:BitsPerSample: 5
+Comparing "../oiio-images/bmpsuite/g16bf565.bmp" and "g16bf565.bmp"
+PASS
+Reading ../oiio-images/bmpsuite/g16def555.bmp
+../oiio-images/bmpsuite/g16def555.bmp :  127 x   64, 3 channel, uint5 bmp
+    SHA-1: F040412A98C1F9B55F377BA74418D79FEA149DD5
+    channel list: R, G, B
+    bmp:bitsperpixel: 16
+    bmp:version: 3
+    oiio:BitsPerSample: 5
+Comparing "../oiio-images/bmpsuite/g16def555.bmp" and "g16def555.bmp"
 PASS
 Reading src/g01bg2-v5.bmp
 src/g01bg2-v5.bmp    :  127 x   64, 3 channel, uint8 bmp

--- a/testsuite/bmp/run.py
+++ b/testsuite/bmp/run.py
@@ -11,13 +11,10 @@ files = [ "g01bg.bmp", "g01bw.bmp", "g01p1.bmp", "g01wb.bmp",
           "g08res11.bmp", "g08res21.bmp", "g08res22.bmp",
           "g08s0.bmp", "g08w124.bmp", "g08w125.bmp", "g08w126.bmp",
           "g08rle.bmp", "g08offs.bmp",
-          "g24.bmp", "g32bf.bmp", "g32def.bmp", "g32bf.bmp"
-           ]
+          "g24.bmp", "g32bf.bmp", "g32def.bmp",
+          "g16bf555.bmp", "g16bf565.bmp", "g16def555.bmp" ]
 for f in files :
     command += rw_command (OIIO_TESTSUITE_IMAGEDIR, f)
-
-# TODO: seems broken: g16bf555.bmp,
-#                     g16bf565.bmp, g16def555.bmp
 
 # Test BMR version 5
 command += rw_command ("src", "g01bg2-v5.bmp")


### PR DESCRIPTION
## Description

16 bit per pixel (e.g. 555, 565, 444) formats probably have never worked. One part of the code was assuming 5 bits in the mask, another was shifting by 4 bits, and the 16-bit pixel fetch code was reading just one byte. Fixes #2808.

## Tests

The test suited added back in #2976 already had a `TODO: seems broken: g16bf555.bmp, g16bf565.bmp, g16def555.bmp` comment, which is exactly 16 bpp test cases. So I've uncommented them here, and made them work.

Also removed one `g32bf.bmp` from the tests lists; it was listed there twice (looked more like a copy-paste accident than on purpose).

## Checklist:

- [x] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

