### PR TITLE
Additional testing and improved code coverage (and minor fixes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ ext/
 .project
 .DS_Store
 *.pyc
+_coverage/
 
 # Exclude test files I tend to leave around at the top level. The leading
 # slash ensures that files with these extensions within subdirectories are not

--- a/Makefile
+++ b/Makefile
@@ -316,11 +316,12 @@ test: build
 	      lcov --remove cov.info "/Library/Developer/*" -o cov.info ; \
 	      lcov --remove cov.info "*/detail/pugixml/*" -o cov.info ; \
 	      lcov --remove cov.info "*/detail/fmt/*" -o cov.info ; \
+	      lcov --remove cov.info "*/detail/farmhash.h" -o cov.info ; \
 	      lcov --remove cov.info "*/v1/*" -o cov.info ; \
 	      lcov --remove cov.info "*/ext/robin-map/*" -o cov.info ; \
 	      lcov --remove cov.info "*/kissfft.hh" -o cov.info ; \
 	      lcov --remove cov.info "*/stb_sprintf.h" -o cov.info ; \
-	      genhtml -o ./cov -t "Test coverage" --num-spaces 4 cov.info ; \
+	      genhtml -o ../_coverage -t "Test coverage" --num-spaces 4 cov.info ; \
 	  fi )
 
 # 'make testall' does a full build and then runs all tests (even the ones

--- a/src/build-scripts/ci-test.bash
+++ b/src/build-scripts/ci-test.bash
@@ -16,7 +16,9 @@ fi
 #
 echo ; echo "Results of oiiotool --version:"
 $OpenImageIO_ROOT/bin/oiiotool --version || true
-echo ; echo "Results of oiiotool --help:"
+echo ; echo "Results of oiiotool brief help:"
+$OpenImageIO_ROOT/bin/oiiotool || true
+echo ; echo "Results of oiiotool full --help:"
 $OpenImageIO_ROOT/bin/oiiotool --help || true
 echo ; echo "Results of oiiotool --colorconfiginfo:"
 $OpenImageIO_ROOT/bin/oiiotool --colorconfiginfo

--- a/src/cmake/testing.cmake
+++ b/src/cmake/testing.cmake
@@ -184,6 +184,7 @@ macro (oiio_add_all_tests)
                     texture-wrapfill
                     texture-fat texture-skinny
                     texture-stats
+                    texture-threadtimes
                     texture-env
                    )
     oiio_add_tests (${all_texture_tests})

--- a/src/include/OpenImageIO/typedesc.h
+++ b/src/include/OpenImageIO/typedesc.h
@@ -508,7 +508,7 @@ template<> struct CType<(int)TypeDesc::DOUBLE> { typedef double type; };
 /// that control exactly how all the data types that can be described as
 /// TypeDesc ought to be formatted as a string. Uses printf-like
 /// conventions. This will someday be deprecated.
