### PR TITLE
Windows: fewer windows.h includes from platform.h

### DIFF
--- a/src/include/OpenImageIO/platform.h
+++ b/src/include/OpenImageIO/platform.h
@@ -48,6 +48,9 @@
 #    ifndef NOMINMAX
 #        define NOMINMAX
 #    endif
+#    ifndef NOGDI
+#        define NOGDI
+#    endif
 #    include <windows.h>
 #endif
 


### PR DESCRIPTION
## Description

Using almost any OIIO header (e.g. `imageio.h`) includes `platform.h`, which on Windows includes `<windows.h>`. That IMHO is "not ideal at all", primarily because windows headers are fairly terrible in what they hijack as preprocessor symbols, that often clash with sensible things used by other code.

The most famous ones being them defining `min` and `max`, but there are many others. Now, I tried removing inclusion of `<windows.h>` from public OIIO headers, and that _almost_ works, except for the usage of `YieldProcessor()` from an inline function in `thread.h`, which is hard to remove in a clean way.

So instead of that, here's a much smaller proposal: in addition to defining `NOMINMAX` (salvages `min` and `max` symbols) and `WIN32_LEAN_AND_MEAN` / `VC_EXTRALEAN` (salvages `small` symbol), also define `NOGDI`, which saves `ERROR` and `GetObject` among others.

- `ERROR` allows code to use both OIIO and google/gtest library. Case in point: Blender, which up until now always used modified OIIO headers (adding `NOGDI` just like here).
- `GetObject` is just a possibly common symbol; and having it _not_ hijacked to either `GetObjectA` or `GetObjectW` by windows headers sounds useful.

## Tests

N/A

## Checklist:

- [x] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

