### PR TITLE
Try to squash warning in gcc 12.1 + C++20

### DIFF
--- a/src/rla.imageio/rlainput.cpp
+++ b/src/rla.imageio/rlainput.cpp
@@ -330,7 +330,7 @@ RLAInput::seek_subimage(int subimage, int miplevel)
             m_spec.z_channel = z_channel;
             if (m_spec.channelnames.size() < size_t(z_channel + 1))
                 m_spec.channelnames.resize(z_channel + 1);
-            m_spec.channelnames[z_channel] = "Z";
+            m_spec.channelnames[z_channel] = std::string("Z");
         }
     }
     m_stride += m_rla.NumOfAuxChannels * aux_type.size();


### PR DESCRIPTION
This has been causing CI tests to fail.
There's something about gcc12 when using -std=c++20 that is making this line fail when assigning a char* versus a std::string into an element of a std::vector.

    