### PR TITLE
tiff updates for libtiff 4.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,7 +243,7 @@ jobs:
             python_ver: 3.8
             simd: avx2,f16c
             setenvs: export LIBRAW_VERSION=0.20.2
-                            LIBTIFF_VERSION=v4.4.0
+                            LIBTIFF_VERSION=v4.5.0
                             OPENCOLORIO_VERSION=v2.2.0
                             OPENIMAGEIO_OPTIONS="openexr:core=1"
                             OPENJPEG_VERSION=v2.4.0

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -21,7 +21,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
    **Intel icc 17+**, **Intel OneAPI C++ compiler 2022+**.
  * CMake >= 3.12 (tested through 3.24)
  * OpenEXR/Imath >= 2.3 (recommended: 2.4 or higher; tested through 3.1)
- * libTIFF >= 3.9 (recommended: 4.0+; tested through 4.4)
+ * libTIFF >= 3.9 (recommended: 4.0+; tested through 4.5)
  * libjpeg >= 8, or libjpeg-turbo >= 1.1 (tested through jpeg9d and jpeg-turbo
    2.1)
  * Boost >= 1.53 (recommended: at least 1.66; tested through 1.80)

--- a/src/build-scripts/build_libtiff.bash
+++ b/src/build-scripts/build_libtiff.bash
@@ -40,6 +40,9 @@ if [[ -z $DEP_DOWNLOAD_ONLY ]]; then
                -DCMAKE_INSTALL_PREFIX=${LIBTIFF_INSTALL_DIR} \
                -DCMAKE_CXX_FLAGS="${LIBTIFF_CXX_FLAGS}" \
                -DBUILD_SHARED_LIBS=${LIBTIFF_BUILD_SHARED_LIBS:-ON} \
+               -Dtiff-tests=${LIBTIFF_BUILD_TESTS:-OFF} \
+               -Dtiff-docs=${LIBTIFF_BUILD_TESTS:-OFF} \
+               -Dlibdeflate=ON \
                ${LIBTIFF_BUILDOPTS} ..
     time cmake --build . --target install
 fi


### PR DESCRIPTION
libtiff 4.5 was just released, so confirm that we build against it, update the "latest versions" CI test to use 4.5.

More careful sorting out of libtiff version numbers for conditional compilation.

Get rid of some ancient tiff version guards that are related to libtiff versions that are older than we currently support.

When building against libiff 4.5, use the new open calls that allow per-file error handlers, which is better than the old global error handlers for thread safety of multiple threads reading from the same ImageInput if there are errors.

Convert error messages to std::format form.
