### PR TITLE
Windows: stop including <windows.h> from public OIIO headers

### DIFF
--- a/src/include/OpenImageIO/platform.h
+++ b/src/include/OpenImageIO/platform.h
@@ -38,22 +38,6 @@
 #    include <malloc.h>  // for alloca
 #endif
 
-#if defined(_WIN32)
-#    ifndef WIN32_LEAN_AND_MEAN
-#        define WIN32_LEAN_AND_MEAN
-#    endif
-#    ifndef VC_EXTRALEAN
-#        define VC_EXTRALEAN
-#    endif
-#    ifndef NOMINMAX
-#        define NOMINMAX
-#    endif
-#    ifndef NOGDI
-#        define NOGDI
-#    endif
-#    include <windows.h>
-#endif
-
 #ifdef _MSC_VER
 #    include <intrin.h>
 #endif

--- a/src/include/OpenImageIO/thread.h
+++ b/src/include/OpenImageIO/thread.h
@@ -111,11 +111,19 @@ pause(int delay) noexcept
 
 #elif defined(_MSC_VER)
     for (int i = 0; i < delay; ++i) {
-#    if defined(_WIN64)
-        YieldProcessor();
-#    else
+        // A reimplementation of winnt.h YieldProcessor,
+        // to avoid including windows headers.
+        #if defined(_M_AMD64)
+        _mm_pause();
+        #elif defined(_M_ARM64) || defined(_M_HYBRID_X86_ARM64)
+        __dmb(_ARM64_BARRIER_ISHST);
+        __yield();
+        #elif defined(_M_ARM)
+        __dmb(_ARM_BARRIER_ISHST);
+        __yield();
+        #else
         _asm pause
-#    endif /* _WIN64 */
+        #endif
     }
 
 #else

--- a/src/include/OpenImageIO/timer.h
+++ b/src/include/OpenImageIO/timer.h
@@ -21,7 +21,6 @@
 #include <OpenImageIO/strutil.h>
 
 #ifdef _WIN32
-//# include <windows.h>  // Already done by platform.h
 #elif defined(__APPLE__)
 #    include <mach/mach_time.h>
 #else
@@ -199,23 +198,23 @@ private:
     /// Platform-dependent grab of current time, expressed as ticks_t.
     ///
     ticks_t now(void) const
