### PR TITLE
oiiotool testing and minor subimage/miplevel fixes

### DIFF
--- a/src/build-scripts/ci-test.bash
+++ b/src/build-scripts/ci-test.bash
@@ -7,12 +7,26 @@ set -ex
 : ${CTEST_EXCLUSIONS:="broken"}
 : ${CTEST_TEST_TIMEOUT:=180}
 
-$OpenImageIO_ROOT/bin/oiiotool --version --help || /bin/true
-
-# Catch-all of some unit tests and args that aren't used elsewhere
+#
+# Try a few command line options to test them and also get some important
+# debugging info in the CI logs.
+#
+echo ; echo "Results of oiiotool --version:"
+$OpenImageIO_ROOT/bin/oiiotool --version || true
+echo ; echo "Results of oiiotool --help:"
+$OpenImageIO_ROOT/bin/oiiotool --help || true
+echo ; echo "Results of oiiotool with no args (should get short help message):"
+$OpenImageIO_ROOT/bin/oiiotool || true
+echo ; echo "Run unit tests and simple stats:"
 $OpenImageIO_ROOT/bin/oiiotool --unittest --list-formats --threads 0 \
-                 --cache 1000 --autotile --autopremult --runstats || /bin/true
+                 --cache 1000 --autotile --autopremult --runstats || true
+echo ; echo "Try unknown command:"
+$OpenImageIO_ROOT/bin/oiiotool -q --unknown || true
 
+
+#
+# Full test suite
+#
 echo "Parallel test ${CTEST_PARALLEL_LEVEL}"
 echo "Default timeout ${CTEST_TEST_TIMEOUT}"
 echo "Test exclusions '${CTEST_EXCLUSIONS}'"

