### PR TITLE
avoid sanitizer warning unsigned integer overflow

### DIFF
--- a/src/include/OpenImageIO/string_view.h
+++ b/src/include/OpenImageIO/string_view.h
@@ -249,7 +249,7 @@ public:
     OIIO_CONSTEXPR17 int compare (basic_string_view x) const noexcept {
         // N.B. char_traits<char>::compare is constexpr for C++17
         const int cmp = traits_type::compare (m_chars, x.m_chars, (std::min)(m_len, x.m_len));
-        return cmp != 0 ? cmp : int(m_len - x.m_len);
+        return cmp != 0 ? cmp : int(m_len) - int(x.m_len);
         // Equivalent to:
         //  cmp != 0 ? cmp : (m_len == x.m_len ? 0 : (m_len < x.m_len ? -1 : 1));
     }


### PR DESCRIPTION
avoid sanitizer warning of unsigned integer overflow

src/Components/ExternalLibraries/OpenImageIO/install/include/OpenImageIO/string_view.h:252:43: runtime error: unsigned integer overflow: 0 - 17 cannot be represented in type 'unsigned long'
    #0 0x10d0adf61 in OpenImageIOMaya_v2_4::basic_string_view<char, std::__1::char_traits<char> >::compare(OpenImageIOMaya_v2_4::basic_string_view<char, std::__1::char_traits<char> >) const string_view.h:252


## Description

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-CORPORATE)).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

