### PR TITLE
oiiotool: Add unit tests, minor internals utility refactoring

### DIFF
--- a/src/build-scripts/ci-test.bash
+++ b/src/build-scripts/ci-test.bash
@@ -7,7 +7,8 @@ set -ex
 : ${CTEST_EXCLUSIONS:="broken"}
 : ${CTEST_TEST_TIMEOUT:=180}
 
-$OpenImageIO_ROOT/bin/oiiotool --help || /bin/true
+$OpenImageIO_ROOT/bin/oiiotool --version --help || /bin/true
+$OpenImageIO_ROOT/bin/oiiotool --unittest --list-formats --runstats || /bin/true
 
 echo "Parallel test ${CTEST_PARALLEL_LEVEL}"
 echo "Default timeout ${CTEST_TEST_TIMEOUT}"


### PR DESCRIPTION
Add a hidden --unittest command to oiiotool, only functional for Debug builds, which enables additional testing of internal utility funcions and other things that are difficult to fully exercise in the testsuite from normal oiiotool commands (could be done, but would take tons of additional tests to get into particular deep edge cases).

Prototype by adding unit tests for scan_box. More will be added later now that the mechanism exists.

Simplify string_to_dataformat

Make sure to use --list-formats and --runstats during testing.
