### PR TITLE
IFF output safety

### DIFF
--- a/src/iff.imageio/iff_pvt.h
+++ b/src/iff.imageio/iff_pvt.h
@@ -77,19 +77,17 @@ align_size(uint32_t size, uint32_t alignment)
 }
 
 // tile width
-inline const int&
+constexpr uint32_t
 tile_width()
 {
-    static int tile_w = 64;
-    return tile_w;
+    return 64;
 }
 
 // tile height
-inline const int&
+constexpr uint32_t
 tile_height()
 {
-    static int tile_h = 64;
-    return tile_h;
+    return 64;
 }
 
 // tile width size


### PR DESCRIPTION
* Maya IFF documentation says IFF file has max resolution of 8192, and our implementation only allows writing RGB and RGBA, so check these limits when an IFF file is opened for output.

* Make sure scratch space allocates enough for tile padding.

* Check for non-zero image origin coordinates (which are not allowed in IFF files).

* Change some 16-bit loop variables to uint32_t to avoid possible overflow.

Fixes TALOS-2022-1654, TALOS-2022-1655, TALOS-2022-1656
