### PR TITLE
CMake: Adjust how version overrides work

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,14 @@
 
 cmake_minimum_required (VERSION 3.12)
 
-set (OpenImageIO_VERSION "2.5.0.0" CACHE STRING "Version")
+set (OpenImageIO_VERSION "2.5.0.0")
+set (OpenImageIO_VERSION_OVERRIDE "" CACHE STRING
+     "Version override (use with caution)!")
+mark_as_advanced (OpenImageIO_VERSION_OVERRIDE)
+if (OpenImageIO_VERSION_OVERRIDE)
+    set (OpenImageIO_VERSION ${OpenImageIO_VERSION_OVERRIDE})
+endif ()
+
 project (OpenImageIO VERSION ${OpenImageIO_VERSION}
          HOMEPAGE_URL "https://openimageio.org"
          LANGUAGES CXX C)


### PR DESCRIPTION
Kai Pastor (@dg0yt) made an important observation that the way I recently made OpenImageIO_VERSION be a cache variable (#3549) might lead to unexpeted behavior by inadvertently retaining a version number upon recompiles if the cache itself was not cleared, and this can happen unexpectedly even when the user isn't trying to override the version.

This patch changes the behavior as follows:

You must use the special `-DOpenImageIO_VERSION_OVERRIDE=...` to override the version.

  * if you do so, you are playing with fire and get what you deserve if you misuse it or change branches and don't remember to clear the cache.

If you do a normal build (without _trying_ to override the version),

  * you will get the real version number because it IS NOT cached
  * if you switch branches, you'll always get the right version number
  * ...but switching branches without clearing the cache can still, as always, have other subtle behavior differences versus doing a truly fresh build from scratch.

So in short, it still allows a way to override the version if you really want to, but if you are not trying to do that, you can no longer get yourself inadvertently into unexpected trouble.
