### PR TITLE
make_texture: allow existing DateTime to remain

### DIFF
--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -1485,11 +1485,16 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
     // Put a DateTime in the out file, either now, or matching the date
     // stamp of the input file (if update mode).
     time_t date;
-    if (updatemode && from_filename)
-        date = in_time;  // update mode: use the time stamp of the input
-    else
+    if (updatemode && from_filename) {
+        // update mode from a file: Set DateTime to the time stamp of the
+        // input file.
+        date = in_time;
+        dstspec.attribute("DateTime", datestring(date));
+    } else if (!dstspec.extra_attribs.contains("DateTime")) {
+        // Otherwise, if there's no DateTime, set it to now.
         time(&date);  // not update: get the time now
-    dstspec.attribute("DateTime", datestring(date));
+        dstspec.attribute("DateTime", datestring(date));
+    }
 
     std::string cmdline = configspec.get_string_attribute(
         "maketx:full_command_line");


### PR DESCRIPTION
When creating a texture, the old logic was to set the file metadata "DateTime" to the current time, unless update mode was used, in which case it was set to the file's write timestamp of the input file.

But that made it impossible to explicitly set that metadata, and also a big PITA for testing because it meant the metadata of any written texture would be the time of its writing, and so appear different every time.

This change alters the logic: update mode still sets DateTime to the last update time of the input file, as before; other cases will only set DateTime if it isn't already set, but not alter it if the input carries that metadata already.