--- a/src/oiiotool/imagerec.cpp
+++ b/src/oiiotool/imagerec.cpp
@@ -60,12 +60,24 @@ ImageRec::ImageRec(ImageRec& img, int subimage_to_copy, int miplevel_to_copy,
     , m_imagecache(img.m_imagecache)
 {
     img.read();
-    int first_subimage = std::max(0, subimage_to_copy);
+    if (subimage_to_copy >= img.subimages()) {
+        errorfmt("Selecting subimage {}, but there are only {} subimages",
+                 subimage_to_copy, img.subimages());
+        subimage_to_copy = img.subimages() - 1;
+    }
+    int first_subimage = clamp(subimage_to_copy, 0, img.subimages() - 1);
     int subimages      = (subimage_to_copy < 0) ? img.subimages() : 1;
     m_subimages.resize(subimages);
     for (int s = 0; s < subimages; ++s) {
-        int srcsub         = s + first_subimage;
-        int first_miplevel = std::max(0, miplevel_to_copy);
+        int srcsub = s + first_subimage;
+        if (miplevel_to_copy >= img.miplevels(srcsub)) {
+            errorfmt(
+                "Selecting MIP level {} of subimage {}, which has only {} MIP levels",
+                miplevel_to_copy, srcsub, img.miplevels(srcsub));
+            miplevel_to_copy = img.miplevels(srcsub) - 1;
+        }
+        int first_miplevel = clamp(miplevel_to_copy, 0,
+                                   img.miplevels(srcsub) - 1);
         int miplevels      = (miplevel_to_copy < 0) ? img.miplevels(srcsub) : 1;
         m_subimages[s].m_miplevels.resize(miplevels);
         m_subimages[s].m_specs.resize(miplevels);

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -74,6 +74,7 @@ class Oiiotool {
 public:
     // General options
     bool verbose;
+    bool quiet;
     bool debug;
     bool dryrun;
     bool runstats;

--- a/testsuite/oiiotool-control/ref/out.txt
+++ b/testsuite/oiiotool-control/ref/out.txt
@@ -118,6 +118,76 @@ Testing for i 5,10,2,8 (bad range):
 oiiotool ERROR: --for : Invalid range "5,10,2,8"
 Full command line was:
 > oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -echo "Testing for i 5,10,2,8 (bad range):" --for i 5,10,2,8 --echo "  i = {i}" --endfor -echo " "
+SEQUENCE 0
+  copyA.#.jpg -> ./copyA.0001.jpg
+  copyB.#.jpg -> copyB.0001.jpg
+Reading ./copyA.0001.jpg
+Output: copyB.0001.jpg
+Writing copyB.0001.jpg
+
+SEQUENCE 1
+  copyA.#.jpg -> ./copyA.0002.jpg
+  copyB.#.jpg -> copyB.0002.jpg
+Reading ./copyA.0002.jpg
+Output: copyB.0002.jpg
+Writing copyB.0002.jpg
+
+SEQUENCE 2
+  copyA.#.jpg -> ./copyA.0003.jpg
+  copyB.#.jpg -> copyB.0003.jpg
+Reading ./copyA.0003.jpg
+Output: copyB.0003.jpg
+Writing copyB.0003.jpg
+
+SEQUENCE 3
+  copyA.#.jpg -> ./copyA.0004.jpg
+  copyB.#.jpg -> copyB.0004.jpg
+Reading ./copyA.0004.jpg
+Output: copyB.0004.jpg
+Writing copyB.0004.jpg
+
+SEQUENCE 4
+  copyA.#.jpg -> ./copyA.0005.jpg
+  copyB.#.jpg -> copyB.0005.jpg
+Reading ./copyA.0005.jpg
+Output: copyB.0005.jpg
+Writing copyB.0005.jpg
+
+SEQUENCE 5
+  copyA.#.jpg -> ./copyA.0006.jpg
+  copyB.#.jpg -> copyB.0006.jpg
+Reading ./copyA.0006.jpg
+Output: copyB.0006.jpg
+Writing copyB.0006.jpg
+
+SEQUENCE 6
+  copyA.#.jpg -> ./copyA.0007.jpg
+  copyB.#.jpg -> copyB.0007.jpg
+Reading ./copyA.0007.jpg
+Output: copyB.0007.jpg
+Writing copyB.0007.jpg
+
+SEQUENCE 7
+  copyA.#.jpg -> ./copyA.0008.jpg
+  copyB.#.jpg -> copyB.0008.jpg
+Reading ./copyA.0008.jpg
+Output: copyB.0008.jpg
+Writing copyB.0008.jpg
+
+SEQUENCE 8
+  copyA.#.jpg -> ./copyA.0009.jpg
+  copyB.#.jpg -> copyB.0009.jpg
+Reading ./copyA.0009.jpg
+Output: copyB.0009.jpg
+Writing copyB.0009.jpg
+
+SEQUENCE 9
+  copyA.#.jpg -> ./copyA.0010.jpg
+  copyB.#.jpg -> copyB.0010.jpg
+Reading ./copyA.0010.jpg
+Output: copyB.0010.jpg
+Writing copyB.0010.jpg
+
 copyA.0001.jpg       :  128 x   96, 3 channel, uint8 jpeg
 copyA.0002.jpg       :  128 x   96, 3 channel, uint8 jpeg
 copyA.0003.jpg       :  128 x   96, 3 channel, uint8 jpeg
@@ -148,6 +218,10 @@ Sequence -5--2:  -5
 Sequence -5--2:  -4
 Sequence -5--2:  -3
 Sequence -5--2:  -2
+oiiotool WARNING : oiiotool produced no output. Did you forget -o?
+oiiotool ERROR : Not all sequence specifications matched: copyA.#.jpg (10 frames) vs. copyC.1-5#.jpg (5 frames)
+Full command line was:
+> 
 
 Brief:  128 x   96, 3 channel, float tiff
 

--- a/testsuite/oiiotool-control/run.py
+++ b/testsuite/oiiotool-control/run.py
@@ -108,10 +108,17 @@ command += oiiotool ('-echo "Testing for i 5,10,2,8 (bad range):" --for i 5,10,2
 
 # test sequences
 command += oiiotool ("../common/tahoe-tiny.tif -o copyA.1-10#.jpg")
+command += oiiotool ("--debug copyA.#.jpg -o copyB.#.jpg")
 command += oiiotool (" --info  " +  " ".join(["copyA.{0:04}.jpg".format(x) for x in range(1,11)]))
 command += oiiotool ("--frames 1-5 --echo \"Sequence 1-5:  {FRAME_NUMBER}\"")
 command += oiiotool ("--frames -5-5 --echo \"Sequence -5-5:  {FRAME_NUMBER}\"")
 command += oiiotool ("--frames -5--2 --echo \"Sequence -5--2:  {FRAME_NUMBER}\"")
+
+# Sequence errors:
+# No matching files found
+command += oiiotool ("notfound.#.jpg -o alsonotfound.#.jpg")
+# Ranges don't match
+command += oiiotool ("copyA.#.jpg -o copyC.1-5#.jpg")
 
 # Test stats and metadata expression substitution
 command += oiiotool ("../common/tahoe-tiny.tif"

--- a/testsuite/oiiotool-copy/ref/out.txt
+++ b/testsuite/oiiotool-copy/ref/out.txt
@@ -74,6 +74,8 @@ metamerge.exr        :   64 x   64, 6 channel, float openexr
     screenWindowWidth: 1
     oiio:ColorSpace: "Linear"
     oiio:subimages: 1
+Testing -o with no image
+oiiotool WARNING: -o : out.tif did not have any current image to output.
 Comparing "rgonly.exr" and "ref/rgonly.exr"
 PASS
 Comparing "ch-err.exr" and "ref/ch-err.exr"

--- a/testsuite/oiiotool-copy/run.py
+++ b/testsuite/oiiotool-copy/run.py
@@ -93,6 +93,9 @@ command += oiiotool ("--pattern constant:color=0.5 64x64 1 --text R --chnames R 
                      "--chappend:n=3 -d half -o chappend-3images.exr")
 
 
+# Interesting error cases
+command += oiiotool ("-echo \"Testing -o with no image\" -o out.tif")
+
 
 # Outputs to check against references
 outputs = [

--- a/testsuite/oiiotool-subimage/ref/out-oldfreetype.txt
+++ b/testsuite/oiiotool-subimage/ref/out-oldfreetype.txt
@@ -76,6 +76,14 @@ mip4.tif             :   64 x   64, 4 channel, uint8 tiff
     SHA-1: 7DB3F1E464C5F38CAAECE8ABC8684EC66FC9FA68
 unmip.tif            : 1024 x 1024, 4 channel, uint8 tiff
     SHA-1: 7DB3F1E464C5F38CAAECE8ABC8684EC66FC9FA68
+Select nonexistent subimage
+oiiotool ERROR: --subimage : Invalid -subimage (13): subimages-4.exr has 4 subimages
+Full command line was:
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -echo "Select nonexistent subimage" subimages-4.exr --subimage 13 -o subimage13.exr
+Select nonexistent MIP level
+oiiotool ERROR: --selectmip : Selecting MIP level 14 of subimage 0, which has only 11 MIP levels
+Full command line was:
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -echo "Select nonexistent MIP level" ../common/textures/grid.tx --selectmip 14 -o mip14.tif
 Comparing "subimages-2.exr" and "ref/subimages-2.exr"
 PASS
 Comparing "subimages-4.exr" and "ref/subimages-4-freetype2.7.exr"

--- a/testsuite/oiiotool-subimage/ref/out.txt
+++ b/testsuite/oiiotool-subimage/ref/out.txt
@@ -76,6 +76,14 @@ mip4.tif             :   64 x   64, 4 channel, uint8 tiff
     SHA-1: 7DB3F1E464C5F38CAAECE8ABC8684EC66FC9FA68
 unmip.tif            : 1024 x 1024, 4 channel, uint8 tiff
     SHA-1: 7DB3F1E464C5F38CAAECE8ABC8684EC66FC9FA68
+Select nonexistent subimage
+oiiotool ERROR: --subimage : Invalid -subimage (13): subimages-4.exr has 4 subimages
+Full command line was:
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -echo "Select nonexistent subimage" subimages-4.exr --subimage 13 -o subimage13.exr
+Select nonexistent MIP level
+oiiotool ERROR: --selectmip : Selecting MIP level 14 of subimage 0, which has only 11 MIP levels
+Full command line was:
+> oiiotool -colorconfig ../common/OpenColorIO/nuke-default/config.ocio -echo "Select nonexistent MIP level" ../common/textures/grid.tx --selectmip 14 -o mip14.tif
 Comparing "subimages-2.exr" and "ref/subimages-2.exr"
 PASS
 Comparing "subimages-4.exr" and "ref/subimages-4.exr"

--- a/testsuite/oiiotool-subimage/run.py
+++ b/testsuite/oiiotool-subimage/run.py
@@ -4,6 +4,9 @@
 # with changed freetype versions.
 failpercent *= 2.0
 
+redirect = " >> out.txt 2>&1 "
+failureok = 1
+
 # test subimages
 command += oiiotool ("--pattern constant:color=0.5,0.0,0.0 64x64 3 " +
                      "--pattern constant:color=0.0,0.5,0.0 64x64 3 " +
@@ -27,6 +30,12 @@ command += info_command ("mip4.tif", safematch=True)
 command += oiiotool ("../common/textures/grid.tx --unmip -o unmip.tif")
 command += info_command ("../common/textures/grid.tx", verbose=False)
 command += info_command ("unmip.tif", verbose=False)
+
+# Error cases
+command += oiiotool ("-echo \"Select nonexistent subimage\""
+                     + " subimages-4.exr --subimage 13 -o subimage13.exr")
+command += oiiotool ("-echo \"Select nonexistent MIP level\""
+                     + " ../common/textures/grid.tx --selectmip 14 -o mip14.tif")
 
 # Outputs to check against references
 outputs = [ 


### PR DESCRIPTION
* Add casual tests of oiiotool with no args (print brief usage message) and when an unknown command.

* Also changed the meaning of -q (quiet mode) to be more quiet -- in particular, not to print the full help message for errors when quiet mode is used, only print the error.

* oiiotool test sequence errors.

* Test (and fix) --selectmip and --subimage with out of range indices

