### PR TITLE
SIMD: extend NEON coverage, and include neon in oiio_simd_caps

### DIFF
--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -194,6 +194,7 @@ oiio_simd_caps()
     if (OIIO_AVX512CD_ENABLED)   caps.emplace_back ("avx512cd");
     if (OIIO_AVX512BW_ENABLED)   caps.emplace_back ("avx512bw");
     if (OIIO_AVX512VL_ENABLED)   caps.emplace_back ("avx512vl");
+    if (OIIO_SIMD_NEON)          caps.emplace_back ("neon");
     if (OIIO_FMA_ENABLED)        caps.emplace_back ("fma");
     if (OIIO_F16C_ENABLED)       caps.emplace_back ("f16c");
     // if (OIIO_POPCOUNT_ENABLED)   caps.emplace_back ("popcnt");


### PR DESCRIPTION
## Description

Related to points raised over at #3268, this improves NEON coverage a bit. It already works "out of the box" (at least when building on an Apple Silicon, using all default cmake options), but a bunch of functions were missing native NEON implementations. Also `oiio_simd_caps()` did not indicate in any way that NEON SIMD is actually compiled in.

* Use hardware float<->half conversion (similar to F16C on Intel)
* Use hardware sqrt
* Use horizontal adds in more places ("reduce_add")
* Equivalents of _mm_movemask_ps for NEON in vbool4
* Other smaller bits & bobs

## Tests

None of ARM platforms are tested on Github CI here. I manually ran various `_test` executables produced by a local build before & after the changes, and everything is the same correctness wise.

Testing on Apple M1 Max, Release build, notable `simd_test` Mvals/sec changes:

* vfloat4
    * load from half[]: 2457 -> 5890
    * store to half[]: 1041 -> 6074
    * simd sqrt: 2151 -> 6075
* vfloat8
    * load from half[]: 2433 -> 10367
    * store to half[]: 1235 -> 11192
    * reduce_add: 7377 -> 11971
* vfloat16
    * load from half[]: 2672 -> 14505
    * store to half[]: 1322 -> 12558
    * reduce_add: 7123 -> 11858
    * operator<:  3345 -> 7500 (similar with other compare ops)
* vint4
    * blend: 4403 -> 5007
    * blend0: 5187 -> 6076
    * rotl: 1775 -> 2932
* vint8
    * load from int[]: 9415 -> 12152
* vint16
    * operator<<: 4656 -> 5865 (similar for >>, srl)
    * rotl : 4042 -> 5137
* vbool4
    * reduce_and: 875 -> 1361
    * reduce_or: 985 -> 1373

## Checklist:

- [x] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

