### PR TITLE
CI: Temporarily lock fmt to 9.1.0 because its master seems broken

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,7 +258,7 @@ jobs:
             cc_compiler: gcc-12
             cxx_compiler: g++-12
             cxx_std: 20
-            fmt_ver: master
+            fmt_ver: 9.1.0
             openexr_ver: main
             pybind11_ver: master
             python_ver: "3.10"


### PR DESCRIPTION
Investigate later. For now, this is necessary for us to pass CI.