-struct tostring_formatting {
+struct OIIO_UTIL_API tostring_formatting {
     // Printf-like formatting specs for int, float, string, pointer data.
     const char *int_fmt = "%d";
     const char *float_fmt = "%g";

--- a/src/libutil/typedesc.cpp
+++ b/src/libutil/typedesc.cpp
@@ -537,7 +537,7 @@ tostring(TypeDesc type, const void* data, const tostring_formatting& fmt)
     case TypeDesc::CHAR:
         return fmt.use_sprintf
                    ? sprint_type(type, fmt.int_fmt, fmt, (char*)data)
-                   : format_type(type, fmt.int_fmt, fmt, (char*)data);
+                   : format_type(type, "{:d}", fmt, (char*)data);
     case TypeDesc::USHORT:
         return fmt.use_sprintf
                    ? sprint_type(type, fmt.uint_fmt ? fmt.uint_fmt : "%u", fmt,

--- a/src/libutil/typedesc_test.cpp
+++ b/src/libutil/typedesc_test.cpp
@@ -41,10 +41,6 @@ test_type(string_view textrep, TypeDesc constructed,
           TypeDesc named = TypeUnknown, const CType& value = CType(),
           string_view valuerep = "")
 {
-    static tostring_formatting fm;
-    fm.aggregate_sep = ", ";
-    fm.array_sep     = ", ";
-
     Strutil::print("Testing {}\n", textrep);
 
     // Make sure constructing by name from string matches the TypeDesc where
@@ -61,10 +57,29 @@ test_type(string_view textrep, TypeDesc constructed,
 
     // Verify that rendering the sample data `value` as a string matches
     // what we expect.
-    std::string s = tostring(constructed, &value, fm);
-    if (valuerep.size()) {
-        OIIO_CHECK_EQUAL(s, valuerep);
-        Strutil::print("  {}\n", s);
+    {
+        tostring_formatting fm;
+        fm.aggregate_sep = ", ";
+        fm.array_sep     = ", ";
+        std::string s    = tostring(constructed, &value, fm);
+        if (valuerep.size()) {
+            OIIO_CHECK_EQUAL(s, valuerep);
+            Strutil::print("  {}\n", s);
+        }
+    }
+
+    {
+        tostring_formatting fm(tostring_formatting::STDFORMAT);
+        fm.aggregate_sep = ", ";
+        fm.array_sep     = ", ";
+#if FMT_VERSION < 70100
+        fm.float_fmt = "{:g}";
+#endif
+        std::string s = tostring(constructed, &value, fm);
+        if (valuerep.size()) {
+            OIIO_CHECK_EQUAL(s, valuerep);
+            Strutil::print("  {}\n", s);
+        }
     }
 }
 

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -1346,9 +1346,12 @@ OpenEXROutput::close()
 
 
 bool
-OpenEXROutput::write_scanline(int y, int /*z*/, TypeDesc format,
-                              const void* data, stride_t xstride)
+OpenEXROutput::write_scanline(int y, int z, TypeDesc format, const void* data,
+                              stride_t xstride)
 {
+#if 1
+    return write_scanlines(y, y + 1, z, format, data, xstride, AutoStride);
+#else
     if (!(m_output_scanline || m_scanline_output_part)) {
         errorf("called OpenEXROutput::write_scanline without an open file");
         return false;
@@ -1400,6 +1403,7 @@ OpenEXROutput::write_scanline(int y, int /*z*/, TypeDesc format,
     // FIXME -- can we checkpoint the file?
 
     return true;
+#endif
 }
 
 

--- a/src/python/py_imagecache.cpp
+++ b/src/python/py_imagecache.cpp
@@ -124,7 +124,9 @@ declare_imagecache(py::module& m)
         //      "subimage"_a=0),
         // .def("get_thumbnail", &ImageCacheWrap::get_thumbnail,
         //      "subimage"_a=0)
-        .def("get_pixels", &ImageCacheWrap::get_pixels)
+        .def("get_pixels", &ImageCacheWrap::get_pixels, "filename"_a,
+             "subimage"_a, "miplevel"_a, "xbegin"_a, "xend"_a, "ybegin"_a,
+             "yend"_a, "zbegin"_a = 0, "zend"_a = 1, "datatype"_a = TypeUnknown)
         // .def("get_tile", &ImageCacheWrap::get_tile)
         // .def("release_tile", &ImageCacheWrap::release_tile)
         // .def("tile_pixels", &ImageCacheWrap::tile_pixels)

--- a/src/testtex/testtex.cpp
+++ b/src/testtex/testtex.cpp
@@ -445,16 +445,6 @@ warp(const Float& x, const Float& y, const Imath::M33f& xform)
 
 
 template<typename Float = float>
-inline Imath::Vec3<Float>
-warp(const Float& x, const Float& y, const Float& z, const Imath::M33f& xform)
-{
-    Imath::Vec3<Float> coord(x, y, z);
-    coord *= xform;
-    return coord;
-}
-
-
-template<typename Float = float>
 inline Imath::Vec2<Float>
 warp_coord(const Float& x, const Float& y)
 {
@@ -610,38 +600,6 @@ map_default_3D(const Int& x, const Int& y, Imath::Vec3<Float>& P,
     dPdy.x = 0;
     dPdy.y = 1.0f / output_yres * tscale;
     dPdy.z = 0;
-    dPdz.setValue(0, 0, 0);
-}
-
-
-
-template<typename Float = float, typename Int = int>
-void
-map_warp_3D(const Int& x, const Int& y, Imath::Vec3<Float>& P,
-            Imath::Vec3<Float>& dPdx, Imath::Vec3<Float>& dPdy,
-            Imath::Vec3<Float>& dPdz)
-{
-    Imath::Vec3<Float> coord = warp((Float(x) / output_xres),
-                                    (Float(y) / output_yres), Float(0.5),
-                                    xform);
-    coord.x *= sscale;
-    coord.y *= tscale;
-    coord += texoffset;
-    Imath::Vec3<Float> coordx = warp((Float(x + 1) / output_xres),
-                                     (Float(y) / output_yres), Float(0.5),
-                                     xform);
-    coordx.x *= sscale;
-    coordx.y *= tscale;
-    coordx += texoffset;
-    Imath::Vec3<Float> coordy = warp((Float(x) / output_xres),
-                                     (Float(y + 1) / output_yres), Float(0.5),
-                                     xform);
-    coordy.x *= sscale;
-    coordy.y *= tscale;
-    coordy += texoffset;
-    P    = coord;
-    dPdx = coordx - coord;
-    dPdy = coordy - coord;
     dPdz.setValue(0, 0, 0);
 }
 
@@ -1426,7 +1384,7 @@ test_getimagespec_gettexels(ustring filename)
 
 
 
-#ifndef CODECOV
+#ifndef OIIO_CODE_COVERAGE
 static void
 test_hash()
 {
@@ -2017,7 +1975,7 @@ main(int argc, const char* argv[])
         iters = 0;
     }
 
-#ifndef CODECOV
+#ifndef OIIO_CODE_COVERAGE
     if (testhash) {
         test_hash();
     }
@@ -2108,15 +2066,9 @@ main(int argc, const char* argv[])
         }
         if (!strcmp(texturetype, "Volume Texture")) {
             if (batch) {
-                if (nowarp)
-                    test_texture3d_batch(filename, map_default_3D);
-                else
-                    test_texture3d_batch(filename, map_warp_3D);
+                test_texture3d_batch(filename, map_default_3D);
             } else {
-                if (nowarp)
-                    test_texture3d(filename, map_default_3D);
-                else
-                    test_texture3d(filename, map_warp_3D);
+                test_texture3d(filename, map_default_3D);
             }
         }
         if (!strcmp(texturetype, "Shadow")) {

--- a/testsuite/python-imagebuf/ref/out-alt-python3.txt
+++ b/testsuite/python-imagebuf/ref/out-alt-python3.txt
@@ -15,6 +15,7 @@ Resetting to be a writable 640x480,3 Float:
   z channel =  -1
   deep =  False
 Constructing from a bare numpy array:
+ from 3D, shape is float 0 2 0 3 0 1 0 4
   resolution 2x3+0+0
   untiled
   4 channels: ('R', 'G', 'B', 'A')
@@ -23,6 +24,10 @@ Constructing from a bare numpy array:
   z channel =  -1
   deep =  False
   pixel (0,1) = 0.3 0 0.8 1
+
+ from 2D uint8, shape is uint8 0 2 0 3 0 1 0 1
+
+ from 4D, shape is float 0 2 0 2 0 2 0 4
 
 Testing read of ../common/textures/grid.tx:
 subimage: 0  /  1

--- a/testsuite/python-imagebuf/ref/out-alt.txt
+++ b/testsuite/python-imagebuf/ref/out-alt.txt
@@ -15,6 +15,7 @@ Resetting to be a writable 640x480,3 Float:
   z channel =  -1
   deep =  False
 Constructing from a bare numpy array:
+ from 3D, shape is float 0 2 0 3 0 1 0 4
   resolution 2x3+0+0
   untiled
   4 channels: ('R', 'G', 'B', 'A')
@@ -23,6 +24,10 @@ Constructing from a bare numpy array:
   z channel =  -1
   deep =  False
   pixel (0,1) = 0.3 0 0.8 1
+
+ from 2D uint8, shape is uint8 0 2 0 3 0 1 0 1
+
+ from 4D, shape is float 0 2 0 2 0 2 0 4
 
 Testing read of ../common/textures/grid.tx:
 subimage: 0  /  1

--- a/testsuite/python-imagebuf/ref/out-python3.txt
+++ b/testsuite/python-imagebuf/ref/out-python3.txt
@@ -15,6 +15,7 @@ Resetting to be a writable 640x480,3 Float:
   z channel =  -1
   deep =  False
 Constructing from a bare numpy array:
+ from 3D, shape is float 0 2 0 3 0 1 0 4
   resolution 2x3+0+0
   untiled
   4 channels: ('R', 'G', 'B', 'A')
@@ -23,6 +24,10 @@ Constructing from a bare numpy array:
   z channel =  -1
   deep =  False
   pixel (0,1) = 0.3 0 0.8 1
+
+ from 2D uint8, shape is uint8 0 2 0 3 0 1 0 1
+
+ from 4D, shape is float 0 2 0 2 0 2 0 4
 
 Testing read of ../common/textures/grid.tx:
 subimage: 0  /  1

--- a/testsuite/python-imagebuf/ref/out.txt
+++ b/testsuite/python-imagebuf/ref/out.txt
@@ -15,6 +15,7 @@ Resetting to be a writable 640x480,3 Float:
   z channel =  -1
   deep =  False
 Constructing from a bare numpy array:
+ from 3D, shape is float 0 2 0 3 0 1 0 4
   resolution 2x3+0+0
   untiled
   4 channels: ('R', 'G', 'B', 'A')
@@ -23,6 +24,10 @@ Constructing from a bare numpy array:
   z channel =  -1
   deep =  False
   pixel (0,1) = 0.3 0 0.8 1
+
+ from 2D uint8, shape is uint8 0 2 0 3 0 1 0 1
+
+ from 4D, shape is float 0 2 0 2 0 2 0 4
 
 Testing read of ../common/textures/grid.tx:
 subimage: 0  /  1

--- a/testsuite/python-imagebuf/src/test_imagebuf.py
+++ b/testsuite/python-imagebuf/src/test_imagebuf.py
@@ -155,15 +155,29 @@ try:
     b = oiio.ImageBuf(numpy.array([[[0.1,0.0,0.9,1.0], [0.2,0.0,0.7,1.0]],
                                    [[0.3,0.0,0.8,1.0], [0.4,0.0,0.6,1.0]],
                                    [[0.5,0.0,0.7,1.0], [0.6,0.0,0.5,1.0]]], dtype="f"))
+    print (" from 3D, shape is", b.spec().format, b.roi)
     # should be width=2, height=3, channels=4, format=FLOAT
     print_imagespec (b.spec())
     print ("  pixel (0,1) = {:.3g} {:.3g} {:.3g} {:.3g}".format(b.getpixel (0,1)[0],
            b.getpixel (0,1)[1], b.getpixel (0,1)[2], b.getpixel(0,1)[3]))
     print ("")
+    b = oiio.ImageBuf(numpy.array([[1.0, 0.5],
+                                   [0.25, 0.125],
+                                   [1.0, 0.5]], dtype="uint8"))
+    print (" from 2D uint8, shape is", b.spec().format, b.roi)
+    print ("")
+    b = oiio.ImageBuf(numpy.array([[[[0.1,0.0,0.9,1.0], [0.2,0.0,0.7,1.0]],
+                                   [[0.3,0.0,0.8,1.0], [0.4,0.0,0.6,1.0]] ],
+                                  [[[0.3,0.0,0.8,1.0], [0.4,0.0,0.6,1.0]],
+                                   [[0.5,0.0,0.7,1.0], [0.6,0.0,0.5,1.0]]]], dtype="f"))
+    print (" from 4D, shape is", b.spec().format, b.roi)
+    print ("")
 
     # Test reading from disk
     print ("Testing read of ../common/textures/grid.tx:")
     b = oiio.ImageBuf ("../common/textures/grid.tx")
+    b.init_spec ("../common/textures/grid.tx")
+    b.read ()
     print ("subimage:", b.subimage, " / ", b.nsubimages)
     print ("miplevel:", b.miplevel, " / ", b.nmiplevels)
     print ("channels:", b.nchannels)

--- a/testsuite/python-imagecache/ref/out-python27.txt
+++ b/testsuite/python-imagecache/ref/out-python27.txt
@@ -13,11 +13,11 @@ untyped getattribute stat:cache_memory_used 0
 untyped getattribute stat:image_size 4036864
 untyped getattribute total_files 2
 untyped getattribute all_filenames ('../common/grid.tif', '../common/tahoe-tiny.tif')
-getpixels from grid.tif: [[[1.         0.49803925 0.49803925 1.        ]
-  [1.         0.49803925 0.49803925 1.        ]]
+getpixels from grid.tif: [[[ 1.          0.49803925  0.49803925  1.        ]
+  [ 1.          0.49803925  0.49803925  1.        ]]
 
- [[1.         0.49803925 0.49803925 1.        ]
-  [1.         0.49803925 0.49803925 1.        ]]]
+ [[ 1.          0.49803925  0.49803925  1.        ]
+  [ 1.          0.49803925  0.49803925  1.        ]]]
   has_error? False
   geterror? 
 getpixels from broken.tif: None

--- a/testsuite/python-imagecache/ref/out-win.txt
+++ b/testsuite/python-imagecache/ref/out-win.txt
@@ -22,7 +22,7 @@ getpixels from grid.tif: [[[1.         0.49803925 0.49803925 1.        ]
   geterror? 
 getpixels from broken.tif: None
   has_error? True
-  geterror? Invalid image file "broken.tif": Could not open file: broken.tif: No such file or directory
+  geterror? Invalid image file "broken.tif": Could not open file: S: Cannot open
 getstats beginning:
 ['OpenImageIO', 'ImageCache', 'statistics']
 

--- a/testsuite/python-imagecache/src/test_imagecache.py
+++ b/testsuite/python-imagecache/src/test_imagecache.py
@@ -14,6 +14,14 @@ import OpenImageIO as oiio
 try:
     ic = oiio.ImageCache()
 
+    # Set some attributes
+    ic.attribute("max_open_files", 90)
+    ic.attribute("max_memory_MB", 900.0)
+    ic.attribute("searchpath", "../common")
+    print ("getattribute(\"max_open_files\")", ic.getattribute("max_open_files"))
+    print ("getattribute(\"max_memory_MB\")", ic.getattribute("max_memory_MB"))
+    print ("getattribute(\"searchpath\")", ic.getattribute("searchpath"))
+
     # Force a file to be touched by the IC
     ib = oiio.ImageBuf("../common/tahoe-tiny.tif")
     ib = oiio.ImageBuf("../common/grid.tif")
@@ -36,6 +44,23 @@ try:
     print ("untyped getattribute stat:image_size", ic.getattribute("stat:image_size"))
     print ("untyped getattribute total_files", ic.getattribute("total_files"))
     print ("untyped getattribute all_filenames", ic.getattribute("all_filenames"))
+
+    # Test getpixels()
+    print ("getpixels from grid.tif:", ic.get_pixels("../common/grid.tif", 0, 0,
+                                                     3, 5, 3, 5, 0, 1, "float"))
+    print ("  has_error?", ic.has_error)
+    print ("  geterror?", ic.geterror())
+    print ("getpixels from broken.tif:", ic.get_pixels("broken.tif", 0, 0,
+                                                     3, 5, 3, 5, 0, 1, "float"))
+    print ("  has_error?", ic.has_error)
+    print ("  geterror?", ic.geterror())
+
+    print ("getstats beginning:")
+    print (ic.getstats().split()[0:3])
+
+    # invalidate some things
+    ic.invalidate("../common/tahoe-tiny.tif")
+    ic.invalidate_all(True)
 
     print ("\nDone.")
 except Exception as detail:

--- a/testsuite/texture-threadtimes/run.py
+++ b/testsuite/texture-threadtimes/run.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python 
+
+command += testtex_command ("--maketests 10 \"test{:04}.exr\" --maketest-res 1024 --threadtimes 7 --wedge")
+
+outputs = [ ]


### PR DESCRIPTION
* Better Typedesc testing of 'tostring' with fmt style formatting commands, and fix a bug that uncovered.

* Refine 'make CODECOV=1' behavior

* Beef up python-imagecache test to test getpixels, more attribute, invalidate.

* Better testing of python IB construction from numpy array.

* testtex: Use correct guard to avoid compiling unused code for coverage analysis testtex: get rid of unused 3d warp code.

* Add texture-threadtimes test

* Eliminate redundant code in exroutput.c by implementing write_scanline using write_scanlines.
