### PR TITLE
Refactor font searching and add font getattribute queries

### DIFF
--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -2851,8 +2851,14 @@ inline bool attribute (string_view name, string_view val) {
 ///
 ///        "tiff:LIBTIFF 4.0.4;gif:gif_lib 4.2.3;openexr:OpenEXR 2.2.0"
 ///
-/// - string "timing_report"
-///         A string containing the report of all the log_times.
+/// - `string font_list`
+/// - `string font_file_list`
+/// - `string font_dir_list`
+///
+///   A semicolon-separated list of, respectively, all the fonts that
+///   OpenImageIO can find, all the font files that OpenImageIO can find (with
+///   full paths), and all the directories that OpenImageIO will search for
+///   fonts.  (Added in OpenImageIO 2.5)
 ///
 /// - `string hw:simd`
 /// - `string oiio:simd` (read-only)

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -46,7 +46,7 @@ int tiff_multithread(1);
 int dds_bc5normal(0);
 int limit_channels(1024);
 int limit_imagesize_MB(32 * 1024);
-ustring font_searchpath;
+ustring font_searchpath(Sysutil::getenv("OPENIMAGEIO_FONTS"));
 ustring plugin_searchpath(OIIO_DEFAULT_PLUGIN_SEARCHPATH);
 std::string format_list;         // comma-separated list of all formats
 std::string input_format_list;   // comma-separated list of readable formats
@@ -417,6 +417,18 @@ getattribute(string_view name, TypeDesc type, void* val)
         if (library_list.empty())
             pvt::catalog_all_plugins(plugin_searchpath.string());
         *(ustring*)val = ustring(library_list);
+        return true;
+    }
+    if (name == "font_dir_list" && type == TypeString) {
+        *(ustring*)val = ustring(Strutil::join(font_dirs(), ";"));
+        return true;
+    }
+    if (name == "font_file_list" && type == TypeString) {
+        *(ustring*)val = ustring(Strutil::join(font_file_list(), ";"));
+        return true;
+    }
+    if (name == "font_list" && type == TypeString) {
+        *(ustring*)val = ustring(Strutil::join(font_list(), ";"));
         return true;
     }
     if (name == "exr_threads" && type == TypeInt) {

--- a/src/libOpenImageIO/imageio_pvt.h.in
+++ b/src/libOpenImageIO/imageio_pvt.h.in
@@ -39,6 +39,9 @@ extern int openexr_core;
 extern int limit_channels;
 extern int limit_imagesize_MB;
 extern OIIO_UTIL_API int oiio_use_tbb; // This lives in libOpenImageIO_Util
+OIIO_API const std::vector<std::string>& font_dirs();
+OIIO_API const std::vector<std::string>& font_file_list();
+OIIO_API const std::vector<std::string>& font_list();
 
 
 // For internal use - use error() below for a nicer interface.


### PR DESCRIPTION
* Add OIIO::getattribute() queries for "font_list", "font_file_list", and "font_dir_list", which are, respectively, the lists of fonts that were found, the list of font files (full paths), and the list of directories it searched.  All return a single string that is a semicolon-separated list of the items.

* As a consequence of the new attributes, if you are curious to see the full inventory of fonts it can find, you can just query the attribute:

      oiiotool --echo "{getattribute(font_list)}"

* Some refactoring of the font inventory process (in imagebufalgo_draw.cpp) was necessary to achieve this.

* We now search for ".ttc" (TrueType collection) files, which we didn't notice before.

* We now search explicitly in share/fonts/OpenImageIO, which we neglected to do before, but found those fonts because we searched /share/fonts recursively.  In exchange, we now do not search the directories recursively, because that seems unwise for performance reasons.

* We pass the full testsuite, but it's possible that this change may fail to find fonts that were previously found because of the recusion. If that is the case, you should fix it by explicitly adding the deep directories with fonts to the search path specified in the environment variable `$OPENIMAGEIO_FONTS`.
