### PR TITLE
Testing: optimize oiiotool-control test

### DIFF
--- a/testsuite/oiiotool-control/run.py
+++ b/testsuite/oiiotool-control/run.py
@@ -5,51 +5,52 @@
 # command += oiiotool ("--pattern constant:color=0.5,0.5,0.5 128x128 3 -d half -o grey128.exr")
 # command += oiiotool ("--pattern constant:color=0.5,0.5,0.5 64x64 3 -d half -o grey64.exr")
 # command += oiiotool ("--create 256x256 3 --fill:color=1,.5,.5 256x256 --fill:color=0,1,0 80x80+100+100 -d uint8 -o filled.tif")
-
+# wrapper_cmd = "time"
+# redirect = "2>&1"
 
 # test expression substitution
-command += oiiotool ('-echo "42+2 = {42+2}"')
-command += oiiotool ('-echo "42-2 = {42-2}"')
-command += oiiotool ('-echo "42*2 = {42*2}"')
-command += oiiotool ('-echo "42/2 = {42/2}"')
+command += oiiotool ('-echo "42+2 = {42+2}" ' +
+                     '-echo "42-2 = {42-2}" ' +
+                     '-echo "42*2 = {42*2}" ' +
+                     '-echo "42/2 = {42/2}"')
 
-command += oiiotool ('-echo "42<41 = {42<41}"')
-command += oiiotool ('-echo "42<42 = {42<42}"')
-command += oiiotool ('-echo "42<43 = {42<43}"')
-command += oiiotool ('-echo "42<=41 = {42<=41}"')
-command += oiiotool ('-echo "42<=42 = {42<=42}"')
-command += oiiotool ('-echo "42<=43 = {42<=43}"')
-command += oiiotool ('-echo "42>41 = {42>41}"')
-command += oiiotool ('-echo "42>42 = {42>42}"')
-command += oiiotool ('-echo "42>43 = {42>43}"')
-command += oiiotool ('-echo "42>=41 = {42>=41}"')
-command += oiiotool ('-echo "42>=42 = {42>=42}"')
-command += oiiotool ('-echo "42>=43 = {42>=43}"')
-command += oiiotool ('-echo "42==41 = {42==41}"')
-command += oiiotool ('-echo "42==42 = {42==42}"')
-command += oiiotool ('-echo "42==43 = {42==43}"')
-command += oiiotool ('-echo "42!=41 = {42!=41}"')
-command += oiiotool ('-echo "42!=42 = {42!=42}"')
-command += oiiotool ('-echo "42!=43 = {42!=43}"')
-command += oiiotool ('-echo "42<=>41 = {42<=>41}"')
-command += oiiotool ('-echo "42<=>42 = {42<=>42}"')
-command += oiiotool ('-echo "42<=>43 = {42<=>43}"')
+command += oiiotool ('-echo "42<41 = {42<41}" ' +
+                     '-echo "42<42 = {42<42}" ' +
+                     '-echo "42<43 = {42<43}" ' +
+                     '-echo "42<=41 = {42<=41}" ' +
+                     '-echo "42<=42 = {42<=42}" ' +
+                     '-echo "42<=43 = {42<=43}" ' +
+                     '-echo "42>41 = {42>41}" ' +
+                     '-echo "42>42 = {42>42}" ' +
+                     '-echo "42>43 = {42>43}" ' +
+                     '-echo "42>=41 = {42>=41}" ' +
+                     '-echo "42>=42 = {42>=42}" ' +
+                     '-echo "42>=43 = {42>=43}" ' +
+                     '-echo "42==41 = {42==41}" ' +
+                     '-echo "42==42 = {42==42}" ' +
+                     '-echo "42==43 = {42==43}" ' +
+                     '-echo "42!=41 = {42!=41}" ' +
+                     '-echo "42!=42 = {42!=42}" ' +
+                     '-echo "42!=43 = {42!=43}" ' +
+                     '-echo "42<=>41 = {42<=>41}" ' +
+                     '-echo "42<=>42 = {42<=>42}" ' +
+                     '-echo "42<=>43 = {42<=>43}" ')
 
