### PR TITLE
Move ARM_NEON definition and fix possible double define

### DIFF
--- a/src/include/OpenImageIO/platform.h
+++ b/src/include/OpenImageIO/platform.h
@@ -597,9 +597,6 @@ inline void cpuid (int info[4], int infoType, int extra)
         : "=a" (info[0]), "=r" (info[1]), "=c" (info[2]), "=d" (info[3])
         : "0" (infoType), "2" (extra));
 # endif
-#elif (defined(_M_ARM64) || defined (__aarch64__) || defined(__aarch64))
-    info[0] = 0; info[1] = 0; info[2] = 0; info[3] = 0;
-    #define __ARM_NEON__
 #else
     info[0] = 0; info[1] = 0; info[2] = 0; info[3] = 0;
 #endif

--- a/src/include/OpenImageIO/simd.h
+++ b/src/include/OpenImageIO/simd.h
@@ -75,6 +75,12 @@
 // OIIO_SIMD_HAS_SIMD8 : nonzero if vfloat8, vint8, vbool8 are defined
 // OIIO_SIMD_HAS_SIMD16 : nonzero if vfloat16, vint16, vbool16 are defined
 
+#if defined(_M_ARM64) || defined(__aarch64__) || defined(__aarch64)
+#  ifndef __ARM_NEON__
+#      define __ARM_NEON__
+#  endif
+#endif
+
 #if defined(__CUDA_ARCH__)
     // Cuda -- don't include any of these headers
 #elif defined(_WIN32)


### PR DESCRIPTION
It should not have been set in platform.h (inside the cpuid function!) in the first place. And apparently, though this was ok for Windows ARM, on Mac ARM it's an error because that symbol is already defined. So only redefine it if it's currently undefined. And move the whole check and definition into simd.h where all the other ARM_NEON stuff lives.
