### PR TITLE
ImageSpec:set_colorspace()

### DIFF
--- a/src/doc/pythonbindings.rst
+++ b/src/doc/pythonbindings.rst
@@ -712,6 +712,22 @@ Section :ref:`sec-ImageSpec`, is replicated for Python.
     data types, but not the arbitrary named metadata or channel names.
 
 
+.. py:method:: bool ImageSpec.set_colorspace (name)
+
+    Set metadata to indicate the presumed color space `name`, or clear all
+    such metadata if `name` is the empty string.
+
+    This function was added in version 2.5.
+
+    Example:
+
+    .. code-block:: python
+
+        spec = ImageSpec(...)
+        spec.set_colorspace ("sRGB")
+
+
+
 .. py:method:: ImageSpec.undefined ()
 
     Returns `True` for a newly initialized (undefined) ImageSpec.

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -776,6 +776,15 @@ public:
         deep = other.deep;
     }
 
+    /// Set the metadata to presume that color space is `name` (or to assume
+    /// nothing about the color space if `name` is empty). The core operation
+    /// is to set the "oiio:ColorSpace" attribute, but it also removes or
+    /// alters several other attributes that may hint color space in ways that
+    /// might be contradictory or no longer true.
+    ///
+    /// @version 2.5
+    void set_colorspace(string_view name);
+
     /// Returns `true` for a newly initialized (undefined) `ImageSpec`.
     /// (Designated by no channels and undefined data type -- true of the
     /// uninitialized state of an ImageSpec, and presumably not for any

--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -1823,7 +1823,7 @@ ImageBufAlgo::colorconvert(ImageBuf& dst, const ImageBuf& src, string_view from,
     bool ok = colorconvert(dst, src, processor.get(), unpremult, roi, nthreads);
     if (ok) {
         // DBG("done, setting output colorspace to {}\n", to);
-        dst.specmod().attribute("oiio:ColorSpace", to);
+        dst.specmod().set_colorspace(to);
     }
     return ok;
 }
@@ -2132,7 +2132,7 @@ ImageBufAlgo::ociolook(ImageBuf& dst, const ImageBuf& src, string_view looks,
     logtime.stop();  // transition to colorconvert
     bool ok = colorconvert(dst, src, processor.get(), unpremult, roi, nthreads);
     if (ok)
-        dst.specmod().attribute("oiio:ColorSpace", to);
+        dst.specmod().set_colorspace(to);
     return ok;
 }
 
@@ -2267,7 +2267,7 @@ ImageBufAlgo::ociofiletransform(ImageBuf& dst, const ImageBuf& src,
     logtime.stop();  // transition to colorconvert
     bool ok = colorconvert(dst, src, processor.get(), unpremult, roi, nthreads);
     if (ok)
-        dst.specmod().attribute("oiio:ColorSpace", name);
+        dst.specmod().set_colorspace(name);
     return ok;
 }
 

--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -1222,4 +1222,30 @@ pvt::check_texture_metadata_sanity(ImageSpec& spec)
 }
 
 
+
+void
+ImageSpec::set_colorspace(string_view colorspace)
+{
+    // If we're not changing color space, don't mess with anything
+    string_view oldspace = get_string_attribute("oiio:ColorSpace");
+    if (oldspace.size() && colorspace.size() && oldspace == colorspace)
+        return;
+
+    // Set or clear the main "oiio:ColorSpace" attribute
+    if (colorspace.empty()) {
+        erase_attribute("oiio:ColorSpace");
+    } else {
+        attribute("oiio:ColorSpace", colorspace);
+    }
+
+    // Clear a bunch of other metadata that might contradict the colorspace,
+    // including some format-specific things that we don't want to propagate
+    // from input to output if we know that color space transformations have
+    // occurred.
+    erase_attribute("Exif:ColorSpace");
+    erase_attribute("tiff:ColorSpace");
+    erase_attribute("tiff:PhotometricInterpretation");
+}
+
+
 OIIO_NAMESPACE_END

--- a/src/python/py_imagespec.cpp
+++ b/src/python/py_imagespec.cpp
@@ -261,6 +261,12 @@ declare_imagespec(py::module& m)
         .def("valid_tile_range", &ImageSpec::valid_tile_range, "xbegin"_a,
              "xend"_a, "ybegin"_a, "yend"_a, "zbegin"_a, "zend"_a)
         .def("copy_dimensions", &ImageSpec::copy_dimensions, "other"_a)
+        .def(
+            "set_colorspace",
+            [](ImageSpec& self, const std::string& cs) {
+                self.set_colorspace(cs);
+            },
+            "name"_a)
         // __getitem__ is the dict-like `ImageSpec[key]` lookup
         .def("__getitem__",
              [](const ImageSpec& self, const std::string& key) {

--- a/testsuite/python-imagespec/ref/out-python3.txt
+++ b/testsuite/python-imagespec/ref/out-python3.txt
@@ -202,6 +202,10 @@ Testing construction from ROI:
   deep =  False
 
 
+Testing set_colorspace:
+  after set_colorspace('sRGB'): sRGB
+  after set_colorspace(''): 
+
 Testing global attribute store/retrieve:
 get_string_attribute plugin_searchpath :  perfect
 get_int_attribute plugin_searchpath :  0

--- a/testsuite/python-imagespec/ref/out.txt
+++ b/testsuite/python-imagespec/ref/out.txt
@@ -202,6 +202,10 @@ Testing construction from ROI:
   deep =  False
 
 
+Testing set_colorspace:
+  after set_colorspace('sRGB'): sRGB
+  after set_colorspace(''): 
+
 Testing global attribute store/retrieve:
 get_string_attribute plugin_searchpath :  perfect
 get_int_attribute plugin_searchpath :  0

--- a/testsuite/python-imagespec/src/test_imagespec.py
+++ b/testsuite/python-imagespec/src/test_imagespec.py
@@ -160,6 +160,13 @@ try:
     sroi = oiio.ImageSpec (oiio.ROI(0,640,0,480,0,1,0,3), oiio.FLOAT);
     print_imagespec (sroi)
 
+    print ("\nTesting set_colorspace:")
+    s = oiio.ImageSpec()
+    s.set_colorspace("sRGB")
+    print ("  after set_colorspace('sRGB'):", s.get_string_attribute("oiio:ColorSpace"))
+    s.set_colorspace("")
+    print ("  after set_colorspace(''):", s.get_string_attribute("oiio:ColorSpace"))
+
     # Also test global OIIO functions here
     print ("\nTesting global attribute store/retrieve:")
     oiio.attribute ("plugin_searchpath", "perfect")


### PR DESCRIPTION
Sets color space metadata. While conceptually, the main job is to call `attribute("oiio:ColorSpace",name)`, this is a central spot to add logic that adjusts or removes other contradictory metadata.
