### PR TITLE
BMP: set colorspace to sRGB

### DIFF
--- a/src/bmp.imageio/bmp_pvt.h
+++ b/src/bmp.imageio/bmp_pvt.h
@@ -36,6 +36,12 @@ const int32_t NO_COMPRESSION   = 0;  // BI_RGB
 const int32_t RLE8_COMPRESSION = 1;  // BI_RLE8
 const int32_t RLE4_COMPRESSION = 2;  // BI_RLE4
 
+enum class CSType {
+    CalibratedRGB       = 0,
+    DeviceDependentRGB  = 1,
+    DeviceDependentCMYK = 2
+};
+
 
 
 // store information about BMP file
@@ -89,19 +95,19 @@ public:
     int32_t blue_mask  = 0;
     int32_t green_mask = 0;
     int32_t alpha_mask = 0;
-    int32_t cs_type;  //color space type
-    int32_t red_x;
-    int32_t red_y;
-    int32_t red_z;
-    int32_t green_x;
-    int32_t green_y;
-    int32_t green_z;
-    int32_t blue_x;
-    int32_t blue_y;
-    int32_t blue_z;
-    int32_t gamma_x;
-    int32_t gamma_y;
-    int32_t gamma_z;
+    int32_t cs_type    = 0;  // color space type
+    int32_t red_x      = 0;
+    int32_t red_y      = 0;
+    int32_t red_z      = 0;
+    int32_t green_x    = 0;
+    int32_t green_y    = 0;
+    int32_t green_z    = 0;
+    int32_t blue_x     = 0;
+    int32_t blue_y     = 0;
+    int32_t blue_z     = 0;
+    int32_t gamma_x    = 0;
+    int32_t gamma_y    = 0;
+    int32_t gamma_z    = 0;
 
     // added in Version 5 of the format
     int32_t intent;

--- a/src/bmp.imageio/bmpinput.cpp
+++ b/src/bmp.imageio/bmpinput.cpp
@@ -256,6 +256,25 @@ BmpInput::open(const std::string& name, ImageSpec& newspec,
     case WINDOWS_V5: m_spec.attribute("bmp:version", 5); break;
     }
 
