### PR TITLE
oiiotool --pdiff: test, be sure to count it as making output

### DIFF
--- a/src/libOpenImageIO/imagebufalgo_test.cpp
+++ b/src/libOpenImageIO/imagebufalgo_test.cpp
@@ -1042,6 +1042,24 @@ test_color_management()
 
 
 
+static void
+test_yee()
+{
+    print("Testing Yee comparison\n");
+    ImageSpec spec(1, 1, 3, TypeDesc::FLOAT);
+    ImageBuf img1(spec);
+    ImageBufAlgo::fill(img1, { 0.1f, 0.1f, 0.1f });
+    ImageBuf img2(spec);
+    ImageBufAlgo::fill(img2, { 0.1f, 0.6f, 0.1f });
+    ImageBufAlgo::CompareResults cr;
+    int n = ImageBufAlgo::compare_Yee(img1, img2, cr);
+    OIIO_CHECK_EQUAL(n, 1);
+    OIIO_CHECK_EQUAL(cr.maxx, 0);
+    OIIO_CHECK_EQUAL(cr.maxy, 0);
+}
+
+
+
 int
 main(int argc, char** argv)
 {
@@ -1077,6 +1095,7 @@ main(int argc, char** argv)
     test_validate_st_warp_checks();
     test_opencv();
     test_color_management();
+    test_yee();
 
     benchmark_parallel_image(64, iterations * 64);
     benchmark_parallel_image(512, iterations * 16);

--- a/src/libOpenImageIO/imagebufalgo_yee.cpp
+++ b/src/libOpenImageIO/imagebufalgo_yee.cpp
@@ -106,28 +106,28 @@ AdobeRGBToXYZ(ImageBuf& A, ROI roi, int nthreads)
 
 /// Convert a color in XYZ space to LAB space.
 ///
-static Color3f
-XYZToLAB_color(const Color3f xyz)
+inline Color3f
+XYZToLAB_color(const Color3f& xyz)
 {
     // Reference white point
-    static const Color3f white(0.576700f + 0.185556f + 0.188212f,
-                               0.297361f + 0.627355f + 0.0752847f,
-                               0.0270328f + 0.0706879f + 0.991248f);
-    const float epsilon = 216.0f / 24389.0f;
-    const float kappa   = 24389.0f / 27.0f;
+    static const float white[3] = { 0.576700f + 0.185556f + 0.188212f,
+                                    0.297361f + 0.627355f + 0.0752847f,
+                                    0.0270328f + 0.0706879f + 0.991248f };
+    const float epsilon         = 216.0f / 24389.0f;
+    const float kappa           = 24389.0f / 27.0f;
 
-    Color3f r = xyz / white;
-    Color3f f;
+    float r[3] = { xyz.x / white[0], xyz.y / white[1], xyz.z / white[2] };
+    float f[3];
     for (int i = 0; i < 3; i++) {
         float ri = r[i];  // NOSONAR
         if (ri > epsilon)
-            f[i] = powf(ri, 1.0f / 3.0f);
+            f[i] = fast_cbrt(ri);  // powf(ri, 1.0f / 3.0f);
         else
             f[i] = (kappa * ri + 16.0f) / 116.0f;
     }
-    return Color3f(116.0f * f.y - 16.0f,   // L
-                   500.0f * (f.x - f.y),   // A
-                   200.0f * (f.y - f.z));  // B
+    return Color3f(116.0f * f[1] - 16.0f,    // L
+                   500.0f * (f[0] - f[1]),   // A
+                   200.0f * (f[1] - f[2]));  // B
 }
 
 

--- a/src/oiiotool/diff.cpp
+++ b/src/oiiotool/diff.cpp
@@ -27,37 +27,20 @@ using namespace ImageBufAlgo;
 
 
 
-// function that standardize printing NaN and Inf values on
-// Windows (where they are in 1.#INF, 1.#NAN format) and all
-// others platform
-inline void
-safe_double_print(double val)
-{
-    if (OIIO::isnan(val))
-        std::cout << "nan";
-    else if (OIIO::isinf(val))
-        std::cout << "inf";
-    else
-        std::cout << val;
-    std::cout << '\n';
-}
-
-
-
 inline void
 print_subimage(ImageRec& img0, int subimage, int miplevel)
 {
     if (img0.subimages() > 1)
-        std::cout << "Subimage " << subimage << ' ';
+        print("Subimage {} ", subimage);
     if (img0.miplevels(subimage) > 1)
-        std::cout << " MIP level " << miplevel << ' ';
+        print(" MIP level {} ", miplevel);
     if (img0.subimages() > 1 || img0.miplevels(subimage) > 1)
-        std::cout << ": ";
+        print(": ");
     const ImageSpec& spec(*img0.spec(subimage));
-    std::cout << spec.width << " x " << spec.height;
+    print("{} x {}", spec.width, spec.height);
     if (spec.depth > 1)
-        std::cout << " x " << spec.depth;
-    std::cout << ", " << spec.nchannels << " channel\n";
+        print(" x {}", spec.depth);
+    print(", {} channel\n", spec.nchannels);
 }
 
 
@@ -66,9 +49,8 @@ int
 Oiiotool::do_action_diff(ImageRecRef ir0, ImageRecRef ir1, Oiiotool& ot,
                          int perceptual)
 {
-    std::cout << "Computing " << (perceptual ? "perceptual " : "")
-              << "diff of \"" << ir0->name() << "\" vs \"" << ir1->name()
-              << "\"\n";
+    print("Computing {}diff of \"{}\" vs \"{}\"\n",
+          perceptual ? "perceptual " : "", ir0->name(), ir1->name());
     read(ir0);
     read(ir1);
 
@@ -83,8 +65,7 @@ Oiiotool::do_action_diff(ImageRecRef ir0, ImageRecRef ir1, Oiiotool& ot,
             if (m > 0 && !ot.allsubimages)
                 break;
             if (m > 0 && ir0->miplevels(subimage) != ir1->miplevels(subimage)) {
-                std::cout
-                    << "Files do not match in their number of MIPmap levels\n";
+                print("Files do not match in their number of MIPmap levels\n");
                 ret = DiffErrDifferentSize;
                 break;
             }
@@ -126,76 +107,65 @@ Oiiotool::do_action_diff(ImageRecRef ir0, ImageRecRef ir1, Oiiotool& ot,
             if (ot.verbose || ot.debug || ret != DiffErrOK) {
                 if (ot.allsubimages)
                     print_subimage(*ir0, subimage, m);
-                std::cout << "  Mean error = ";
-                safe_double_print(cr.meanerror);
-                std::cout << "  RMS error = ";
-                safe_double_print(cr.rms_error);
-                std::cout << "  Peak SNR = ";
-                safe_double_print(cr.PSNR);
-                std::cout << "  Max error  = " << cr.maxerror;
+                if (!perceptual) {
+                    print("  Mean error = {:.6g}\n", cr.meanerror);
+                    print("  RMS error = {:.6g}\n", cr.rms_error);
+                    print("  Peak SNR = {:.6g}\n", cr.PSNR);
+                }
+                print("  Max error  = {}", cr.maxerror);
                 if (cr.maxerror != 0) {
-                    std::cout << " @ (" << cr.maxx << ", " << cr.maxy;
+                    print(" @ ({}, {}", cr.maxx, cr.maxy);
                     if (img0.spec().depth > 1)
-                        std::cout << ", " << cr.maxz;
+                        print(", {}", cr.maxz);
                     if (cr.maxc < (int)img0.spec().channelnames.size())
-                        std::cout << ", " << img0.spec().channelnames[cr.maxc]
-                                  << ')';
+                        print(", {})", img0.spec().channelnames[cr.maxc]);
                     else if (cr.maxc < (int)img1.spec().channelnames.size())
-                        std::cout << ", " << img1.spec().channelnames[cr.maxc]
-                                  << ')';
+                        print(", {})", img1.spec().channelnames[cr.maxc]);
                     else
-                        std::cout << ", channel " << cr.maxc << ')';
+                        print(", channel {})", cr.maxc);
                     if (!img0.deep()) {
-                        std::cout << "  values are ";
+                        print("  values are ");
                         for (int c = 0; c < img0.spec().nchannels; ++c)
-                            std::cout
-                                << (c ? ", " : "")
-                                << img0.getchannel(cr.maxx, cr.maxy, 0, c);
-                        std::cout << " vs ";
+                            print("{}{}", (c ? ", " : ""),
+                                  img0.getchannel(cr.maxx, cr.maxy, 0, c));
+                        print(" vs ");
                         for (int c = 0; c < img1.spec().nchannels; ++c)
-                            std::cout
-                                << (c ? ", " : "")
-                                << img1.getchannel(cr.maxx, cr.maxy, 0, c);
+                            print("{}{}", (c ? ", " : ""),
+                                  img1.getchannel(cr.maxx, cr.maxy, 0, c));
                     }
                 }
-                std::cout << "\n";
-
-                std::streamsize precis = std::cout.precision();
-                std::cout << "  " << cr.nwarn << " pixels ("
-                          << std::setprecision(3) << (100.0 * cr.nwarn / npels)
-                          << std::setprecision(precis) << "%) over "
-                          << ot.diff_warnthresh << "\n";
-                std::cout << "  " << cr.nfail << " pixels ("
-                          << std::setprecision(3) << (100.0 * cr.nfail / npels)
-                          << std::setprecision(precis) << "%) over "
-                          << ot.diff_failthresh << "\n";
-                if (perceptual == 1)
-                    std::cout << "  " << yee_failures << " pixels ("
-                              << std::setprecision(3)
-                              << (100.0 * yee_failures / npels)
-                              << std::setprecision(precis)
-                              << "%) failed the perceptual test\n";
+                print("\n");
+                if (perceptual == 1) {
+                    print("  {} pixels ({:.3g}%) failed the perceptual test\n",
+                          yee_failures, 100.0 * yee_failures / npels);
+                } else {
+                    print("  {} pixels ({:.3g}%) over {}\n", cr.nwarn,
+                          (100.0 * cr.nwarn / npels), ot.diff_warnthresh);
+                    print("  {} pixels ({:.3g}%) over {}\n", cr.nfail,
+                          (100.0 * cr.nfail / npels), ot.diff_failthresh);
+                }
             }
         }
     }
 
     if (ot.allsubimages && ir0->subimages() != ir1->subimages()) {
-        std::cout << "Images had differing numbers of subimages ("
-                  << ir0->subimages() << " vs " << ir1->subimages() << ")\n";
+        print("Images had differing numbers of subimages ({} vs {})\n",
+              ir0->subimages(), ir1->subimages());
         ret = DiffErrFail;
     }
     if (!ot.allsubimages && (ir0->subimages() > 1 || ir1->subimages() > 1)) {
-        std::cout << "Only compared the first subimage (of " << ir0->subimages()
-                  << " and " << ir1->subimages() << ", respectively)\n";
+        print("Only compared the first subimage (of {} and {}, respectively)\n",
+              ir0->subimages(), ir1->subimages());
     }
 
     if (ret == DiffErrOK)
-        std::cout << "PASS\n";
+        print("PASS\n");
     else if (ret == DiffErrWarn)
-        std::cout << "WARNING\n";
+        print("WARNING\n");
     else {
-        std::cout << "FAILURE\n";
+        print("FAILURE\n");
         ot.return_value = ret;
     }
+    fflush(stdout);
     return ret;
 }

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -3458,6 +3458,7 @@ action_pdiff(int argc, const char* argv[])
     if (ret != DiffErrOK && ret != DiffErrWarn && ret != DiffErrFail)
         ot.error(command, "Diff failed");
 
+    ot.printed_info = true;  // because taking the diff has output
     return 0;
 }
 

