### PR TITLE
oiiotool --point fix problem when there's no alpha

### DIFF
--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -5065,7 +5065,7 @@ OIIOTOOL_OP(point, 1, [](OiiotoolOp& op, span<ImageBuf*> img) {
     const ImageSpec& Rspec(img[0]->spec());
     std::vector<int> points;
     Strutil::extract_from_list_string(points, op.args(1));
-    std::vector<float> color(Rspec.nchannels + 1, 1.0f);
+    std::vector<float> color(Rspec.nchannels, 1.0f);
     Strutil::extract_from_list_string(color, op.options().get_string("color"));
     bool ok = true;
     for (size_t i = 0, e = points.size() - 1; i < e; i += 2)


### PR DESCRIPTION
We were over-allocating the color vector, and that was throwing off the operation of IBA::render_point for cases where the image had no alpha channel.
