### PR TITLE
TIFF: refine logic for setting PhotometricInterpretation on output

### DIFF
--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -2474,9 +2474,13 @@ aspects of the writing itself:
        TIFF files despite their being legal.
    * - ``tiff:ColorSpace``
      - string
-     - Requests that the file be saved with a non-RGB color spaces. Choices
-       are ``RGB``, ``CMYK``.  (``YCbCr``, ``CIELAB``, ``ICCLAB``,
-       ``ITULAB`` are not yet supported.)
+     - Requests that the RGB image be converted and saved in the TIFF file in
+       a non-RGB color space. Choices are ``RGB``, ``CMYK``.  (Note that
+       ``YCbCr``, ``CIELAB``, ``ICCLAB``, ``ITULAB`` are not yet supported
+       for convertion. However, if the `oiio:ColorSpace` is one of those,
+       meaning that the image data is presumed to already be in that
+       space, the TIFF PhotometricInterpretation tag will be set to convey
+       this information.)
    * - ``tiff:zipquality``
      - int
      - A time-vs-space knob for ``zip`` compression, ranging from 1-9
@@ -2504,18 +2508,17 @@ aspects of the writing itself:
 **TIFF compression modes**
 
 The full list of possible TIFF compression mode values are as
-follows ($ ^*$ indicates that OpenImageIO can write that format, and is not
-part of the format name):
+follows.
 
-    ``none`` $ ^*$
-    ``lzw`` $ ^*$
-    ``zip`` $ ^*$
+    ``none`` :sup:`*`
+    ``lzw`` :sup:`*`
+    ``zip`` :sup:`*`
     ``ccitt_t4``
     ``ccitt_t6``
     ``ccittfax3``
     ``ccittfax4``
     ``ccittrle2``
-    ``ccittrle`` $ ^*$
+    ``ccittrle`` :sup:`*`
     ``dcs``
     ``isojbig``
     ``IT8BL``
@@ -2523,11 +2526,11 @@ part of the format name):
     ``IT8LW``
     ``IT8MP``
     ``jp2000``
-    ``jpeg`` $ ^*$
+    ``jpeg`` :sup:`*`
     ``lzma``
     ``next``
     ``ojpeg``
-    ``packbits`` $ ^*$
+    ``packbits`` :sup:`*`
     ``pixarfilm``
     ``pixarlog``
     ``sgilog24``
@@ -2535,6 +2538,10 @@ part of the format name):
     ``T43``
     ``T85``
     ``thunderscan``
+
+:sup:`*` indicates that OpenImageIO can write that format, and is not
+part of the format name. The compression types without the asterisk are
+supported for reading but not for writing.
 
 **Custom I/O Overrides**
 

--- a/testsuite/iinfo/ref/out-fmt6.txt
+++ b/testsuite/iinfo/ref/out-fmt6.txt
@@ -341,10 +341,10 @@ Reading tmp.tif
 <deep>0</deep>
 <attrib name="oiio:BitsPerSample" type="int">8</attrib>
 <attrib name="Orientation" type="int" description="normal">1</attrib>
+<attrib name="tiff:Compression" type="int">8</attrib>
 <attrib name="tiff:PhotometricInterpretation" type="int">2</attrib>
 <attrib name="tiff:PlanarConfiguration" type="int">1</attrib>
 <attrib name="planarconfig" type="string">contig</attrib>
-<attrib name="tiff:Compression" type="int">8</attrib>
 <attrib name="compression" type="string">zip</attrib>
 <attrib name="tiff:RowsPerStrip" type="int">32</attrib>
 </ImageSpec>

--- a/testsuite/iinfo/ref/out.txt
+++ b/testsuite/iinfo/ref/out.txt
@@ -341,10 +341,10 @@ Reading tmp.tif
 <deep>0</deep>
 <attrib name="oiio:BitsPerSample" type="int">8</attrib>
 <attrib name="Orientation" type="int" description="normal">1</attrib>
+<attrib name="tiff:Compression" type="int">8</attrib>
 <attrib name="tiff:PhotometricInterpretation" type="int">2</attrib>
 <attrib name="tiff:PlanarConfiguration" type="int">1</attrib>
 <attrib name="planarconfig" type="string">contig</attrib>
-<attrib name="tiff:Compression" type="int">8</attrib>
 <attrib name="compression" type="string">zip</attrib>
 <attrib name="tiff:RowsPerStrip" type="int">32</attrib>
 </ImageSpec>

