### PR TITLE
IOMemReader ctr should take const buffer pointer

### DIFF
--- a/src/include/OpenImageIO/filesystem.h
+++ b/src/include/OpenImageIO/filesystem.h
@@ -539,7 +539,7 @@ protected:
 /// IOProxy subclass for reading that wraps an cspan<char>.
 class OIIO_UTIL_API IOMemReader : public IOProxy {
 public:
-    IOMemReader(void* buf, size_t size)
+    IOMemReader(const void* buf, size_t size)
         : IOProxy("", Read)
         , m_buf((const unsigned char*)buf, size)
     {


### PR DESCRIPTION
The ctr is inline, so I don't think it breaks backwards link compatibility to make this change, so I do intend to backport it.
