### PR TITLE
CMake: also find jconfig.h from libturbojpeg from arch-specific include directory

### DIFF
--- a/src/cmake/modules/FindJPEGTurbo.cmake
+++ b/src/cmake/modules/FindJPEGTurbo.cmake
@@ -29,7 +29,22 @@ endif ()
 if (JPEG_INCLUDE_DIR AND JPEG_LIBRARY)
   set (JPEG_INCLUDE_DIRS ${JPEG_INCLUDE_DIR} CACHE PATH "JPEG include dirs")
   set (JPEG_LIBRARIES ${JPEG_LIBRARY} CACHE STRING "JPEG libraries")
-  file(STRINGS "${JPEG_INCLUDE_DIR}/jconfig.h"
+
+  find_path(jconfig_header_file jconfig.h PATHS "${JPEG_INCLUDE_DIR}")
+
+  if (NOT jconfig_header_file)
+    file(GLOB_RECURSE jconfig_header_file_list "${JPEG_INCLUDE_DIR}/*/jconfig.h")
+
+    if (jconfig_header_file_list)
+      list(GET jconfig_header_file_list 0 jconfig_header_file)
+    endif()
+
+    if (NOT jconfig_header_file)
+      message(WARNING "Cannot find jconfig.h from libturbojpeg")
+    endif()
+  endif()
+
+  file(STRINGS "${jconfig_header_file}"
                 jpeg_lib_version REGEX "^#define[\t ]+JPEG_LIB_VERSION[\t ]+.*")
   if (jpeg_lib_version)
       string(REGEX REPLACE "^#define[\t ]+JPEG_LIB_VERSION[\t ]+([0-9]+).*"


### PR DESCRIPTION
## Description

This header file is architecture-dependent and can be stored as:

- `/usr/include/i386-linux-gnu/jconfig.h`
- `/usr/include/x86_64-linux-gnu/jconfig.h`

Instead of:

- `/usr/include/jconfig.h`

That fixes build errors like this:

```
CMake Error at src/cmake/modules/FindJPEGTurbo.cmake:32 (file):
  file STRINGS file "/usr/include/jconfig.h" cannot be read.
Call Stack (most recent call first):
  src/cmake/checked_find_package.cmake:127 (find_package)
  src/cmake/externalpackages.cmake:139 (checked_find_package)
  CMakeLists.txt:155 (include)
```
## Checklist:

- [x] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [x] ~~If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-CORPORATE)).~~   
  This change is too small and not original enough to be subject to copyright.
- [x] ~~I have updated the documentation, if applicable.~~  
  Not applicable.
- [x] ~~I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).~~  
  Not applicable.
- [x] My code follows the prevailing code style of this project.

