### PR TITLE
CI: eliminate xxhash and farmhash code from coverage analysis

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -11,7 +11,7 @@ sonar.projectKey=OpenImageIO_oiio
 
 # Source properties
 sonar.sources=src
-sonar.exclusions=src/include/OpenImageIO/detail/pugixml/**,src/libutil/stb_sprintf.h
+sonar.exclusions=src/include/OpenImageIO/detail/pugixml/**,src/libutil/stb_sprintf.h,src/libutil/xxhash.cpp,src/include/OpenImageIO/detail/farmhash.h,src/libutil/farmhash.cpp
 sonar.sourceEncoding=UTF-8
 
 # C/C++ analyzer properties


### PR DESCRIPTION
Because we're not the originators of the code and we use only a tiny subset of what's in those files.