--- a/testsuite/python-imagebuf/ref/out-alt-python3.txt
+++ b/testsuite/python-imagebuf/ref/out-alt-python3.txt
@@ -60,10 +60,10 @@ Printing the whole spec to be sure:
   textureformat = "Plain Texture"
   wrapmodes = "black,black"
   fovcot = 1.0
+  tiff:Compression = 8
   tiff:PhotometricInterpretation = 2
   tiff:PlanarConfiguration = 1
   planarconfig = "contig"
-  tiff:Compression = 8
   compression = "zip"
   PixelAspectRatio = 1.0
   oiio:AverageColor = "0.608983,0.608434,0.608728,1"
@@ -88,10 +88,10 @@ Resetting to a different MIP level:
   textureformat = "Plain Texture"
   wrapmodes = "black,black"
   fovcot = 1.0
+  tiff:Compression = 8
   tiff:PhotometricInterpretation = 2
   tiff:PlanarConfiguration = 1
   planarconfig = "contig"
-  tiff:Compression = 8
   compression = "zip"
   PixelAspectRatio = 1.0
   oiio:AverageColor = "0.608983,0.608434,0.608728,1"

--- a/testsuite/python-imagebuf/ref/out-alt.txt
+++ b/testsuite/python-imagebuf/ref/out-alt.txt
@@ -60,10 +60,10 @@ Printing the whole spec to be sure:
   textureformat = "Plain Texture"
   wrapmodes = "black,black"
   fovcot = 1.0
+  tiff:Compression = 8
   tiff:PhotometricInterpretation = 2
   tiff:PlanarConfiguration = 1
   planarconfig = "contig"
-  tiff:Compression = 8
   compression = "zip"
   PixelAspectRatio = 1.0
   oiio:AverageColor = "0.608983,0.608434,0.608728,1"
@@ -88,10 +88,10 @@ Resetting to a different MIP level:
   textureformat = "Plain Texture"
   wrapmodes = "black,black"
   fovcot = 1.0
+  tiff:Compression = 8
   tiff:PhotometricInterpretation = 2
   tiff:PlanarConfiguration = 1
   planarconfig = "contig"
-  tiff:Compression = 8
   compression = "zip"
   PixelAspectRatio = 1.0
   oiio:AverageColor = "0.608983,0.608434,0.608728,1"

--- a/testsuite/python-imagebuf/ref/out-python3.txt
+++ b/testsuite/python-imagebuf/ref/out-python3.txt
@@ -60,10 +60,10 @@ Printing the whole spec to be sure:
   textureformat = "Plain Texture"
   wrapmodes = "black,black"
   fovcot = 1.0
+  tiff:Compression = 8
   tiff:PhotometricInterpretation = 2
   tiff:PlanarConfiguration = 1
   planarconfig = "contig"
-  tiff:Compression = 8
   compression = "zip"
   PixelAspectRatio = 1.0
   oiio:AverageColor = "0.608983,0.608434,0.608728,1"
@@ -88,10 +88,10 @@ Resetting to a different MIP level:
   textureformat = "Plain Texture"
   wrapmodes = "black,black"
   fovcot = 1.0
+  tiff:Compression = 8
   tiff:PhotometricInterpretation = 2
   tiff:PlanarConfiguration = 1
   planarconfig = "contig"
-  tiff:Compression = 8
   compression = "zip"
   PixelAspectRatio = 1.0
   oiio:AverageColor = "0.608983,0.608434,0.608728,1"

--- a/testsuite/python-imagebuf/ref/out.txt
+++ b/testsuite/python-imagebuf/ref/out.txt
@@ -60,10 +60,10 @@ Printing the whole spec to be sure:
   textureformat = "Plain Texture"
   wrapmodes = "black,black"
   fovcot = 1.0
+  tiff:Compression = 8
   tiff:PhotometricInterpretation = 2
   tiff:PlanarConfiguration = 1
   planarconfig = "contig"
-  tiff:Compression = 8
   compression = "zip"
   PixelAspectRatio = 1.0
   oiio:AverageColor = "0.608983,0.608434,0.608728,1"
@@ -88,10 +88,10 @@ Resetting to a different MIP level:
   textureformat = "Plain Texture"
   wrapmodes = "black,black"
   fovcot = 1.0
+  tiff:Compression = 8
   tiff:PhotometricInterpretation = 2
   tiff:PlanarConfiguration = 1
   planarconfig = "contig"
