### PR TITLE
Strutil read_text_from_command, and limit size of read_text_file

### DIFF
--- a/src/include/OpenImageIO/filesystem.h
+++ b/src/include/OpenImageIO/filesystem.h
@@ -245,8 +245,19 @@ OIIO_UTIL_API int open (string_view path, int flags);
 
 /// Read the entire contents of the named text file (as a UTF-8 encoded
 /// filename) and place it in str, returning true on success, false on
-/// failure.
-OIIO_UTIL_API bool read_text_file (string_view filename, std::string &str);
+/// failure.  The optional size parameter gives the maximum amount to read
+/// (for memory safety) and defaults to 16MB. Set size to 0 for no limit
+/// (use at your own risk).
+OIIO_UTIL_API bool read_text_file(string_view filename, std::string &str,
+                                  size_t size = (1UL << 24));
+
+/// Run a command line process and capture its console output in `str`,
+/// returning true on success, false on failure.  The optional size parameter
+/// gives the maximum amount to read (for memory safety) and defaults to 16MB.
+/// Set size to 0 for no limit (use at your own risk).
+OIIO_UTIL_API bool read_text_from_command(string_view command,
+                                          std::string &str,
+                                          size_t size = (1UL << 24));
 
 /// Write the entire contents of the string `str` to the named file (UTF-8
 /// encoded), overwriting any prior contents of the file (if it existed),

--- a/src/libutil/filesystem_test.cpp
+++ b/src/libutil/filesystem_test.cpp
@@ -143,6 +143,39 @@ my_read_text_file(string_view filename)
 }
 
 
+inline std::string
+my_read_text_file(string_view filename, size_t size)
+{
+    std::string err;
+    std::string contents;
+    bool ok = Filesystem::read_text_file(filename, contents, size);
+    OIIO_CHECK_ASSERT(ok);
+    return contents;
+}
+
+
+inline std::string
+my_read_text_from_command(string_view filename)
+{
+    std::string err;
+    std::string contents;
+    bool ok = Filesystem::read_text_from_command(filename, contents);
+    OIIO_CHECK_ASSERT(ok);
+    return contents;
+}
+
+
+inline std::string
+my_read_text_from_command(string_view filename, size_t size)
+{
+    std::string err;
+    std::string contents;
+    bool ok = Filesystem::read_text_from_command(filename, contents, size);
+    OIIO_CHECK_ASSERT(ok);
+    return contents;
+}
+
+
 
 static void
 test_file_status()
@@ -162,7 +195,12 @@ test_file_status()
     std::cout << "Testing write_text_file\n";
     Filesystem::write_text_file("testfile4", testtext);
     OIIO_CHECK_EQUAL(my_read_text_file("testfile4"), testtext);
-
+    std::cout << "Testing read_text_file with size limit\n";
+    OIIO_CHECK_EQUAL(my_read_text_file("testfile", 10), "test\nfoo\nb");
+    std::cout << "Testing read_text_from_command\n";
+    OIIO_CHECK_EQUAL(my_read_text_from_command("cat testfile"), testtext);
+    std::cout << "Testing read_text_from_command with size limit\n";
+    OIIO_CHECK_EQUAL(my_read_text_from_command("cat testfile", 7), "test\nfo");
 
     std::cout << "Testing read_bytes:\n";
     char buf[3];


### PR DESCRIPTION
* Add an optional size parameter to read_text_file to limit the maximum size that will be allocated and read (default to a limit of 16MB).

* New read_text_from_command, similar use to read_text_file, but reads from the console output of a shell command.
