### PR TITLE
Testing: improve testing of maketx

### DIFF
--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -576,24 +576,10 @@ fix_latl_edges(ImageBuf& buf)
 
 
 
-static std::string
-formatres(const ImageSpec& spec, bool extended = false)
+inline std::string
+formatres(const ImageSpec& spec)
 {
-    std::string s;
-    s = Strutil::sprintf("%dx%d", spec.width, spec.height);
-    if (extended) {
-        if (spec.x || spec.y)
-            s += Strutil::sprintf("%+d%+d", spec.x, spec.y);
-        if (spec.width != spec.full_width || spec.height != spec.full_height
-            || spec.x != spec.full_x || spec.y != spec.full_y) {
-            s += " (full/display window is ";
-            s += Strutil::sprintf("%dx%d", spec.full_width, spec.full_height);
-            if (spec.full_x || spec.full_y)
-                s += Strutil::sprintf("%+d%+d", spec.full_x, spec.full_y);
-            s += ")";
-        }
-    }
-    return s;
+    return Strutil::fmt::format("{}x{}", spec.width, spec.height);
 }
 
 
@@ -705,9 +691,10 @@ write_mipmap(ImageBufAlgo::MakeTextureMode mode, std::shared_ptr<ImageBuf>& img,
 
     // Write out the image
     if (verbose) {
-        outstream << "  Writing file: " << outputfilename << std::endl;
-        outstream << "  Filter \"" << filtername << "\"\n";
-        outstream << "  Top level is " << formatres(outspec) << std::endl;
+        print(outstream, "  Writing file: {}\n", outputfilename);
+        print(outstream, "  Filter \"{}\"\n", filtername);
+        print(outstream, "  Top level is {}x{}\n", outspec.width,
+              outspec.height);
     }
 
     if (clamp_half) {

--- a/src/maketx/maketx.cpp
+++ b/src/maketx/maketx.cpp
@@ -291,7 +291,7 @@ getargs(int argc, char* argv[], ImageSpec& configspec)
       .hidden(); // DEPRECATED 1.6
     ap.arg("--mipimage %L:FILENAME", &mipimages)
       .help("Specify an individual MIP level");
-    ap.arg("--cdf %d:N", &cdf)
+    ap.arg("--cdf", &cdf)
       .help("Store the forward and inverse Gaussian CDF as a lookup-table. The variance is set by cdfsigma (1/6 by default), and the number of buckets \
               in the lookup table is determined by cdfbits (8 bit - 256 buckets by default)");
     ap.arg("--cdfsigma %f:N", &cdfsigma)
@@ -531,7 +531,7 @@ main(int argc, char* argv[])
         mode = ImageBufAlgo::MakeTxBumpWithSlopes;
 
     bool ok = ImageBufAlgo::make_texture(mode, filenames[0], outputfilename,
-                                         configspec);
+                                         configspec, &std::cout);
     if (!ok)
         std::cout << "make_texture ERROR: " << OIIO::geterror() << "\n";
     if (runstats)

--- a/testsuite/maketx/ref/out.txt
+++ b/testsuite/maketx/ref/out.txt
@@ -21,6 +21,43 @@ grid.tx              : 1000 x 1000, 4 channel, uint8 tiff
     tiff:Compression: 8
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 1
+Reading checker.tx
+checker.tx           :  128 x  128, 4 channel, uint8 tiff
+    MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
+    SHA-1: 1C1A7D35CCED212B768B31F002B442EA947D89A6
+    channel list: R, G, B, A
+    tile size: 64 x 64
+    compression: "zip"
+    fovcot: 1
+    Orientation: 1 (normal)
+    planarconfig: "contig"
+    textureformat: "Plain Texture"
+    wrapmodes: "black,black"
+    oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:BitsPerSample: 8
+    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
+    tiff:Compression: 8
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 1
+maketx: no update required for "checker.tx"
+Reading checker.tx
+checker.tx           :  128 x  128, 4 channel, uint8 tiff
+    MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
+    SHA-1: 1C1A7D35CCED212B768B31F002B442EA947D89A6
+    channel list: R, G, B, A
+    tile size: 64 x 64
+    compression: "zip"
+    fovcot: 1
+    Orientation: 1 (normal)
+    planarconfig: "contig"
+    textureformat: "Plain Texture"
+    wrapmodes: "black,black"
+    oiio:AverageColor: "0.5,0.5,0.5,1"
+    oiio:BitsPerSample: 8
+    oiio:SHA-1: "D924CA144A02479D1507F5910F5FC8F51EF78765"
+    tiff:Compression: 8
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 1
 Reading grid-resize.tx
 grid-resize.tx       : 1024 x 1024, 4 channel, uint8 tiff
     MIP-map levels: 1024x1024 512x512 256x256 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1
@@ -264,6 +301,7 @@ checker-prman.tx     :  128 x  128, 4 channel, int16 tiff
     tiff:PhotometricInterpretation: 2
     tiff:PlanarConfiguration: 2
 make_texture ERROR: maketx ERROR: Nan/Inf at 2 pixels
+make_texture ERROR: maketx ERROR: Nan/Inf at 2 pixels
 Reading nan.exr
 nan.exr              :   64 x   64, 3 channel, half openexr
     SHA-1: 47A8E8F3E8B2C3B6B032FCC8C39D3C5FC1AAA390
@@ -399,6 +437,27 @@ bumpslope.exr        :   64 x   64, 6 channel, half openexr
     oiio:AverageColor: "0.499779,-0.000457942,-4.17233e-05,0.00197116,0.00178894,3.45764e-05"
     oiio:ColorSpace: "Linear"
     oiio:SHA-1: "49B533110A914CE89BE0B14753A6A4CC037C964F"
+    oiio:subimages: 1
+    openexr:roundingmode: 0
+Reading cdf.exr
+cdf.exr              :   64 x   64, 1 channel, half openexr
+    MIP-map levels: 64x64 32x32 16x16 8x8 4x4 2x2 1x1
+    SHA-1: 4125BD6CDB6F869433A2C4A3DF5A16AF92EC9641
+    channel list: Y
+    tile size: 64 x 64
+    CDF_0: 0.129412, 0.129412, 0.129412, 0.152941, 0.152941, 0.192157, 0.196078, 0.196078, 0.203922, 0.207843, 0.219608, 0.219608, 0.219608, 0.223529, 0.227451, 0.231373, ... [256 x float]
+    CDF_bits: 8
+    compression: "zip"
+    fovcot: 1
+    invCDF_0: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... [256 x float]
+    PixelAspectRatio: 1
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    textureformat: "Plain Texture"
+    wrapmodes: "black,black"
+    oiio:AverageColor: "0.499779"
+    oiio:ColorSpace: "Linear"
+    oiio:SHA-1: "00DFB31D0260CC466CDCF9FE42446D4896E655FE"
     oiio:subimages: 1
     openexr:roundingmode: 0
 Comparing "uffizi_latlong_env-128.exr" and "ref/uffizi_latlong_env-128.exr"

--- a/testsuite/maketx/run.py
+++ b/testsuite/maketx/run.py
@@ -7,9 +7,17 @@ outputs = [ ]
 # Just for simplicity, make a checkerboard with a solid alpha
 command += oiiotool (" --pattern checker 128x128 4 --ch R,G,B,=1.0"
             + " -d uint8 -o " + make_relpath("checker.tif") )
+# Noise bump pattern
+command += oiiotool (" --pattern noise 64x64 1"
+           + " -d half -o " + make_relpath("noise.exr"))
 
 # Basic test - recreate the grid texture
 command += maketx_command ("../common/grid.tif", "grid.tx", showinfo=True)
+
+# Make tex twice using -u
+command += maketx_command ("checker.tif", "checker.tx", "-u", showinfo=True)
+command += maketx_command ("checker.tif", "checker.tx", "-u", showinfo=True)
+
 
 # Test --resize (to power of 2) with the grid, which is 1000x1000
 command += maketx_command ("../common/grid.tif", "grid-resize.tx",
@@ -122,11 +130,21 @@ command += maketx_command ("src/uffizi_probe-128.exr", "uffizi_latlong_env-128.e
                            "--lightprobe -d half")
 outputs += [ "uffizi_latlong_env-128.exr" ]
 
-#Test --bumpslopes to export a 6 channels height map with gradients
-command += oiiotool (" --pattern noise 64x64 1"
-           + " -d half -o " + make_relpath("bump.exr"))
-command += maketx_command ("bump.exr", "bumpslope.exr",
+# Test --bumpslopes to export a 6 channels height map with gradients
+command += maketx_command ("noise.exr", "bumpslope.exr",
                            "--bumpslopes -d half", showinfo=True)
+
+# Test --cdf
+command += maketx_command ("noise.exr", "cdf.exr",
+                           "--cdf -d half", showinfo=True)
+
+# Test --sattrib, --attrib
+command += maketx_command ("checker.tif", "checker-attribs.tx",
+                           "--sattrib sattr sname sval " +
+                           "--attrib iattr iname 42 " +
+                           "--attrib fattr iname 3.14159 " +
+                           "--attrib sattr2 sval2 ",
+                           showinfo = True)
 
 
 outputs += [ "out.txt" ]


### PR DESCRIPTION
* Tests for maketx -u, --attrib, --sattrib, --cdf

* maketx was documeted to take --cdf as a simple flag, but was incorrectly implemented as requiring a (pointless) nonzero argument. Fix it and hope nobody was depending on the undocumented behavior.

* maketx -v arg never had any effect. Add it back.
