### PR TITLE
Centralize ImageOutput validity checks

### DIFF
--- a/src/bmp.imageio/bmpoutput.cpp
+++ b/src/bmp.imageio/bmpoutput.cpp
@@ -81,27 +81,11 @@ BmpOutput::supports(string_view feature) const
 bool
 BmpOutput::open(const std::string& name, const ImageSpec& spec, OpenMode mode)
 {
-    if (mode != Create) {
-        errorfmt("{} does not support subimages or MIP levels", format_name());
+    if (!check_open(mode, spec, { 0, 65535, 0, 65535, 0, 1, 0, 4 },
+                    uint64_t(OpenChecks::Disallow2Channel)))
         return false;
-    }
 
-    // saving 'name' and 'spec' for later use
     m_filename = name;
-    m_spec     = spec;
-
-    if (m_spec.nchannels != 1 && m_spec.nchannels != 3
-        && m_spec.nchannels != 4) {
-        errorfmt("{} does not support {}-channel images\n", format_name(),
-                 m_spec.nchannels);
-        return false;
-    }
-
-    if (m_spec.x || m_spec.y || m_spec.z) {
-        errorfmt("{} does not support images with non-zero image origin offset",
-                 format_name());
-        return false;
-    }
 
     // Only support 8 bit channels for now.
     m_spec.set_format(TypeDesc::UINT8);

--- a/src/fits.imageio/fitsoutput.cpp
+++ b/src/fits.imageio/fitsoutput.cpp
@@ -31,7 +31,7 @@ FitsOutput::supports(string_view feature) const
 {
     return (feature == "multiimage" || feature == "alpha"
             || feature == "nchannels" || feature == "random_access"
-            || feature == "arbitrary_metadata"
+            || feature == "noimage" || feature == "arbitrary_metadata"
             || feature == "exif"    // Because of arbitrary_metadata
             || feature == "iptc");  // Because of arbitrary_metadata
 }
@@ -41,14 +41,12 @@ FitsOutput::supports(string_view feature) const
 bool
 FitsOutput::open(const std::string& name, const ImageSpec& spec, OpenMode mode)
 {
-    if (mode == AppendMIPLevel) {
-        errorf("%s does not support MIP levels", format_name());
+    close();
+    if (!check_open(mode, spec, { 0, 1 << 30, 0, 1 << 30, 0, 1, 0, 1 << 10 }))
         return false;
-    }
 
-    // saving 'name' and 'spec' for later use
     m_filename = name;
-    m_spec     = spec;
+
     if (m_spec.format == TypeDesc::UNKNOWN)  // if unknown, default to float
         m_spec.set_format(TypeDesc::FLOAT);
     // FITS only supports signed short and int pixels
@@ -60,12 +58,7 @@ FitsOutput::open(const std::string& name, const ImageSpec& spec, OpenMode mode)
     // checking if the file exists and can be opened in WRITE mode
     m_fd = Filesystem::fopen(m_filename, mode == AppendSubimage ? "r+b" : "wb");
     if (!m_fd) {
-        errorf("Could not open \"%s\"", m_filename);
-        return false;
-    }
-
-    if (m_spec.depth != 1) {
-        errorf("Volume FITS files not supported");
+        errorfmt("Could not open \"{}\"", m_filename);
         return false;
     }
 
@@ -92,7 +85,7 @@ FitsOutput::write_scanline(int y, int /*z*/, TypeDesc format, const void* data,
     if (m_spec.width == 0 && m_spec.height == 0)
         return true;
     if (y > m_spec.height) {
-        errorf("Attempt to write too many scanlines to %s", m_filename);
+        errorfmt("Attempt to write too many scanlines to {}", m_filename);
         close();
         return false;
     }
@@ -224,7 +217,7 @@ FitsOutput::create_fits_header(void)
     size_t byte_count = fwrite(&header[0], 1, header.size(), m_fd);
     if (byte_count != header.size()) {
         // FIXME Bad Write
-        errorf("Bad header write (err %d)", byte_count);
+        errorfmt("Bad header write (err {})", byte_count);
     }
 }
 

--- a/src/hdr.imageio/hdroutput.cpp
+++ b/src/hdr.imageio/hdroutput.cpp
@@ -204,33 +204,11 @@ bool
 HdrOutput::open(const std::string& name, const ImageSpec& newspec,
                 OpenMode mode)
 {
-    if (mode != Create) {
-        errorf("%s does not support subimages or MIP levels", format_name());
+    if (!check_open(mode, newspec, { 0, 1 << 20, 0, 1 << 20, 0, 1, 0, 3 },
+                    uint64_t(OpenChecks::Disallow1or2Channel)))
         return false;
-    }
 
-    // Save spec for later use
-    m_spec = newspec;
     // HDR always behaves like floating point
-    m_spec.set_format(TypeDesc::FLOAT);
-
-    // Check for things HDR can't support
-    if (m_spec.nchannels != 3) {
-        errorf("HDR can only support 3-channel images");
-        return false;
-    }
-    if (m_spec.width < 1 || m_spec.height < 1) {
-        errorf("Image resolution must be at least 1x1, you asked for %d x %d",
-               m_spec.width, m_spec.height);
-        return false;
-    }
-    if (m_spec.depth < 1)
-        m_spec.depth = 1;
-    if (m_spec.depth > 1) {
-        errorf("%s does not support volume images (depth > 1)", format_name());
-        return false;
-    }
-
     m_spec.set_format(TypeDesc::FLOAT);  // Native rgbe is float32 only
 
     ioproxy_retrieve_from_config(m_spec);

--- a/src/iff.imageio/iffoutput.cpp
+++ b/src/iff.imageio/iffoutput.cpp
@@ -143,32 +143,23 @@ IffOutput::open(const std::string& name, const ImageSpec& spec, OpenMode mode)
     //       RGBA <size> tile pixels
     //       ...
 
-    if (mode != Create) {
-        errorfmt("{} does not support subimages or MIP levels", format_name());
-        return false;
-    }
-
     // saving 'name' and 'spec' for later use
     m_filename = name;
-    m_spec     = spec;
 
-    // Maya docs say 8k is the limit
-    if (m_spec.width < 1 || m_spec.width > 8192 || m_spec.height < 1
-        || m_spec.height > 8192) {
-        errorfmt("Image resolution {} x {} is not valid for an IFF file",
-                 m_spec.width, m_spec.height);
+    if (!check_open(mode, spec, { 0, 8192, 0, 8192, 0, 1, 0, 4 }))
         return false;
-    }
+    // Maya docs say 8k is the limit
+
+    // tiles always
+    m_spec.tile_width  = tile_width();
+    m_spec.tile_height = tile_height();
+    m_spec.tile_depth  = 1;
+
     // This implementation only supports writing RGB and RGBA images as IFF
     if (m_spec.nchannels < 3 || m_spec.nchannels > 4) {
         errorfmt("Cannot write IFF file with {} channels", m_spec.nchannels);
         return false;
     }
-
-    // tiles
-    m_spec.tile_width  = tile_width();
-    m_spec.tile_height = tile_height();
-    m_spec.tile_depth  = 1;
 
     uint64_t xtiles = tile_width_size(m_spec.width);
     uint64_t ytiles = tile_height_size(m_spec.height);

--- a/src/jpeg.imageio/jpegoutput.cpp
+++ b/src/jpeg.imageio/jpegoutput.cpp
@@ -121,27 +121,16 @@ bool
 JpgOutput::open(const std::string& name, const ImageSpec& newspec,
                 OpenMode mode)
 {
-    if (mode != Create) {
-        errorf("%s does not support subimages or MIP levels", format_name());
-        return false;
-    }
-
     // Save name and spec for later use
     m_filename = name;
-    m_spec     = newspec;
 
-    // Check for things this format doesn't support
-    if (m_spec.width < 1 || m_spec.height < 1) {
-        errorf("Image resolution must be at least 1x1, you asked for %d x %d",
-               m_spec.width, m_spec.height);
+    if (!check_open(mode, newspec,
+                    { 0, JPEG_MAX_DIMENSION, 0, JPEG_MAX_DIMENSION, 0, 1, 0,
+                      256 }))
         return false;
-    }
-    if (m_spec.depth < 1)
-        m_spec.depth = 1;
-    if (m_spec.depth > 1) {
-        errorf("%s does not support volume images (depth > 1)", format_name());
-        return false;
-    }
+    // NOTE: we appear to let a large number of channels be allowed, but
+    // that's only because we robustly truncate to only RGB no matter what we
+    // are handed.
 
     ioproxy_retrieve_from_config(m_spec);
     if (!ioproxy_use_or_open(name))

--- a/src/png.imageio/pngoutput.cpp
+++ b/src/png.imageio/pngoutput.cpp
@@ -119,12 +119,8 @@ bool
 PNGOutput::open(const std::string& name, const ImageSpec& userspec,
                 OpenMode mode)
 {
-    if (mode != Create) {
-        errorf("%s does not support subimages or MIP levels", format_name());
+    if (!check_open(mode, userspec, { 0, 65535, 0, 65535, 0, 1, 0, 256 }))
         return false;
-    }
-
-    m_spec = userspec;  // Stash the spec
 
     // If not uint8 or uint16, default to uint8
     if (m_spec.format != TypeDesc::UINT8 && m_spec.format != TypeDesc::UINT16)
@@ -140,7 +136,7 @@ PNGOutput::open(const std::string& name, const ImageSpec& userspec,
                                                  m_spec, this);
     if (s.length()) {
         close();
-        errorf("%s", s);
+        errorfmt("{}", s);
         return false;
     }
 
@@ -314,7 +310,7 @@ PNGOutput::write_scanline(int y, int z, TypeDesc format, const void* data,
         swap_endian((unsigned short*)data, m_spec.width * m_spec.nchannels);
 
     if (!PNG_pvt::write_row(m_png, (png_byte*)data)) {
-        errorf("PNG library error");
+        errorfmt("PNG library error");
         return false;
     }
 

--- a/src/pnm.imageio/pnmoutput.cpp
+++ b/src/pnm.imageio/pnmoutput.cpp
@@ -144,23 +144,15 @@ bool
 PNMOutput::open(const std::string& name, const ImageSpec& userspec,
                 OpenMode mode)
 {
-    if (mode != Create) {
-        errorf("%s does not support subimages or MIP levels", format_name());
+    if (!check_open(mode, userspec, { 0, 65535, 0, 65535, 0, 1, 0, 3 },
+                    uint64_t(OpenChecks::Disallow2Channel)))
         return false;
-    }
 
-    m_spec = userspec;                   // Stash the spec
     m_spec.set_format(TypeDesc::UINT8);  // Force 8 bit output
     int bits_per_sample = m_spec.get_int_attribute("oiio:BitsPerSample", 8);
     m_dither            = (m_spec.format == TypeDesc::UINT8)
                               ? m_spec.get_int_attribute("oiio:dither", 0)
                               : 0;
-
-    if (m_spec.nchannels != 1 && m_spec.nchannels != 3) {
-        errorf("%s does not support %d-channel images\n", format_name(),
-               m_spec.nchannels);
-        return false;
-    }
 
     if (bits_per_sample == 1)
         m_pnm_type = 4;

--- a/src/sgi.imageio/sgioutput.cpp
+++ b/src/sgi.imageio/sgioutput.cpp
@@ -67,19 +67,10 @@ SgiOutput::supports(string_view feature) const
 bool
 SgiOutput::open(const std::string& name, const ImageSpec& spec, OpenMode mode)
 {
-    if (mode != Create) {
-        errorfmt("{} does not support subimages or MIP levels", format_name());
+    if (!check_open(mode, spec, { 0, 65535, 0, 65535, 0, 1, 0, 256 }))
         return false;
-    }
 
-    // saving 'name' and 'spec' for later use
     m_filename = name;
-    m_spec     = spec;
-
-    if (m_spec.width >= 65535 || m_spec.height >= 65535) {
-        errorfmt("Exceeds the maximum resolution (65535)");
-        return false;
-    }
 
     ioproxy_retrieve_from_config(m_spec);
     if (!ioproxy_use_or_open(name))
@@ -111,7 +102,7 @@ SgiOutput::write_scanline(int y, int z, TypeDesc format, const void* data,
     y    = m_spec.height - y - 1;
     data = to_native_scanline(format, data, xstride, m_scratch, m_dither, y, z);
 
-    // In SGI format all channels are saved to file separately: firsty all
+    // In SGI format all channels are saved to file separately: first, all
     // channel 1 scanlines are saved, then all channel2 scanlines are saved
     // and so on.
     //

--- a/src/targa.imageio/targaoutput.cpp
+++ b/src/targa.imageio/targaoutput.cpp
@@ -153,43 +153,15 @@ bool
 TGAOutput::open(const std::string& name, const ImageSpec& userspec,
                 OpenMode mode)
 {
-    if (mode != Create) {
-        errorf("%s does not support subimages or MIP levels", format_name());
+    if (!check_open(mode, userspec, { 0, 65535, 0, 65535, 0, 1, 0, 4 }))
         return false;
-    }
-
-    m_spec = userspec;  // Stash the spec
-
-    // Check for things this format doesn't support
-    if (m_spec.width < 1 || m_spec.height < 1) {
-        errorf("Image resolution must be at least 1x1, you asked for %d x %d",
-               m_spec.width, m_spec.height);
-        return false;
-    }
-    if (m_spec.width > 65535 || m_spec.height > 65535) {
-        errorf("TGA image resolution maximum is 65535, you asked for %d x %d",
-               m_spec.width, m_spec.height);
-        return false;
-    }
-
-    if (m_spec.depth < 1)
-        m_spec.depth = 1;
-    else if (m_spec.depth > 1) {
-        errorf("TGA does not support volume images (depth > 1)");
-        return false;
-    }
-
-    if (m_spec.nchannels < 1 || m_spec.nchannels > 4) {
-        errorf("TGA only supports 1-4 channels, not %d", m_spec.nchannels);
-        return false;
-    }
 
     // Offsets within the file are 32 bits. Guard against creating a TGA
     // file that (even counting the file footer or header) might exceed
     // this.
     if (m_spec.image_bytes() + sizeof(tga_header) + sizeof(tga_footer)
         >= (int64_t(1) << 32)) {
-        errorf("Too large a TGA file");
+        errorfmt("Too large a TGA file");
         return false;
     }
 

--- a/src/term.imageio/termoutput.cpp
+++ b/src/term.imageio/termoutput.cpp
@@ -57,18 +57,9 @@ TermOutput::supports(string_view feature) const
 bool
 TermOutput::open(const std::string& name, const ImageSpec& spec, OpenMode mode)
 {
-    if (mode != Create) {
-        errorfmt("{} does not support subimages or MIP levels", format_name());
+    if (!check_open(mode, spec, { 0, 255, 0, 255, 0, 1, 0, 4 },
+                    uint64_t(OpenChecks::Disallow1or2Channel)))
         return false;
-    }
-
-    if (spec.nchannels != 3 && spec.nchannels != 4) {
-        errorfmt("{} does not support {}-channel images\n", format_name(),
-                 m_spec.nchannels);
-        return false;
-    }
-
-    m_spec = spec;
 
     // Retrieve config hints giving special instructions
     m_method = Strutil::lower(m_spec["term:method"].get());

--- a/src/webp.imageio/webpoutput.cpp
+++ b/src/webp.imageio/webpoutput.cpp
@@ -69,20 +69,11 @@ WebpImageWriter(const uint8_t* img_data, size_t data_size,
 bool
 WebpOutput::open(const std::string& name, const ImageSpec& spec, OpenMode mode)
 {
-    if (mode != Create) {
-        errorfmt("{} does not support subimages or MIP levels", format_name());
+    if (!check_open(mode, spec, { 0, 1 << 20, 0, 1 << 20, 0, 1, 0, 4 },
+                    uint64_t(OpenChecks::Disallow1or2Channel)))
         return false;
-    }
 
-    // saving 'name' and 'spec' for later use
     m_filename = name;
-    m_spec     = spec;
-
-    if (m_spec.nchannels != 3 && m_spec.nchannels != 4) {
-        errorfmt("{} does not support {}-channel images\n", format_name(),
-                 m_spec.nchannels);
-        return false;
-    }
 
     ioproxy_retrieve_from_config(m_spec);
     if (!ioproxy_use_or_open(name))

--- a/src/zfile.imageio/zfile.cpp
+++ b/src/zfile.imageio/zfile.cpp
@@ -258,40 +258,12 @@ bool
 ZfileOutput::open(const std::string& name, const ImageSpec& userspec,
                   OpenMode mode)
 {
-    if (mode != Create) {
-        errorfmt("{} does not support subimages or MIP levels", format_name());
-        return false;
-    }
-
     close();  // Close any already-opened file
     m_gz   = 0;
     m_file = NULL;
-    m_spec = userspec;  // Stash the spec
 
-    // Check for things this format doesn't support
-    if (m_spec.width < 1 || m_spec.height < 1) {
-        errorfmt("Image resolution must be at least 1x1, you asked for {} x {}",
-                 m_spec.width, m_spec.height);
+    if (!check_open(mode, userspec, { 0, 32767, 0, 32767, 0, 1, 0, 1 }))
         return false;
-    }
-    if (m_spec.width > 32767 || m_spec.height > 32767) {
-        errorfmt(
-            "zfile image resolution maximum is 32767, you asked for {} x {}",
-            m_spec.width, m_spec.height);
-        return false;
-    }
-    if (m_spec.depth < 1)
-        m_spec.depth = 1;
-    if (m_spec.depth > 1) {
-        errorfmt("{} does not support volume images (depth > 1)",
-                 format_name());
-        return false;
-    }
-
-    if (m_spec.nchannels != 1) {
-        errorfmt("Zfile only supports 1 channel, not {}", m_spec.nchannels);
-        return false;
-    }
 
     // Force float
     m_spec.format = TypeDesc::FLOAT;


### PR DESCRIPTION
Many ImageOutput::open implementations start out with various validity checks -- such as whether the ImageSpec requests a resolution, number of channels, or other features simply not allowed by that file format. This is not only repetitive, but which checks are done by each file type is somewhat haphazard, error-prone, hard to get full test coverage (must we separately test each possible failure case for every file format?), and the error messages are not always consistent across formats. Frankly, most of the format writers assume that the caller has a full understanding of supports() and will never send requests for features that are unsupported, which is obviously not a careful approach.

This PR proposes adding a utility method ImageOutput::check_open(), which performs all validity checks on the ImageSpec that can be deduced from supports(). The various ImageOutput::open() implementations may call this function and avoid having to replicate (or forget) all the checks done in other output formats.  This is a protected method that is used by ImageOutput implementations internally, but has no use for client-side code.

I've implemented check_open, and also used it here for all the output formats. If this seems ok to everyone, I also plan to do an analogous helper for ImageInput common validity checks (which will be an even bigger reduction of redundant code and greatly increase the safety against corrupted or nonsensical input files).

Along the way I also instituted a new supports() query: "noimage". That is to indicate a file for which it is permitted to have a pixel data window consisting of 0 pixels (i.e. an "image" that is only a container for metadata). Currently, FITS is the only format we support that allows this, though it's something we occasionally talk about for OpenEXR. Allowing an explicit way for formats to say they allow no pixels is what allows check_open to issue error messages for all the other formats if it is passed zero-sized width, height, depth, or nchannels.
