### PR TITLE
CI: Sonar analysis should exclude stb_sprintf.h

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -11,7 +11,7 @@ sonar.projectKey=OpenImageIO_oiio
 
 # Source properties
 sonar.sources=src
-sonar.exclusions=src/include/OpenImageIO/detail/pugixml/**
+sonar.exclusions=src/include/OpenImageIO/detail/pugixml/**,src/libutil/stb_sprintf.h
 sonar.sourceEncoding=UTF-8
 
 # C/C++ analyzer properties


### PR DESCRIPTION
It's not really "our code", and we use very little of that file, so it's not helpful to include it in coverage or other analysis.