+    // Default presumption is that a BMP file is meant to look reasonable on a
+    // display, so assume it's sRGB. This is not really correct -- see the
+    // comments below.
+    m_spec.attribute("oiio:ColorSpace", "sRGB");
+#if 0
+    if (m_dib_header.size >= WINDOWS_V4
+        && m_dib_header.cs_type == CSType::CalibratedRGB) {
+        // FIXME: V4 and newer BMP files have color primary information, but
+        // we currently ignore it and presume sRGB. I don't know how
+        // frequently the color primaries are reliable or if anybody cares for
+        // this ancient format. We may come back to this later.
+    }
+    if (m_dib_header.size >= WINDOWS_V4
+        && m_dib_header.cs_type == CSType::DeviceDependentCMYK) {
+        // FIXME: I've never encountered a BMP file that holds CMYK data. If
+        // this is a problem for people, we can return to fix this later.
+    }
+#endif
+
     // Bite the bullet and uncompress now, for simplicity
     if (m_dib_header.compression == RLE4_COMPRESSION
         || m_dib_header.compression == RLE8_COMPRESSION) {

--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -54,6 +54,9 @@ tiles.
    * - ``bmp:version``
      - int
      - Version of the BMP file format
+   * - ``oiio:ColorSpace``
+     - string
+     - currently, it is always ``"sRGB"`` (we presume all BMP files are sRGB)
 
 **Configuration settings for BMP input**
 
@@ -117,6 +120,10 @@ BMP input and output both support the "custom I/O" feature via the special
   of the file format itself.
 * BMP only supports uint8 pixel data types. Requests for other pixel data
   types will automatically be converted to uint8.
+* OIIO's current implementation only supports RGB BMP files and presumes that
+  the pixel data are in sRGB color space.  It does not currently support CMYK
+  files or the color primary header information. (Though if this is important
+  to anyone, support can be added in the future.)
 
 |
 

--- a/testsuite/bmp/ref/out.txt
+++ b/testsuite/bmp/ref/out.txt
@@ -4,6 +4,7 @@ Reading ../oiio-images/bmpsuite/g01bg.bmp
     channel list: R, G, B
     bmp:bitsperpixel: 1
     bmp:version: 3
+    oiio:ColorSpace: "sRGB"
 Comparing "../oiio-images/bmpsuite/g01bg.bmp" and "g01bg.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g01bw.bmp
@@ -12,6 +13,7 @@ Reading ../oiio-images/bmpsuite/g01bw.bmp
     channel list: R, G, B
     bmp:bitsperpixel: 1
     bmp:version: 3
+    oiio:ColorSpace: "sRGB"
 Comparing "../oiio-images/bmpsuite/g01bw.bmp" and "g01bw.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g01p1.bmp
@@ -20,6 +22,7 @@ Reading ../oiio-images/bmpsuite/g01p1.bmp
     channel list: R, G, B
     bmp:bitsperpixel: 1
     bmp:version: 3
+    oiio:ColorSpace: "sRGB"
 Comparing "../oiio-images/bmpsuite/g01p1.bmp" and "g01p1.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g01wb.bmp
@@ -28,6 +31,7 @@ Reading ../oiio-images/bmpsuite/g01wb.bmp
     channel list: R, G, B
     bmp:bitsperpixel: 1
     bmp:version: 3
+    oiio:ColorSpace: "sRGB"
 Comparing "../oiio-images/bmpsuite/g01wb.bmp" and "g01wb.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g04.bmp
@@ -36,6 +40,7 @@ Reading ../oiio-images/bmpsuite/g04.bmp
     channel list: R, G, B
     bmp:bitsperpixel: 4
     bmp:version: 3
+    oiio:ColorSpace: "sRGB"
 Comparing "../oiio-images/bmpsuite/g04.bmp" and "g04.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g04p4.bmp
@@ -44,6 +49,7 @@ Reading ../oiio-images/bmpsuite/g04p4.bmp
     channel list: R, G, B
     bmp:bitsperpixel: 4
     bmp:version: 3
+    oiio:ColorSpace: "sRGB"
 Comparing "../oiio-images/bmpsuite/g04p4.bmp" and "g04p4.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g04rle.bmp
@@ -53,6 +59,7 @@ Reading ../oiio-images/bmpsuite/g04rle.bmp
     compression: "rle4"
     bmp:bitsperpixel: 4
     bmp:version: 3
+    oiio:ColorSpace: "sRGB"
 Comparing "../oiio-images/bmpsuite/g04rle.bmp" and "g04rle.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g08.bmp
@@ -61,6 +68,7 @@ Reading ../oiio-images/bmpsuite/g08.bmp
     channel list: R, G, B
     bmp:bitsperpixel: 8
     bmp:version: 3
+    oiio:ColorSpace: "sRGB"
 Comparing "../oiio-images/bmpsuite/g08.bmp" and "g08.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g08os2.bmp
@@ -69,6 +77,7 @@ Reading ../oiio-images/bmpsuite/g08os2.bmp
     channel list: R, G, B
     bmp:bitsperpixel: 8
     bmp:version: 1
+    oiio:ColorSpace: "sRGB"
 Comparing "../oiio-images/bmpsuite/g08os2.bmp" and "g08os2.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g08p64.bmp
@@ -77,6 +86,7 @@ Reading ../oiio-images/bmpsuite/g08p64.bmp
     channel list: Y
     bmp:bitsperpixel: 8
     bmp:version: 3
+    oiio:ColorSpace: "sRGB"
 Comparing "../oiio-images/bmpsuite/g08p64.bmp" and "g08p64.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g08p256.bmp
@@ -85,6 +95,7 @@ Reading ../oiio-images/bmpsuite/g08p256.bmp
     channel list: R, G, B
     bmp:bitsperpixel: 8
     bmp:version: 3
+    oiio:ColorSpace: "sRGB"
 Comparing "../oiio-images/bmpsuite/g08p256.bmp" and "g08p256.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g08pi64.bmp
@@ -93,6 +104,7 @@ Reading ../oiio-images/bmpsuite/g08pi64.bmp
     channel list: R, G, B
     bmp:bitsperpixel: 8
     bmp:version: 3
+    oiio:ColorSpace: "sRGB"
 Comparing "../oiio-images/bmpsuite/g08pi64.bmp" and "g08pi64.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g08pi256.bmp
@@ -101,6 +113,7 @@ Reading ../oiio-images/bmpsuite/g08pi256.bmp
     channel list: R, G, B
     bmp:bitsperpixel: 8
     bmp:version: 3
+    oiio:ColorSpace: "sRGB"
 Comparing "../oiio-images/bmpsuite/g08pi256.bmp" and "g08pi256.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g08res11.bmp
@@ -112,6 +125,7 @@ Reading ../oiio-images/bmpsuite/g08res11.bmp
     YResolution: 3937
     bmp:bitsperpixel: 8
     bmp:version: 3
+    oiio:ColorSpace: "sRGB"
 Comparing "../oiio-images/bmpsuite/g08res11.bmp" and "g08res11.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g08res21.bmp
@@ -123,6 +137,7 @@ Reading ../oiio-images/bmpsuite/g08res21.bmp
     YResolution: 3937
     bmp:bitsperpixel: 8
     bmp:version: 3
+    oiio:ColorSpace: "sRGB"
 Comparing "../oiio-images/bmpsuite/g08res21.bmp" and "g08res21.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g08res22.bmp
@@ -134,6 +149,7 @@ Reading ../oiio-images/bmpsuite/g08res22.bmp
     YResolution: 7874
     bmp:bitsperpixel: 8
     bmp:version: 3
+    oiio:ColorSpace: "sRGB"
 Comparing "../oiio-images/bmpsuite/g08res22.bmp" and "g08res22.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g08s0.bmp
@@ -142,6 +158,7 @@ Reading ../oiio-images/bmpsuite/g08s0.bmp
     channel list: R, G, B
     bmp:bitsperpixel: 8
     bmp:version: 3
+    oiio:ColorSpace: "sRGB"
 Comparing "../oiio-images/bmpsuite/g08s0.bmp" and "g08s0.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g08w124.bmp
@@ -150,6 +167,7 @@ Reading ../oiio-images/bmpsuite/g08w124.bmp
     channel list: R, G, B
     bmp:bitsperpixel: 8
     bmp:version: 3
+    oiio:ColorSpace: "sRGB"
 Comparing "../oiio-images/bmpsuite/g08w124.bmp" and "g08w124.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g08w125.bmp
@@ -158,6 +176,7 @@ Reading ../oiio-images/bmpsuite/g08w125.bmp
     channel list: R, G, B
     bmp:bitsperpixel: 8
     bmp:version: 3
+    oiio:ColorSpace: "sRGB"
 Comparing "../oiio-images/bmpsuite/g08w125.bmp" and "g08w125.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g08w126.bmp
@@ -166,6 +185,7 @@ Reading ../oiio-images/bmpsuite/g08w126.bmp
     channel list: R, G, B
     bmp:bitsperpixel: 8
     bmp:version: 3
+    oiio:ColorSpace: "sRGB"
 Comparing "../oiio-images/bmpsuite/g08w126.bmp" and "g08w126.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g08rle.bmp
@@ -175,6 +195,7 @@ Reading ../oiio-images/bmpsuite/g08rle.bmp
     compression: "rle8"
     bmp:bitsperpixel: 8
     bmp:version: 3
+    oiio:ColorSpace: "sRGB"
 Comparing "../oiio-images/bmpsuite/g08rle.bmp" and "g08rle.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g08offs.bmp
@@ -183,6 +204,7 @@ Reading ../oiio-images/bmpsuite/g08offs.bmp
     channel list: R, G, B
     bmp:bitsperpixel: 8
     bmp:version: 3
+    oiio:ColorSpace: "sRGB"
 Comparing "../oiio-images/bmpsuite/g08offs.bmp" and "g08offs.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g24.bmp
@@ -190,6 +212,7 @@ Reading ../oiio-images/bmpsuite/g24.bmp
     SHA-1: B1FB63649469F31D02D7AD065D3128EE04CC662E
     channel list: R, G, B
     bmp:version: 3
+    oiio:ColorSpace: "sRGB"
 Comparing "../oiio-images/bmpsuite/g24.bmp" and "g24.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g32bf.bmp
@@ -197,6 +220,7 @@ Reading ../oiio-images/bmpsuite/g32bf.bmp
     SHA-1: D8807C680B17C70CB33B43AC072E0A9121C551B4
     channel list: R, G, B, A
     bmp:version: 3
+    oiio:ColorSpace: "sRGB"
 Comparing "../oiio-images/bmpsuite/g32bf.bmp" and "g32bf.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g32def.bmp
@@ -204,6 +228,7 @@ Reading ../oiio-images/bmpsuite/g32def.bmp
     SHA-1: D8807C680B17C70CB33B43AC072E0A9121C551B4
     channel list: R, G, B, A
     bmp:version: 3
+    oiio:ColorSpace: "sRGB"
 Comparing "../oiio-images/bmpsuite/g32def.bmp" and "g32def.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g16bf555.bmp
@@ -213,6 +238,7 @@ Reading ../oiio-images/bmpsuite/g16bf555.bmp
     bmp:bitsperpixel: 16
     bmp:version: 3
     oiio:BitsPerSample: 5
+    oiio:ColorSpace: "sRGB"
 Comparing "../oiio-images/bmpsuite/g16bf555.bmp" and "g16bf555.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g16bf565.bmp
@@ -222,6 +248,7 @@ Reading ../oiio-images/bmpsuite/g16bf565.bmp
     bmp:bitsperpixel: 16
     bmp:version: 3
     oiio:BitsPerSample: 5
+    oiio:ColorSpace: "sRGB"
 Comparing "../oiio-images/bmpsuite/g16bf565.bmp" and "g16bf565.bmp"
 PASS
 Reading ../oiio-images/bmpsuite/g16def555.bmp
@@ -231,6 +258,7 @@ Reading ../oiio-images/bmpsuite/g16def555.bmp
     bmp:bitsperpixel: 16
     bmp:version: 3
     oiio:BitsPerSample: 5
+    oiio:ColorSpace: "sRGB"
 Comparing "../oiio-images/bmpsuite/g16def555.bmp" and "g16def555.bmp"
 PASS
 Reading src/g01bg2-v5.bmp
@@ -241,6 +269,7 @@ src/g01bg2-v5.bmp    :  127 x   64, 3 channel, uint8 bmp
     XResolution: 2835
     YResolution: 2835
     bmp:version: 5
+    oiio:ColorSpace: "sRGB"
 Comparing "src/g01bg2-v5.bmp" and "g01bg2-v5.bmp"
 PASS
 Reading src/PRINTER.BMP
@@ -249,6 +278,7 @@ src/PRINTER.BMP      :  160 x  120, 3 channel, uint8 bmp
     channel list: R, G, B
     bmp:bitsperpixel: 8
     bmp:version: 1
+    oiio:ColorSpace: "sRGB"
 Comparing "src/PRINTER.BMP" and "PRINTER.BMP"
 PASS
 Reading ../oiio-images/bmp/gracehopper.bmp
@@ -258,6 +288,7 @@ Reading ../oiio-images/bmp/gracehopper.bmp
     ResolutionUnit: "m"
     XResolution: 2835
     YResolution: 2835
+    oiio:ColorSpace: "sRGB"
 Comparing "../oiio-images/bmp/gracehopper.bmp" and "gracehopper.bmp"
 PASS
 oiiotool ERROR: read : "src/decodecolormap-corrupt.bmp": Possible corrupted header, invalid palette size


### PR DESCRIPTION
Seems like a reasonable assumption for BMP files.  It's not strictly correct -- there are header fields on V4 and V5 BMP files that communicate color primaries and gamma, but honestly, I do not have any idea if anybody uses them or whether they're more misleading than helpful. For now, assuming that a BMP file is meant for output on an sRGB display seems like it's likely to be true.

