### PR TITLE
oiiotool: --printinfo improvements to fix mem vs file ambiguities

### DIFF
--- a/src/doc/oiiotool.rst
+++ b/src/doc/oiiotool.rst
@@ -131,18 +131,24 @@ contents of an expression may be any of:
     `ImageDescription`, or `width`)
   * `filename` : the name of the file (e.g., `foo.tif`)
   * `file_extension` : the extension of the file (e.g., `tif`)
-  * `geom` : the pixel data size in the form `640x480+0+0`)
   * `full_geom` : the "full" or "display" size)
+  * `full_geom` : the "full" or "display" size)
+  * `geom` : the pixel data size in the form `640x480+0+0`)
+  * `nativeformat` : the pixel data type from the file.
   * `MINCOLOR` : the minimum value in each channel (channels are
     comma-separated)
   * `MAXCOLOR` : the maximum value in each channel (channels are
     comma-separated)
   * `AVGCOLOR` : the average pixel value of the image (channels are
     comma-separated)
-  * `METABRIEF` : a string containing the brief one-line description that
-    would be printed with `oiiotool -info`.
-  * `META` : a multi-line string containing the full metadata that would
-    be printed with `oiiotool -info -v`.
+  * `META` : a multi-line string containing the full metadata of the image,
+    similar to what would be printed with `oiiotool -info -v`.
+  * `METABRIEF` : a string containing the brief one-line description,
+    similar to what would be printed that with `oiiotool -info`.
+  * `METANATIVE` : like `META`, but for the "native" original information from
+    when the file was read from disk.
+  * `METANATIVEBRIEF` : like `METABRIEF`, but for the "native" original
+    information from when the file was read from disk.
   * `STATS` : a multi-line string containing the image statistics that would
     be printed with `oiiotool -stats`.
 
@@ -1364,7 +1370,7 @@ Writing images
     
       `:type=` *name*
         Set the pixel data type (like `-d`) for this output image (e.g.,
-        `:uint8`, `uint16`, `half`, `float`, etc.).
+        `uint8`, `uint16`, `half`, `float`, etc.).
       `:bits=` *int*
         Set the bits per pixel (if nonstandard for the datatype) for this
         output image.
@@ -1654,11 +1660,40 @@ Writing images
 
 .. option:: --printinfo
 
-    Prints information and all metadata about the current image.
+    Prints information and all metadata about the current (top) image. This
+    behavior is similar to invoking oiiotool with :option:`--info -v`, but it
+    applies immediately to the current top image, even if it is a "computed"
+    image (whereas :option:`--info` only applies to images as they are read
+    from disk).
+
+    Optional appended modifiers include:
+
+    - `:allsubimages=` *int*
+        If nonzero, stats will be printed about all subimages of the current
+        image. (The default is given by whether or not the `-a` option was
+        used.)
+
+    - `:native=1`
+        Print metadata reflecting the "native" image as it was originally
+        read from disk. This may have a data type, tile size, or other
+        items that differ from the current in-memory representation of
+        the image.
+
+    - `:stats=1`
+        Print statistics about the image (much like the :option:`--stats`
+        command).
+
+    - `:verbose=0`
+        Overrides the default verbosity (1, on) with a less verbose output.
+
 
 .. option:: --printstats
 
-    Prints detailed statistical information about the current image.
+    Prints detailed statistical information about the current image. This
+    behavior is similar to invoking oiiotool with :option:`--stats`, but it
+    applies immediately to the current top image, even if it is a "computed"
+    image (whereas :option:`--stats` only applies to images as they are read
+    from disk).
 
     Optional appended modifiers include:
 
@@ -1674,8 +1709,8 @@ Writing images
 
     - `:allsubimages=` *int*
         If nonzero, stats will be printed about all subimages of the current
-        image. (The default is zero, meaning that stats will only be printed for
-        the first subimage of the current image.)
+        image. (The default is given by whether or not the `-a` option was
+        used.)
 
 .. option:: --colorcount r1,g1,b1,...:r2,g2,b2,...:...
 

--- a/src/libutil/paramlist_test.cpp
+++ b/src/libutil/paramlist_test.cpp
@@ -265,6 +265,7 @@ test_paramlist()
     OIIO_CHECK_EQUAL(pl.get_int("bar"), 0);
     OIIO_CHECK_EQUAL(pl.get_int("bar"), 0);
     OIIO_CHECK_EQUAL(pl.get_string("bar"), "barbarbar?");