--- a/testsuite/diff/ref/out-fmt6.txt
+++ b/testsuite/diff/ref/out-fmt6.txt
@@ -16,7 +16,7 @@ Computing diff of "img1.exr" vs "img2.exr"
   121 pixels (2.95%) over 1e-06
 FAILURE
 Computing perceptual diff of "img1.exr" vs "img2.exr"
-  Max error  = 1 @ (5, 17, R)  values are 0.1, 0.1, 0.1 vs 0.1, 0.6, 0.1
+  Max error  = 1.0 @ (5, 17, R)  values are 0.1, 0.1, 0.1 vs 0.1, 0.6, 0.1
   121 pixels (2.95%) failed the perceptual test
 FAILURE
 Computing perceptual diff of "img1.exr" vs "img1.exr"

--- a/testsuite/diff/run.py
+++ b/testsuite/diff/run.py
@@ -1,13 +1,19 @@
 #!/usr/bin/env python
 
 # Make two images that differ by a particular known pixel value
-command += oiiotool("-pattern fill:color=0.1,0.1,0.1 10x10 3 -d float -o img1.exr")
-command += oiiotool("-pattern fill:color=0.1,0.1,0.1 10x10 3 -d float -box:color=0.1,0.6,0.1 5,7,5,7 -o img2.exr")
+command += oiiotool("-pattern fill:color=0.1,0.1,0.1 64x64 3 -d float -o img1.exr")
+command += oiiotool("-pattern fill:color=0.1,0.1,0.1 64x64 3 -d float -box:fill=1:color=0.1,0.6,0.1 5,17,15,27 -o img2.exr")
 
 # Now make sure idiff and oiiotool --diff print the right info
 failureok = True
