### PR TITLE
CI: adjust when workflows are run to cut needless CI runs

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -22,6 +22,11 @@ on:
 
 permissions: read-all
 
+# Allow subsequent pushes to the same PR or REF to cancel any previous jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 
 jobs:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ on:
   schedule:
     # Full nightly build
     - cron: "0 8 * * *"
+      if: github.repository == 'OpenImageIO/oiio'
 
 permissions: read-all
 

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -14,9 +14,16 @@ on:
 # Declare default permissions as read only.
 permissions: read-all
 
+# Allow subsequent pushes to the same PR or REF to cancel any previous jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+
 jobs:
   analysis:
     name: Scorecards analysis
+    if: github.repository == 'OpenImageIO/oiio'
     runs-on: ubuntu-latest
     permissions:
       # Needed to upload the results to code-scanning dashboard.


### PR DESCRIPTION
Changes:

* Scorecards and analysis -- allow newly launched job to cancel running old job from the same PR.

* Scorecard only runs on main repo, no need to run on forks.

* Nightly CI only runs on main repo, no need to run on forks.