+    OIIO_CHECK_EQUAL(pl.get_string("foo"), "42");
     OIIO_CHECK_ASSERT(pl.find("foo") != pl.cend());
     OIIO_CHECK_ASSERT(pl.find("Foo") == pl.cend());
     OIIO_CHECK_ASSERT(pl.find("Foo", TypeDesc::UNKNOWN, false) != pl.cend());

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -56,6 +56,7 @@ struct print_info_options {
     bool dumpdata           = false;
     bool dumpdata_showempty = true;
     bool dumpdata_C         = false;
+    bool native             = false;
     std::string dumpdata_C_name;
     std::string metamatch;
     std::string nometamatch;

--- a/src/oiiotool/printinfo.cpp
+++ b/src/oiiotool/printinfo.cpp
@@ -818,11 +818,11 @@ OiioTool::print_info(std::ostream& out, Oiiotool& ot, ImageRec* img,
         }
     }
 
-    // checking how many subimages and mipmap levels are stored in the file
     for (int s = 0, nsubimages = img->subimages(); s < nsubimages; ++s) {
         print_info_subimage(out, ot, s, nsubimages, img->miplevels(s),
-                            *img->spec(s), img, nullptr, "", opt, field_re,
-                            field_exclude_re, serformat, verbose);
+                            opt.native ? *img->nativespec(s) : *img->spec(s),
+                            img, nullptr, "", opt, field_re, field_exclude_re,
+                            serformat, verbose);
         // If opt.subimages is not set, we print info about first subimage
         // only.
         if (!opt.subimages)

--- a/testsuite/oiiotool-control/ref/out.txt
+++ b/testsuite/oiiotool-control/ref/out.txt
@@ -131,7 +131,9 @@ Sequence -5--2:  -2
 
 Brief:  128 x   96, 3 channel, float tiff
 
-Meta:  128 x   96, 3 channel, float tiff
+Brief native:  128 x   96, 3 channel, uint8 tiff
+
+Meta native:  128 x   96, 3 channel, uint8 tiff
     channel list: R, G, B
     compression: "lzw"
     DateTime: "2013:04:16 10:20:35"
@@ -162,6 +164,18 @@ Monochrome: No
 Stack holds [0] = ../common/tahoe-small.tif, [1] = ../common/tahoe-tiny.tif
 filename=../common/tahoe-tiny.tif file_extension=.tif file_noextension=../common/tahoe-tiny
 MINCOLOR=0,0,0 MAXCOLOR=0.745098,1,1 AVGCOLOR=0.101942,0.216695,0.425293
+postponed sub:
+ 128 x   96, 3 channel, float 
+    Stats Min: 0.000000 0.000000 0.000000 (float)
+    Stats Max: 0.000000 0.000000 0.000000 (float)
+    Stats Avg: 0.000000 0.000000 0.000000 (float)
+    Stats StdDev: 0.000000 0.000000 0.000000 (float)
+    Stats NanCount: 0 0 0 
+    Stats InfCount: 0 0 0 
+    Stats FiniteCount: 12288 12288 12288 
+    Constant: Yes
+    Constant Color: 0.000000 0.000000 0.000000 (float)
+    Monochrome: Yes
 Comparing "exprgradient.tif" and "ref/exprgradient.tif"
 PASS
 Comparing "exprcropped.tif" and "ref/exprcropped.tif"

--- a/testsuite/oiiotool-control/run.py
+++ b/testsuite/oiiotool-control/run.py
@@ -107,9 +107,11 @@ command += oiiotool ("--frames -5-5 --echo \"Sequence -5-5:  {FRAME_NUMBER}\"")
 command += oiiotool ("--frames -5--2 --echo \"Sequence -5--2:  {FRAME_NUMBER}\"")
 
 # Test stats and metadata expression substitution
