### PR TITLE
Expose OIIO::Strutil::print in the main OIIO namespace

### DIFF
--- a/src/include/OpenImageIO/strutil.h
+++ b/src/include/OpenImageIO/strutil.h
@@ -1141,4 +1141,8 @@ edit_distance(string_view a, string_view b,
 
 }  // namespace Strutil
 
+
+// Bring the ever-useful Strutil::print into the OIIO namespace.
+using Strutil::print;
+
 OIIO_NAMESPACE_END


### PR DESCRIPTION
We use this all the time in our internals, and I'm tired of having to write Strutil::print. Too verbose. By putting it in the main OIIO namespace, OIIO internals can reference as simply print(), and external users now have a choice of saying Strutil::print() or OIIO::print().