-command += oiiotool ('-echo "(1==2)&&(2==2) = {(1==2)&&(2==2)}"')
-command += oiiotool ('-echo "(1==1)&&(2==2) = {(1==1)&&(2==2)}"')
-command += oiiotool ('-echo "(1==2)&&(1==2) = {(1==2)&&(1==2)}"')
-command += oiiotool ('-echo "(1==2)||(2==2) = {(1==2)||(2==2)}"')
-command += oiiotool ('-echo "(1==1)||(2==2) = {(1==1)||(2==2)}"')
-command += oiiotool ('-echo "(1==2)||(1==2) = {(1==2)||(1==2)}"')
-command += oiiotool ('-echo "not(1==1) = {not(1==1)}"')
-command += oiiotool ('-echo "not(1==2) = {not(1==2)}"')
-command += oiiotool ('-echo "!(1==1) = {!(1==1)}"')
-command += oiiotool ('-echo "!(1==2) = {!(1==2)}"')
+command += oiiotool ('-echo "(1==2)&&(2==2) = {(1==2)&&(2==2)}" ' +
+                     '-echo "(1==1)&&(2==2) = {(1==1)&&(2==2)}" ' +
+                     '-echo "(1==2)&&(1==2) = {(1==2)&&(1==2)}" ' +
+                     '-echo "(1==2)||(2==2) = {(1==2)||(2==2)}" ' +
+                     '-echo "(1==1)||(2==2) = {(1==1)||(2==2)}" ' +
+                     '-echo "(1==2)||(1==2) = {(1==2)||(1==2)}" ' +
+                     '-echo "not(1==1) = {not(1==1)}" ' +
+                     '-echo "not(1==2) = {not(1==2)}" ' +
+                     '-echo "!(1==1) = {!(1==1)}" ' +
+                     '-echo "!(1==2) = {!(1==2)}"')
 
-command += oiiotool ('-echo "eq(foo,foo) = {eq(\'foo\',\'foo\')}"')
-command += oiiotool ('-echo "eq(foo,bar) = {eq(\'foo\',\'bar\')}"')
-command += oiiotool ('-echo "neq(foo,foo) = {neq(\'foo\',\'foo\')}"')
-command += oiiotool ('-echo "neq(foo,bar) = {neq(\'foo\',\'bar\')}"')
+command += oiiotool ('-echo "eq(foo,foo) = {eq(\'foo\',\'foo\')}" ' +
+                     '-echo "eq(foo,bar) = {eq(\'foo\',\'bar\')}" ' +
+                     '-echo "neq(foo,foo) = {neq(\'foo\',\'foo\')}" ' +
+                     '-echo "neq(foo,bar) = {neq(\'foo\',\'bar\')}"')
 
 command += oiiotool ('-echo "16+5={16+5}" -echo "16-5={16-5}" -echo "16*5={16*5}"')
 command += oiiotool ('-echo "16/5={16/5}" -echo "16//5={16//5}" -echo "16%5={16%5}"')

--- a/testsuite/runtest.py
+++ b/testsuite/runtest.py
@@ -44,6 +44,7 @@ OIIO_BUILD_ROOT = path
 tmpdir = "."
 tmpdir = os.path.abspath (tmpdir)
 redirect = " >> out.txt "
+wrapper_cmd = ""
 
 def make_relpath (path, start=os.curdir):
     "Wrapper around os.path.relpath which always uses '/' as the separator."
@@ -202,9 +203,12 @@ def run_app(app, silent=False, concat=True):
 
 def oiio_app (app):
     if (platform.system () != 'Windows' or options.devenv_config == ""):
-        return os.path.join(OIIO_BUILD_ROOT, "bin", app) + " "
+        cmd = os.path.join(OIIO_BUILD_ROOT, "bin", app) + " "
     else:
-        return os.path.join(OIIO_BUILD_ROOT, "bin", options.devenv_config, app) + " "
+        cmd = os.path.join(OIIO_BUILD_ROOT, "bin", options.devenv_config, app) + " "
+    if wrapper_cmd != "":
+        cmd = wrapper_cmd + " " + cmd
+    return cmd
 
 
 # Construct a command that will print info for an image, appending output to


### PR DESCRIPTION
This test was taking almost 30 seconds to run, without a lot of images being read or written. Turns out it was just a large number of separate oiiotool invocations, and the overhead of all those shells and programs launched adds up. Most of them were just firing up oiiotool for the sake of doing an `--echo` to print things. A little bit of restructuring to make fewer oiiotool invocations (each one doing a bunch of echo commands, each testing a different thing) cuts the time for the whole test by 50%.

I also made the runtest.py script allow certain test debugging by letting a test set the `wrapper_cmd`, and if so, will prepend every oiio utility launch with it. For example, a test could say `wrapper_cmd='time'` to time every command.