-command += oiiotool ("../common/tahoe-tiny.tif --echo \"\\nBrief: {TOP.METABRIEF}\"")
-command += oiiotool ("../common/tahoe-tiny.tif --echo \"\\nMeta: {TOP.META}\"")
-command += oiiotool ("../common/tahoe-tiny.tif --echo \"\\nStats:\\n{TOP.STATS}\\n\"")
+command += oiiotool ("../common/tahoe-tiny.tif"
+                     + " --echo \"\\nBrief: {TOP.METABRIEF}\""
+                     + " --echo \"\\nBrief native: {TOP.METANATIVEBRIEF}\""
+                     + " --echo \"\\nMeta native: {TOP.METANATIVE}\""
+                     + " --echo \"\\nStats:\\n{TOP.STATS}\\n\"")
 
 # Test IMG[]
 command += oiiotool ("../common/tahoe-tiny.tif ../common/tahoe-small.tif " +
@@ -120,6 +122,10 @@ command += oiiotool ("../common/tahoe-tiny.tif " +
                      "--echo \"filename={TOP.filename} file_extension={TOP.file_extension} file_noextension={TOP.file_noextension}\" " +
                      "--echo \"MINCOLOR={TOP.MINCOLOR} MAXCOLOR={TOP.MAXCOLOR} AVGCOLOR={TOP.AVGCOLOR}\"")
 
+# Test "postpone_callback" with an "image -BINOP image" operation instead of
+# "image image -BINOP".
+command += oiiotool ("../common/tahoe-tiny.tif -sub ../common/tahoe-tiny.tif "
+                     + "-echo \"postponed sub:\" --printinfo:stats=1:verbose=0")
 
 # To add more tests, just append more lines like the above and also add
 # the new 'feature.tif' (or whatever you call it) to the outputs list,

--- a/testsuite/oiiotool-copy/ref/out.txt
+++ b/testsuite/oiiotool-copy/ref/out.txt
@@ -14,6 +14,10 @@ copy with explicit -d uint16 result:
 copy_uint16.tif      :  128 x  128, 3 channel, uint16 tiff
     tile size: 16 x 16
 
+copy with -o:type=uint16 result: 
+ 128 x  128, 3 channel, uint16 tiff
+copy with -o:datatype=uint16 result: 
+ 128 x  128, 3 channel, uint16 tiff
 siappend result: 
 tmp.tif              :  128 x  128, 3 channel, uint8 tiff
     tile size: 16 x 16

--- a/testsuite/oiiotool-copy/run.py
+++ b/testsuite/oiiotool-copy/run.py
@@ -32,6 +32,13 @@ command += oiiotool ("uint8.tif -o tmp.tif " +
 # Copy with explicit data request should change data type
 command += oiiotool ("uint8.tif -d uint16 -o copy_uint16.tif " +
                      "-echo \"copy with explicit -d uint16 result: \" -metamatch \"width|tile\" -i:info=2 copy_uint16.tif -echo \"\"")
+# Copy with data request in the -o
+command += oiiotool ("uint8.tif -o:type=uint16 copy_uint16-o.tif " +
+                     "-i copy_uint16-o.tif " +
+                     "-echo \"copy with -o:type=uint16 result: \" -printinfo:native=1:verbose=0")
+command += oiiotool ("uint8.tif -o:datatype=uint16 copy_uint16-o.tif " +
+                     "-i copy_uint16-o.tif " +
+                     "-echo \"copy with -o:datatype=uint16 result: \" -printinfo:native=1:verbose=0")
 # Subimage concatenation should preserve data type
 command += oiiotool ("uint8.tif copy_uint16.tif -siappend -o tmp.tif " +
                      "-echo \"siappend result: \" -metamatch \"width|tile\" -i:info=2 tmp.tif -echo \"\"")

--- a/testsuite/oiiotool/run.py
+++ b/testsuite/oiiotool/run.py
@@ -210,8 +210,8 @@ command += oiiotool ("subimages-2.exr --sisplit -o subimage2.exr " +
 command += oiiotool ("subimages-4.exr -cmul:subimages=0,2 0.5 -o subimage-individual.exr")
 
 # Test --printstats
-command += oiiotool ("../common/tahoe-tiny.tif --echo \"--printstats:\" --printstats")
-command += oiiotool ("../common/tahoe-tiny.tif --printstats:window=10x10+50+50 --echo \" \"")
+command += oiiotool ("../common/tahoe-tiny.tif --echo \"--printstats:\" --printstats:native=1")
+command += oiiotool ("../common/tahoe-tiny.tif --printstats:natve=1:window=10x10+50+50 --echo \" \"")
 
 # test --iconfig
 command += oiiotool ("--info -v -metamatch Debug --iconfig oiio:DebugOpenConfig! 1 " +


### PR DESCRIPTION
It surprised me a little to realize that --printinfo prints the current spec of the top image (I mean, duh), but that may not match what you'd get with `oiiotool -info -v`, which prints the data about each file as it's read from disk, inasmuch as the "current" spec reflects the in-memory representation. So, for example, it might say the image is float, because oiiotool tends to store everything in-memory as float, rather than uint8 of the disk file.

So these changes help fix this oddity and other ambiguities I realized follow:

* Give --printinfo an optional modifier `:native=1` that will print the native (from the original file) info, if that's what you need, rather than the up-to-the-moment in-memory data.

* Also add --printinfo optional modifiers `:verbose=` and `:stats=`.

* Expression substitution gets some new names it knows: "nativeformat" is the data type in the file, versus "format" which I now see would return the in-memory version; METANATIVE and METANDATIVEBRIEF, which are the native versions of META and METABRIEF.
