### PR TITLE
Improve oiiotool test coverage

### DIFF
--- a/testsuite/oiiotool-attribs/ref/out-jpeg9d.txt
+++ b/testsuite/oiiotool-attribs/ref/out-jpeg9d.txt
@@ -53,6 +53,9 @@ noattribs.jpg        : 2048 x 1536, 3 channel, uint8 jpeg
     Exif:FlashPixVersion: "0100"
     jpeg:subsampling: "4:2:0"
     oiio:ColorSpace: "sRGB"
+initial keywords=
+after adding, keywords=foo; bar
+after clearing, keywords=
 Reading attrib2.exr
 attrib2.exr          :   64 x   64, 3 channel, half openexr
     2 subimages: 64x64 [h,h,h], 64x64 [h,h,h]

--- a/testsuite/oiiotool-attribs/ref/out.txt
+++ b/testsuite/oiiotool-attribs/ref/out.txt
@@ -53,6 +53,9 @@ noattribs.jpg        : 2048 x 1536, 3 channel, uint8 jpeg
     Exif:FlashPixVersion: "0100"
     jpeg:subsampling: "4:2:0"
     oiio:ColorSpace: "sRGB"
+initial keywords=
+after adding, keywords=foo; bar
+after clearing, keywords=
 Reading attrib2.exr
 attrib2.exr          :   64 x   64, 3 channel, half openexr
     2 subimages: 64x64 [h,h,h], 64x64 [h,h,h]

--- a/testsuite/oiiotool-attribs/run.py
+++ b/testsuite/oiiotool-attribs/run.py
@@ -18,6 +18,13 @@ command += info_command ("nogps.jpg", safematch=True)
 command += oiiotool (OIIO_TESTSUITE_IMAGEDIR+"/tahoe-gps.jpg --eraseattrib \".*\" -o noattribs.jpg")
 command += info_command ("noattribs.jpg", safematch=True)
 
+# Test keywords
+command += oiiotool ("../common/tahoe-tiny.tif --echo \"initial keywords={TOP[keywords]}\" " +
+                     "--keyword foo --keyword bar " +
+                     "--echo \"after adding, keywords={TOP[keywords]}\" " +
+                     "--clear-keywords " +
+                     "--echo \"after clearing, keywords={TOP[keywords]}\" ")
+
 # Test adding and erasing attribs to multiple subimages
 command += oiiotool ("--create 64x64 3 -dup --siappend " +
                      "--attrib:allsubimages=1 foo bar -d half -o attrib2.exr")

--- a/testsuite/oiiotool-control/ref/out.txt
+++ b/testsuite/oiiotool-control/ref/out.txt
@@ -48,9 +48,13 @@ timecode is 01:02:03:04
 2
 {3+4}
 4
-Testing --set:
+Testing --set, expr i:
   i = 1
   now i = 42
+Testing --set, expr var(i):
+  i = 1
+  now i = 42
+Expr getattribute(limits:channels) = 1024
 Testing if with true cond (expect output):
   inside if clause, i=42
   done
@@ -151,6 +155,9 @@ Stats FiniteCount: 12288 12288 12288
 Constant: No
 Monochrome: No
 
+Stack holds [0] = ../common/tahoe-small.tif, [1] = ../common/tahoe-tiny.tif
+filename=../common/tahoe-tiny.tif file_extension=.tif file_noextension=../common/tahoe-tiny
+MINCOLOR=0,0,0 MAXCOLOR=0.745098,1,1 AVGCOLOR=0.101942,0.216695,0.425293
 Comparing "exprgradient.tif" and "ref/exprgradient.tif"
 PASS
 Comparing "exprcropped.tif" and "ref/exprcropped.tif"

--- a/testsuite/oiiotool-control/run.py
+++ b/testsuite/oiiotool-control/run.py
@@ -69,7 +69,11 @@ command += oiiotool ("-create 16x16 3 -attrib smpte:TimeCode \"01:02:03:04\" -ec
 command += oiiotool ("-echo \"{1+1}\" --evaloff -echo \"{3+4}\" --evalon -echo \"{2*2}\"")
 
 # Test user variables
-command += oiiotool ('-echo "Testing --set:" -set i 1 -echo "  i = {i}" -set i "{i+41}" -echo "  now i = {i}"')
+command += oiiotool ('-echo "Testing --set, expr i:" -set i 1 -echo "  i = {i}" -set i "{i+41}" -echo "  now i = {i}"')
+command += oiiotool ('-echo "Testing --set, expr var(i):" -set i 1 -echo "  i = {var(i)}" -set i "{i+41}" -echo "  now i = {var(i)}"')
+
+# Test getattribute in an expression
+command += oiiotool ('-echo "Expr getattribute(\"limits:channels\") = {getattribute(\"limits:channels\")}"')
 
 # Test --if --else --endif
 command += oiiotool ('-echo "Testing if with true cond (expect output):" -set i 42 -if "{i}" -echo "  inside if clause, i={i}" -endif -echo "  done" -echo " "')
@@ -97,6 +101,14 @@ command += oiiotool ("../common/tahoe-tiny.tif --echo \"\\nBrief: {TOP.METABRIEF
 command += oiiotool ("../common/tahoe-tiny.tif --echo \"\\nMeta: {TOP.META}\"")
 command += oiiotool ("../common/tahoe-tiny.tif --echo \"\\nStats:\\n{TOP.STATS}\\n\"")
 
+# Test IMG[]
+command += oiiotool ("../common/tahoe-tiny.tif ../common/tahoe-small.tif " +
+                     "--echo \"Stack holds [0] = {IMG[0].filename}, [1] = {IMG[1].filename}\"")
+
+# Test some special attribute evaluation names
+command += oiiotool ("../common/tahoe-tiny.tif " +
+                     "--echo \"filename={TOP.filename} file_extension={TOP.file_extension} file_noextension={TOP.file_noextension}\" " +
+                     "--echo \"MINCOLOR={TOP.MINCOLOR} MAXCOLOR={TOP.MAXCOLOR} AVGCOLOR={TOP.AVGCOLOR}\"")
 
 
 # To add more tests, just append more lines like the above and also add

--- a/testsuite/oiiotool/run.py
+++ b/testsuite/oiiotool/run.py
@@ -209,7 +209,7 @@ command += oiiotool ("subimages-2.exr --sisplit -o subimage2.exr " +
                      "--pop -o subimage1.exr")
 command += oiiotool ("subimages-4.exr -cmul:subimages=0,2 0.5 -o subimage-individual.exr")
 
-# Test --statsnow
+# Test --printstats
 command += oiiotool ("../common/tahoe-tiny.tif --echo \"--printstats:\" --printstats")
 command += oiiotool ("../common/tahoe-tiny.tif --printstats:window=10x10+50+50 --echo \" \"")
 


### PR DESCRIPTION
* oiiotool tests for expressions var() and getattribute()

* Make sure we test oiiotool IMG[] expressions and several specific special attributes to retrieve.

* Add coverage of oiiotool --keyword and --clear-keywords
