### PR TITLE
Static analysis related fixes

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -17,6 +17,9 @@ sonar.sourceEncoding=UTF-8
 # C/C++ analyzer properties
 sonar.cfamily.build-wrapper-output=build/bw_output
 sonar.cfamily.gcov.reportsPath=_coverage
+sonar.coverage.exclusions=src/iv/**,src/include/OpenImageIO/detail/pugixml/**
 
 sonar.cfamily.cache.enabled=true
 sonar.cfamily.cache.path=/tmp/sonarcache
+
+sonar.verbose=false

--- a/src/build-scripts/ci-coverage.bash
+++ b/src/build-scripts/ci-coverage.bash
@@ -10,18 +10,6 @@ echo "Performing code coverage analysis"
 mkdir _coverage
 pushd _coverage
 
-ls -R ../build/src/
-
-# Remove files or directories we want to exclude from code coverage analysis,
-# generally because we don't expect to execute any of their code during our
-# CI. (Because it's only used interactively, or is fallback code only used
-# when certain dependencies are not found.) Including these when we know we
-# won't be calling them during coverage gathering will just make our coverage
-# percentage look artifically low.
-rm -f ../build/src/iv/CMakeFiles/iv.dir/*.cpp.{gcno,gcda}
-rm -f ../build/src/iv/CMakeFiles/iv.dir/iv_autogen/*.cpp.{gcno,gcda}
-rm -f ../build/src/libOpenImageIO/CMakeFiles/OpenImageIO.dir/__/include/OpenImageIO/detail/pugixml/*.cpp.{gcno,gcda}
-
 
 # The sed command below converts from:
 #   ../build/src/libOpenImageIO/CMakeFiles/OpenImageIO.dir/foo.gcno

--- a/src/iff.imageio/iff_pvt.h
+++ b/src/iff.imageio/iff_pvt.h
@@ -140,7 +140,7 @@ public:
     {
         try {
             close();
-        } catch (std::exception& e) {
+        } catch (const std::exception& e) {
             OIIO::pvt::errorfmt("{}", e.what());
         }
     }
@@ -219,7 +219,14 @@ private:
 class IffOutput final : public ImageOutput {
 public:
     IffOutput() { init(); }
-    ~IffOutput() override { close(); }
+    ~IffOutput() override
+    {
+        try {
+            close();
+        } catch (const std::exception& e) {
+            OIIO::pvt::errorfmt("{}", e.what());
+        }
+    }
     const char* format_name(void) const override { return "iff"; }
     int supports(string_view feature) const override;
     bool open(const std::string& name, const ImageSpec& spec,

--- a/src/python/py_oiio.cpp
+++ b/src/python/py_oiio.cpp
@@ -223,6 +223,8 @@ py::object
 make_pyobject(const void* data, TypeDesc type, int nvalues,
               py::object defaultvalue)
 {
+    if (!data || !nvalues)
+        return defaultvalue;
     if (type.basetype == TypeDesc::INT32)
         return C_to_val_or_tuple((const int*)data, type, nvalues);
     if (type.basetype == TypeDesc::FLOAT)
@@ -247,8 +249,11 @@ make_pyobject(const void* data, TypeDesc type, int nvalues,
         // Array of uint8 bytes
         // Have to make a copy of the data, because make_numpy_array will
         // take possession of it.
-        uint8_t* ucdata(new uint8_t[type.arraylen * nvalues]);
-        std::memcpy(ucdata, data, type.arraylen * nvalues);
+        int n = type.arraylen * nvalues;
+        if (n <= 0)
+            return defaultvalue;
+        uint8_t* ucdata(new uint8_t[n]);
+        std::memcpy(ucdata, data, n);
         return make_numpy_array(ucdata, 1, 1, size_t(type.arraylen),
                                 size_t(nvalues));
     }


### PR DESCRIPTION
* Protect against 0-sized allocation
* Exception safety in IffOutput destructor
* Using sonar.coverage.exclusions as a better way to exclude files from coverage analysis
* Null pointer safety
