### PR TITLE
Strutil: trimmed_whitespace

### DIFF
--- a/src/include/OpenImageIO/strutil.h
+++ b/src/include/OpenImageIO/strutil.h
@@ -938,6 +938,14 @@ inline void trim_whitespace (string_view &str) noexcept {
     remove_trailing_whitespace(str);
 }
 
+/// Return the portion of str that is trimmed of any whitespace (space, tab,
+/// linefeed, cr) from both the front and back.
+inline string_view trimmed_whitespace (string_view str) noexcept {
+    skip_whitespace(str);
+    remove_trailing_whitespace(str);
+    return str;
+}
+
 /// If str's first character is c (or first non-whitespace char is c, if
 /// skip_whitespace is true), return true and additionally modify str to
 /// skip over that first character if eat is also true. Otherwise, if str

--- a/src/libutil/strutil_test.cpp
+++ b/src/libutil/strutil_test.cpp
@@ -1270,6 +1270,18 @@ void test_parse ()
     s = "\tfoo\t"; remove_trailing_whitespace(s);  OIIO_CHECK_EQUAL (s, "\tfoo");
     s = "  foo  "; remove_trailing_whitespace(s);  OIIO_CHECK_EQUAL (s, "  foo");
 
+    s = "";        trim_whitespace(s);  OIIO_CHECK_EQUAL (s, "");
+    s = "   ";     trim_whitespace(s);  OIIO_CHECK_EQUAL (s, "");
+    s = "foo";     trim_whitespace(s);  OIIO_CHECK_EQUAL (s, "foo");
+    s = "\tfoo\t"; trim_whitespace(s);  OIIO_CHECK_EQUAL (s, "foo");
+    s = "  foo  "; trim_whitespace(s);  OIIO_CHECK_EQUAL (s, "foo");
+   
+    OIIO_CHECK_EQUAL(trimmed_whitespace(""),        "");
+    OIIO_CHECK_EQUAL(trimmed_whitespace("   "),     "");
+    OIIO_CHECK_EQUAL(trimmed_whitespace("foo"),     "foo");
+    OIIO_CHECK_EQUAL(trimmed_whitespace("\tfoo\t"), "foo");
+    OIIO_CHECK_EQUAL(trimmed_whitespace("  foo  "), "foo");
+   
     s = "abc"; OIIO_CHECK_ASSERT (! parse_char (s, 'd') && s == "abc");
 
     s = "abc"; OIIO_CHECK_ASSERT (parse_char (s, 'a', true, false) && s == "abc");


### PR DESCRIPTION
It's similar to trim_whitespace, but returns the trimmed result, rather than operating in-place on a `string_view&`.

Also add unit testing of trim_whitespace and trimmed_whitespace
