### PR TITLE
span minor improvements

### DIFF
--- a/src/include/OpenImageIO/detail/fmt.h
+++ b/src/include/OpenImageIO/detail/fmt.h
@@ -102,7 +102,7 @@ struct index_formatter : format_parser_with_separator {
     {
         std::string vspec = elem_fmt.size() ? fmt::format("{{:{}}}", elem_fmt)
                                             : std::string("{}");
-        for (size_t i = 0; i < v.size(); ++i) {
+        for (size_t i = 0; i < size_t(v.size()); ++i) {
             if (i)
                 fmt::format_to(ctx.out(), "{}", sep == ',' ? ", " : " ");
 #if FMT_VERSION >= 80000

--- a/src/include/OpenImageIO/span.h
+++ b/src/include/OpenImageIO/span.h
@@ -17,6 +17,7 @@
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/oiioversion.h>
 #include <OpenImageIO/platform.h>
+#include <OpenImageIO/detail/fmt.h>
 
 OIIO_NAMESPACE_BEGIN
 
@@ -219,8 +220,8 @@ private:
 
 
 /// cspan<T> is a synonym for a non-mutable span<const T>.
-template <typename T>
-using cspan = span<const T>;
+template <typename T, oiio_span_size_type Extent = dynamic_extent>
+using cspan = span<const T, Extent>;
 
 
 
@@ -345,8 +346,8 @@ private:
 
 
 /// cspan_strided<T> is a synonym for a non-mutable span_strided<const T>.
-template <typename T>
-using cspan_strided = span_strided<const T>;
+template <typename T, oiio_span_size_type Extent = dynamic_extent>
+using cspan_strided = span_strided<const T, Extent>;
 
 
 
@@ -405,3 +406,15 @@ constexpr ptrdiff_t ssize(const OIIO::span_strided<T, E>& c) {
 #define OIIO_SPAN_HAS_STD_SIZE 1
 
 } // namespace std
+
+// clang-format on
+
+
+
+/// Custom fmtlib formatters for span/cspan types.
+namespace fmt {
+template<typename T, OIIO::oiio_span_size_type Extent>
+struct formatter<OIIO::span<T, Extent>>
+    : OIIO::pvt::index_formatter<OIIO::span<T, Extent>> {
+};
+}  // namespace fmt

--- a/src/libutil/strutil_test.cpp
+++ b/src/libutil/strutil_test.cpp
@@ -185,6 +185,18 @@ test_format_custom()
     OIIO_CHECK_EQUAL(Strutil::fmt::format("X|({:,.3f})|Y", ivf3iota),
                      "X|(1.500, 2.500, 3.500)|Y");
     Strutil::print("\n");
+
+    // Test custom formatting of spans
+    float farray[] = { 1.5f, 2.5f, 3.5f, 4.5f };
+    Strutil::print("cspan<float> {{}}  '{}'\n", cspan<float>(farray));
+    Strutil::print("cspan<float> {{:.3f}}  '{:.3f}'\n", cspan<float>(farray));
+    Strutil::print("cspan<float> {{:,.3f}}  '{:,.3f}'\n", cspan<float>(farray));
+    OIIO_CHECK_EQUAL(Strutil::fmt::format("X|{}|Y", cspan<float>(farray)),
+                     "X|1.5 2.5 3.5 4.5|Y");
+    OIIO_CHECK_EQUAL(Strutil::fmt::format("X|{:.3f}|Y", cspan<float>(farray)),
+                     "X|1.500 2.500 3.500 4.500|Y");
+    OIIO_CHECK_EQUAL(Strutil::fmt::format("X|({:,.3f})|Y", cspan<float>(farray)),
+                     "X|(1.500, 2.500, 3.500, 4.500)|Y");
 }
 
 


### PR DESCRIPTION
* Make sure the cspan alias also allows the Extent template argument.

* Add a custom formatter for {fmt} to print spans, like we did for Imath types.