-command += oiio_app("idiff") + " img1.exr img2.exr >> out.txt ;\n"
-command += oiio_app("oiiotool") + " -diff img1.exr img2.exr >> out.txt ;\n"
+command += diff_command("img1.exr", "img2.exr")
+command += oiiotool("--diff img1.exr img2.exr")
+
+# --pdiff
+command += oiiotool("-pdiff img1.exr img2.exr")
+command += oiiotool("-pdiff img1.exr img1.exr")
+command += diff_command("img1.exr", "img2.exr", extraargs="-p")
+command += diff_command("img1.exr", "img1.exr", extraargs="-p")
 
 
 # Outputs to check against references

--- a/testsuite/oiiotool-deep/ref/out-fmt6.txt
+++ b/testsuite/oiiotool-deep/ref/out-fmt6.txt
@@ -137,17 +137,17 @@ Computing diff of "src/deep-nosamples.exr" vs "src/deep-onesample.exr"
   Mean error = 42
   RMS error = 42
   Peak SNR = 0
-  Max error  = 42 @ (0, 0, Z)
+  Max error  = 42.0 @ (0, 0, Z)
   1 pixels (100%) over 1e-06
-  0 pixels (0%) over 100
+  0 pixels (0%) over 100.0
 WARNING
 Computing diff of "src/deep-onesample.exr" vs "src/deep-nosamples.exr"
   Mean error = 42
   RMS error = 42
   Peak SNR = 0
-  Max error  = 42 @ (0, 0, Z)
+  Max error  = 42.0 @ (0, 0, Z)
   1 pixels (100%) over 1e-06
-  0 pixels (0%) over 100
+  0 pixels (0%) over 100.0
 WARNING
 Comparing "flat.exr" and "ref/flat.exr"
 PASS


### PR DESCRIPTION
We had no testsuite exercise of --pdiff, add it.

Along the way, I saw tha we were getting the "you didn't have any output" warning when using pdiff, so fix that.

And some other minor changes: formatted output update, some other tightening up of things.

A little bit of jiggling the contents of XYZtoLAB_color to work around what I think is a compiler error with icx -- it was generating NaNs for reasons I was unable to understand or fix, but not if I rearranged the code slightly. All the other compilers and versions had correct behavior.
