### PR TITLE
Improve cineon build and test

### DIFF
--- a/src/cineon.imageio/CMakeLists.txt
+++ b/src/cineon.imageio/CMakeLists.txt
@@ -4,5 +4,8 @@
 
 add_oiio_plugin (cineoninput.cpp
                  libcineon/Cineon.cpp libcineon/OutStream.cpp libcineon/Codec.cpp
-                 libcineon/Reader.cpp libcineon/Writer.cpp libcineon/CineonHeader.cpp
+                 libcineon/Reader.cpp libcineon/CineonHeader.cpp
                  libcineon/ElementReadStream.cpp libcineon/InStream.cpp)
+
+# Note: OIIO doesn't support cineon output, so we don't compile
+# libcineon/Writer.cpp

--- a/src/cineon.imageio/cineoninput.cpp
+++ b/src/cineon.imageio/cineoninput.cpp
@@ -108,7 +108,6 @@ CineonInput::open(const std::string& name, ImageSpec& newspec)
     // fill channel names
     m_spec.channelnames.clear();
     int gscount = 0, rcount = 0, gcount = 0, bcount = 0;
-    char buf[3];
     for (int i = 0; i < m_cin.header.NumberOfElements(); i++) {
         switch (m_cin.header.ImageDescriptor(i)) {
         case cineon::kGrayscale:
@@ -337,9 +336,12 @@ CineonInput::open(const std::string& name, ImageSpec& newspec)
                                               m_cin.header.sourceTime));
         // FIXME: do something about the time zone
     }
-    m_cin.header.FilmEdgeCode(buf);
-    if (buf[0])
-        m_spec.attribute("cineon:FilmEdgeCode", buf);
+    {
+        char filmedge[17];
+        m_cin.header.FilmEdgeCode(filmedge);
+        if (filmedge[0])
+            m_spec.attribute("cineon:FilmEdgeCode", filmedge);
+    }
 
     // read in user data
     if (m_cin.header.UserSize() != 0 && m_cin.header.UserSize() != 0xFFFFFFFF) {

--- a/src/cmake/testing.cmake
+++ b/src/cmake/testing.cmake
@@ -243,6 +243,9 @@ macro (oiio_add_all_tests)
     oiio_add_tests (bmp
                     ENABLEVAR ENABLE_BMP
                     IMAGEDIR oiio-images/bmpsuite)
+    oiio_add_tests (cineon
+                    ENABLEVAR ENABLE_CINEON
+                    IMAGEDIR oiio-images URL "Recent checkout of oiio-images")
     oiio_add_tests (dpx
                     ENABLEVAR ENABLE_DPX
                     IMAGEDIR oiio-images URL "Recent checkout of oiio-images")

--- a/src/dpx.imageio/dpxinput.cpp
+++ b/src/dpx.imageio/dpxinput.cpp
@@ -360,10 +360,12 @@ DPXInput::seek_subimage(int subimage, int miplevel)
     }
     if (m_dpx.header.ImageEncoding(subimage) == dpx::kRLE)
         m_spec.attribute("compression", "rle");
-    char buf[32 + 1];
-    m_dpx.header.Description(subimage, buf);
-    if (buf[0] && buf[0] != char(-1))
-        m_spec.attribute("ImageDescription", buf);
+    {
+        char desc[32 + 1];
+        m_dpx.header.Description(subimage, desc);
+        if (desc[0] && desc[0] != char(-1))
+            m_spec.attribute("ImageDescription", desc);
+    }
     m_spec.attribute("PixelAspectRatio",
                      m_dpx.header.AspectRatio(1)
                          ? (m_dpx.header.AspectRatio(0)
@@ -484,9 +486,12 @@ DPXInput::seek_subimage(int subimage, int miplevel)
         date[19] = 0;
         m_spec.attribute("dpx:SourceDateTime", date);
     }
-    m_dpx.header.FilmEdgeCode(buf);
-    if (buf[0])
-        m_spec.attribute("dpx:FilmEdgeCode", buf);
+    {
+        char filmedge[17];
+        m_dpx.header.FilmEdgeCode(filmedge);
+        if (filmedge[0])
+            m_spec.attribute("dpx:FilmEdgeCode", filmedge);
+    }
 
     tmpstr.clear();
     switch (m_dpx.header.Signal()) {

--- a/testsuite/cineon/ref/out.txt
+++ b/testsuite/cineon/ref/out.txt
@@ -1,0 +1,31 @@
+Reading ../oiio-images/cineon/test.cin
+../oiio-images/cineon/test.cin :  800 x  600, 3 channel, uint8 cineon
+    SHA-1: 7AC3FF4F83F4EB4BDCD903E3378BDFD697E5BEF9
+    channel list: I, I2, I3
+    DateTime: "2020:02:09 15:33:48UTC"
+    Orientation: 1 (normal)
+    cineon:BitDepth: 8, 8, 8
+    cineon:BluePrimary: 0.15, 0.06
+    cineon:FilmEdgeCode: "0000000000000000"
+    cineon:FramePosition: 0
+    cineon:FrameRate: 0
+    cineon:GreenPrimary: 0.3, 0.6
+    cineon:HighData: 255, 255, 255
+    cineon:HighQuantity: 2.048, 2.048, 2.048
+    cineon:ImageDescriptor: "Grayscale", "Grayscale", "Grayscale"
+    cineon:LinesPerElement: 600, 600, 600
+    cineon:LowData: 0, 0, 0
+    cineon:LowQuantity: 0, 0, 0
+    cineon:Metric: 0, 0, 0
+    cineon:Packing: "32-bit boundary, left justified, at most one pixel per cell"
+    cineon:PixelsPerLine: 800, 800, 800
+    cineon:RedPrimary: 0.64, 0.33
+    cineon:SourceImageFileName: "abydos.cin"
+    cineon:Version: "V4.5"
+    cineon:WhitePoint: 0.3127, 0.329
+    cineon:XDevicePitch: 0
+    cineon:XOffset: 0
+    cineon:YDevicePitch: 0
+    cineon:YOffset: 0
+    oiio:BitsPerSample: 8
+    oiio:ColorSpace: "KodakLog"

--- a/testsuite/cineon/run.py
+++ b/testsuite/cineon/run.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+
+files = [ "test.cin" ]
+for f in files:
+    command += info_command ("../oiio-images/cineon/" + f)


### PR DESCRIPTION
* Add a test for cineon -- we never directly tested it before

* Don't compile code used only for writing. We don't supporting writing cineon, so there is no point compiling the cineon module used only for writing.

* And of course, once cineon was in the testsuite, we immediately found a problem via the sanitizers! So fix buffer overflows when reading FilmEdgeCode in Cineon.  (And clean but equally sloppy, but not buggy, code in DPX as well.)
