### PR TITLE
Add EXIF write support to PNG output.

### DIFF
--- a/src/png.imageio/png_pvt.h
+++ b/src/png.imageio/png_pvt.h
@@ -684,6 +684,13 @@ write_info(png_structp& sp, png_infop& ip, int& color_type, ImageSpec& spec,
                      (png_uint_32)(yres * scale), unittype);
     }
 
+#ifdef PNG_eXIf_SUPPORTED
+    std::vector<char> exifBlob;
+    encode_exif(spec, exifBlob, endian::big);
+    png_set_eXIf_1(sp, ip, static_cast<png_uint_32>(exifBlob.size()),
+                   reinterpret_cast<png_bytep>(exifBlob.data()));
+#endif
+
     // Deal with all other params
     for (size_t p = 0; p < spec.extra_attribs.size(); ++p)
         put_parameter(sp, ip, spec.extra_attribs[p].name().string(),

--- a/src/png.imageio/pngoutput.cpp
+++ b/src/png.imageio/pngoutput.cpp
@@ -21,7 +21,11 @@ public:
     const char* format_name(void) const override { return "png"; }
     int supports(string_view feature) const override
     {
-        return (feature == "alpha" || feature == "ioproxy");
+        return (feature == "alpha" || feature == "ioproxy"
+#ifdef PNG_eXIf_SUPPORTED
+                || feature == "exif"
+#endif
+        );
     }
     bool open(const std::string& name, const ImageSpec& spec,
               OpenMode mode = Create) override;

--- a/testsuite/png/ref/out-libpng15.txt
+++ b/testsuite/png/ref/out-libpng15.txt
@@ -1,0 +1,24 @@
+Reading ../oiio-images/oiio-logo-no-alpha.png
+../oiio-images/oiio-logo-no-alpha.png :  135 x  135, 4 channel, uint8 png
+    SHA-1: 75ED9B183E083ECF0A4881EEE0B553457B698CF4
+    channel list: R, G, B, A
+    Comment: "Created with GIMP"
+    DateTime: "2009:03:26 17:19:47"
+    ResolutionUnit: "inch"
+    XResolution: 72.009
+    YResolution: 72.009
+    oiio:ColorSpace: "sRGB"
+Comparing "../oiio-images/oiio-logo-no-alpha.png" and "oiio-logo-no-alpha.png"
+PASS
+Reading ../oiio-images/oiio-logo-with-alpha.png
+../oiio-images/oiio-logo-with-alpha.png :  135 x  135, 4 channel, uint8 png
+    SHA-1: 8AED04DCCE8F83B068C537DC0982A42EFBE431B6
+    channel list: R, G, B, A
+    Comment: "Created with GIMP"
+    DateTime: "2009:03:26 18:44:26"
+    ResolutionUnit: "inch"
+    XResolution: 72.009
+    YResolution: 72.009
+    oiio:ColorSpace: "sRGB"
+Comparing "../oiio-images/oiio-logo-with-alpha.png" and "oiio-logo-with-alpha.png"
+PASS

--- a/testsuite/png/ref/out-libpng15.txt
+++ b/testsuite/png/ref/out-libpng15.txt
@@ -22,3 +22,8 @@ Reading ../oiio-images/oiio-logo-with-alpha.png
     oiio:ColorSpace: "sRGB"
 Comparing "../oiio-images/oiio-logo-with-alpha.png" and "oiio-logo-with-alpha.png"
 PASS
+Reading exif.png
+exif.png             :   64 x   64, 3 channel, uint8 png
+    SHA-1: 7CB41FEA50720B48BE0C145E1473982B23E9AB77
+    channel list: R, G, B
+    oiio:ColorSpace: "sRGB"

--- a/testsuite/png/ref/out.txt
+++ b/testsuite/png/ref/out.txt
@@ -22,3 +22,12 @@ Reading ../oiio-images/oiio-logo-with-alpha.png
     oiio:ColorSpace: "sRGB"
 Comparing "../oiio-images/oiio-logo-with-alpha.png" and "oiio-logo-with-alpha.png"
 PASS
+Reading exif.png
+exif.png             :   64 x   64, 3 channel, uint8 png
+    SHA-1: 7CB41FEA50720B48BE0C145E1473982B23E9AB77
+    channel list: R, G, B
+    Exif:ExifVersion: "0230"
+    Exif:FlashPixVersion: "0100"
+    Exif:FocalLength: 45.7 (45.7 mm)
+    Exif:WhiteBalance: 0 (auto)
+    oiio:ColorSpace: "sRGB"

--- a/testsuite/png/run.py
+++ b/testsuite/png/run.py
@@ -6,3 +6,10 @@ redirect = " >> out.txt 2>&1 "
 files = [ "oiio-logo-no-alpha.png",  "oiio-logo-with-alpha.png" ]
 for f in files:
         command += rw_command (OIIO_TESTSUITE_IMAGEDIR,  f)
+
+# test writing of exif data
+command += oiiotool ("--create 64x64 3 " +
+                     "--attrib Exif:WhiteBalance 0 " +
+                     "--attrib Exif:FocalLength 45.7 " +
+                     "-o exif.png")
+command += info_command ("exif.png", safematch=True)


### PR DESCRIPTION
## Description

Stores any EXIF data from the given ImageSpec into the PNG eXIf chunk.

## Tests


## Checklist:

- [x] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [x] ~~If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-CORPORATE)).~~ Change is small enough to not require a CLA
- [x] ~~I have updated the documentation, if applicable.~~ Not applicable I think
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