-    {
 #ifdef _WIN32
-        LARGE_INTEGER n;
-        QueryPerformanceCounter(&n);  // From MSDN web site
-        return n.QuadPart;
-#elif defined(__APPLE__)
+        ;  // a non-inline function on Windows
+#else
+    {
+#    if defined(__APPLE__)
         return mach_absolute_time();
-#elif OIIO_TIMER_LINUX_USE_clock_gettime
+#    elif OIIO_TIMER_LINUX_USE_clock_gettime
         struct timespec t;
         clock_gettime(CLOCK_MONOTONIC, &t);
         return int64_t(t.tv_sec) * int64_t(1000000000) + t.tv_nsec;
-#else
+#    else
         struct timeval t;
         gettimeofday(&t, NULL);
         return int64_t(t.tv_sec) * int64_t(1000000) + t.tv_usec;
-#endif
+#    endif
     }
+#endif
 
     /// Difference between two times, expressed in (platform-dependent)
     /// ticks.

--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -20,7 +20,11 @@
 #include <OpenImageIO/ustring.h>
 
 #ifdef _WIN32
-// # include <windows.h>   // Already done by platform.h
+#    define WIN32_LEAN_AND_MEAN
+#    define VC_EXTRALEAN
+#    define NOMINMAX
+#    include <windows.h>
+
 #    include <direct.h>
 #    include <io.h>
 #    include <shellapi.h>

--- a/src/libutil/plugin.cpp
+++ b/src/libutil/plugin.cpp
@@ -7,7 +7,12 @@
 
 #include <OpenImageIO/platform.h>
 
-#ifndef _WIN32
+#ifdef _WIN32
+#    define WIN32_LEAN_AND_MEAN
+#    define VC_EXTRALEAN
+#    define NOMINMAX
+#    include <windows.h>
+#else
 #    include <dlfcn.h>
 #endif
 

--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -32,6 +32,11 @@
 #include <OpenImageIO/ustring.h>
 
 #ifdef _WIN32
+#    define WIN32_LEAN_AND_MEAN
+#    define VC_EXTRALEAN
+#    define NOMINMAX
+#    include <windows.h>
+
 #    include <shellapi.h>
 #endif
 

--- a/src/libutil/sysutil.cpp
+++ b/src/libutil/sysutil.cpp
@@ -46,6 +46,10 @@
 
 #ifdef _WIN32
 #    define WIN32_LEAN_AND_MEAN
+#    define VC_EXTRALEAN
+#    define NOMINMAX
+#    include <windows.h>
+
 #    define DEFINE_CONSOLEV2_PROPERTIES
 #    include <cstdio>
 #    include <io.h>

--- a/src/libutil/thread.cpp
+++ b/src/libutil/thread.cpp
@@ -35,6 +35,13 @@
 
 #include <boost/container/flat_map.hpp>
 
+#ifdef _WIN32
+#    define WIN32_LEAN_AND_MEAN
+#    define VC_EXTRALEAN
+#    define NOMINMAX
+#    include <windows.h>
+#endif
+
 #if 0
 
 // Use boost::lockfree::queue for the task queue

--- a/src/libutil/timer.cpp
+++ b/src/libutil/timer.cpp
@@ -7,13 +7,18 @@
 
 #include <OpenImageIO/timer.h>
 
+#ifdef _WIN32
+#    define WIN32_LEAN_AND_MEAN
+#    define VC_EXTRALEAN
+#    define NOMINMAX
+#    include <windows.h>
+#endif
+
 
 OIIO_NAMESPACE_BEGIN
 
 double Timer::seconds_per_tick;
 Timer::ticks_t Timer::ticks_per_second;
-
-
 
 class TimerSetupOnce {
 public:
@@ -54,6 +59,16 @@ public:
 
 static TimerSetupOnce once;
 
-
+#ifdef _WIN32
+// a non-inline function on Windows, to avoid
+// including windows headers from OIIO public header.
+Timer::ticks_t
+Timer::now(void) const
+{
+    LARGE_INTEGER n;
+    QueryPerformanceCounter(&n);
+    return n.QuadPart;
+}
+#endif
 
 OIIO_NAMESPACE_END


### PR DESCRIPTION
## Description

Including windows.h leads to a lot of possibly common names being "taken", mostly by preprocessor defines. Some of these are possible to turn off (like "max" and "min" by defining "NOMINMAX" before including <windows.h>). But many others are not possible to turn off, e.g. "near" and "far" just get defined to nothing, preventing from using variables named like that.

Additionally, includes have a cost, and while <windows.h>, being a C header does not have expensive language constructs that would slow down compilation a lot, it's still something close to 100k lines of preprocessed code to wade through.

Now, only the OIIO implementation .cpp files that actually need <windows.h> include it (all of them under "libutil").

There were two exceptions:
1) thread.h `pause()` implementation uses `YieldProcessor()` macro when on
  a Windows system. Replaced it with manually "re-implemented"
  things that YieldProcessor expands to. Right now made the
  implementation for all 4 platforms that Windows normally supports
  (x64, x86, arm, arm64); the latter two OIIO does not support though
  when on Windows so it's untested.
2) timer.h `Timer::now()` inline function used `QueryPerformanceCounter`
  and `LARGE_INTEGER`. These are quite hard to somehow "forward-declare"
  or similar, without resulting in duplicate type definitions. So on
  Windows I moved the now() function to be non-inline. A though for another
  day: maybe all of that could be replaced by C++ `<chrono>` instead.

## Tests

Existing CI tests.

## Checklist:

- [x] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