-  tiff:Compression = 8
   compression = "zip"
   PixelAspectRatio = 1.0
   oiio:AverageColor = "0.608983,0.608434,0.608728,1"

--- a/testsuite/python-imageinput/ref/out-alt.txt
+++ b/testsuite/python-imageinput/ref/out-alt.txt
@@ -56,10 +56,10 @@ Opened "grid.tx" as a tiff
   textureformat = "Plain Texture"
   wrapmodes = "black,black"
   fovcot = 1.0
+  tiff:Compression = 8
   tiff:PhotometricInterpretation = 2
   tiff:PlanarConfiguration = 1
   planarconfig = "contig"
-  tiff:Compression = 8
   compression = "zip"
   PixelAspectRatio = 1.0
   oiio:AverageColor = "0.608983,0.608434,0.608728,1"

--- a/testsuite/python-imageinput/ref/out-alt2.txt
+++ b/testsuite/python-imageinput/ref/out-alt2.txt
@@ -56,10 +56,10 @@ Opened "grid.tx" as a tiff
   textureformat = "Plain Texture"
   wrapmodes = "black,black"
   fovcot = 1.0
+  tiff:Compression = 8
   tiff:PhotometricInterpretation = 2
   tiff:PlanarConfiguration = 1
   planarconfig = "contig"
-  tiff:Compression = 8
   compression = "zip"
   PixelAspectRatio = 1.0
   oiio:AverageColor = "0.608983,0.608434,0.608728,1"

--- a/testsuite/python-imageinput/ref/out-py27-jpeg9d.txt
+++ b/testsuite/python-imageinput/ref/out-py27-jpeg9d.txt
@@ -56,10 +56,10 @@ Opened "grid.tx" as a tiff
   textureformat = "Plain Texture"
   wrapmodes = "black,black"
   fovcot = 1.0
+  tiff:Compression = 8
   tiff:PhotometricInterpretation = 2
   tiff:PlanarConfiguration = 1
   planarconfig = "contig"
-  tiff:Compression = 8
   compression = "zip"
   PixelAspectRatio = 1.0
   oiio:AverageColor = "0.608983,0.608434,0.608728,1"

--- a/testsuite/python-imageinput/ref/out-py27.txt
+++ b/testsuite/python-imageinput/ref/out-py27.txt
@@ -56,10 +56,10 @@ Opened "grid.tx" as a tiff
   textureformat = "Plain Texture"
   wrapmodes = "black,black"
   fovcot = 1.0
+  tiff:Compression = 8
   tiff:PhotometricInterpretation = 2
   tiff:PlanarConfiguration = 1
   planarconfig = "contig"
-  tiff:Compression = 8
   compression = "zip"
   PixelAspectRatio = 1.0
   oiio:AverageColor = "0.608983,0.608434,0.608728,1"

--- a/testsuite/python-imageinput/ref/out-py37-jpeg9d.txt
+++ b/testsuite/python-imageinput/ref/out-py37-jpeg9d.txt
@@ -56,10 +56,10 @@ Opened "grid.tx" as a tiff
   textureformat = "Plain Texture"
   wrapmodes = "black,black"
   fovcot = 1.0
+  tiff:Compression = 8
   tiff:PhotometricInterpretation = 2
   tiff:PlanarConfiguration = 1
   planarconfig = "contig"
-  tiff:Compression = 8
   compression = "zip"
   PixelAspectRatio = 1.0
   oiio:AverageColor = "0.608983,0.608434,0.608728,1"

--- a/testsuite/python-imageinput/ref/out-python3-win.txt
+++ b/testsuite/python-imageinput/ref/out-python3-win.txt
@@ -56,10 +56,10 @@ Opened "grid.tx" as a tiff
   textureformat = "Plain Texture"
   wrapmodes = "black,black"
   fovcot = 1.0
+  tiff:Compression = 8
   tiff:PhotometricInterpretation = 2
   tiff:PlanarConfiguration = 1
   planarconfig = "contig"
-  tiff:Compression = 8
   compression = "zip"
   PixelAspectRatio = 1.0
   oiio:AverageColor = "0.608983,0.608434,0.608728,1"

--- a/testsuite/python-imageinput/ref/out-python3.txt
+++ b/testsuite/python-imageinput/ref/out-python3.txt
@@ -56,10 +56,10 @@ Opened "grid.tx" as a tiff
   textureformat = "Plain Texture"
   wrapmodes = "black,black"
   fovcot = 1.0
+  tiff:Compression = 8
   tiff:PhotometricInterpretation = 2
   tiff:PlanarConfiguration = 1
   planarconfig = "contig"
-  tiff:Compression = 8
   compression = "zip"
   PixelAspectRatio = 1.0
   oiio:AverageColor = "0.608983,0.608434,0.608728,1"

--- a/testsuite/python-imageinput/ref/out-ubuntu-py2.7-pybind2.3.txt
+++ b/testsuite/python-imageinput/ref/out-ubuntu-py2.7-pybind2.3.txt
@@ -56,10 +56,10 @@ Opened "grid.tx" as a tiff
   textureformat = "Plain Texture"
   wrapmodes = "black,black"
   fovcot = 1.0
+  tiff:Compression = 8
   tiff:PhotometricInterpretation = 2
   tiff:PlanarConfiguration = 1
   planarconfig = "contig"
-  tiff:Compression = 8
   compression = "zip"
   PixelAspectRatio = 1.0
   oiio:AverageColor = "0.608983,0.608434,0.608728,1"

--- a/testsuite/python-imageinput/ref/out.txt
+++ b/testsuite/python-imageinput/ref/out.txt
@@ -56,10 +56,10 @@ Opened "grid.tx" as a tiff
   textureformat = "Plain Texture"
   wrapmodes = "black,black"
   fovcot = 1.0
+  tiff:Compression = 8
   tiff:PhotometricInterpretation = 2
   tiff:PlanarConfiguration = 1
   planarconfig = "contig"
-  tiff:Compression = 8
   compression = "zip"
   PixelAspectRatio = 1.0
   oiio:AverageColor = "0.608983,0.608434,0.608728,1"


### PR DESCRIPTION
Some background: TIFF allows for pixel values to be encoded in some alternative color spaces, like YCbCr, CIELAB, etc., and this is indicated by the TIFF PhotometricInterpretation tag. Since in practice we almost never encounter these encodings in the wild, and they require a lot of custom code to handle (for example, YCbCr also comes along with the ability to subsample the chroma, and options for different placements of the subsampled positions, yuck), for most of these cases we just lean on libtiff's ability to convert the whole thing to RGBA for us, and so in that case, we return to the user the pixels as RGBA, and set the "tiff:ColorSpace" metadata just as an advisory to indicate how it had been encoded in the file. But we don't support writing any of those. (One exception is that we do allow reading and writing of CMYK files.)

OK, but now what about a case where the app already has the data in one of these spaces (such as YCrCb; and let's ignore the whole subsampling miasma and assume we don't want to support that), and all we want to do is write that data to a TIFF file -- without any kind of data conversion -- but to set the TIFF tags properly to indicate that the data in the file is what we know it to be?

A related special case of this is: what if we have a TIFF file that has YCbCr data but neglected to mark it as such (I'm staring daggers at a certain widely used compositing package right now), and to fix this, we want to use OIIO to just copy the file and set the right tags?

It turns out that in the status quo, it is surprisingly difficult to do this. There is just nothing in our existing TIFF output code that will write any of those photometric tags for those spaces, and no way to communicate that this is what we desire.

Whew. Now here's what this patch does:

* If the "oiio:ColorSpace" attribute (our usual way to indicate presumed color space of the pixel data) says that the pixels are already in one of those color spaces (specifically, "YCbCr", "CIELAB", "ICCLAB", "ITULAB", "LOGL", "LOGLUV"), then we set the PhotometricInterpretation tag as such in the TIFF file that we write.

* We still DO NOT interpret that as a request to convert pixel data from any other space into this one. In other words, the TIFF output does not convert color spaces (except for RGB <-> CMYK); this merely lets us output a file that correctly says the data are what the app thinks they are.

* A bunch of minor refactoring was necessary because of some unobvious coupling and order dependencies. For example, the sgilog compression techniques MUST be used with the LOGLUV color space, and vice versa. You have to know how both should be set before checking that they are compatible, and if they are not, adjust something that it's not too late to change.

So the punchline at the end is that if you had a TIFF file that has YCbCr encoded pixels, but for some reason it's marked as ordinary RGB, you can fix it as follows:

    oiiotool ycbcr_disguised_as_rgb.tif --iscolorspace YCbCb -o real_ycbcr.tif

