### PR TITLE
Fix wrong oiio:UnassociatedAlpha metadata for PSD files

### DIFF
--- a/src/psd.imageio/psdinput.cpp
+++ b/src/psd.imageio/psdinput.cpp
@@ -1751,9 +1751,13 @@ PSDInput::setup()
     // Composite spec
     m_specs.emplace_back(m_header.width, m_header.height, spec_channel_count,
                          m_type_desc);
-    m_specs.back().extra_attribs = m_composite_attribs.extra_attribs;
+    ImageSpec& spec    = m_specs.back();
+    spec.extra_attribs = m_composite_attribs.extra_attribs;
     if (m_WantRaw)
-        fill_channel_names(m_specs.back(), m_image_data.transparency);
+        fill_channel_names(spec, m_image_data.transparency);
+    if (spec.alpha_channel != -1)
+        if (m_keep_unassociated_alpha)
+            spec.attribute("oiio:UnassociatedAlpha", 1);
 
     // Composite channels
     m_channels.reserve(m_subimage_count);
@@ -1780,6 +1784,9 @@ PSDInput::setup()
         spec.extra_attribs = m_common_attribs.extra_attribs;
         if (m_WantRaw)
             fill_channel_names(spec, transparency);
+        if (spec.alpha_channel != -1)
+            if (m_keep_unassociated_alpha)
+                spec.attribute("oiio:UnassociatedAlpha", 1);
 
         m_channels.resize(m_channels.size() + 1);
         std::vector<ChannelInfo*>& channels = m_channels.back();
@@ -1793,10 +1800,6 @@ PSDInput::setup()
         if (layer.name.size())
             spec.attribute("oiio:subimagename", layer.name);
     }
-
-    if (m_specs.back().alpha_channel != -1)
-        if (m_keep_unassociated_alpha)
-            m_specs.back().attribute("oiio:UnassociatedAlpha", 1);
 }
 
 

--- a/testsuite/psd/ref/out.txt
+++ b/testsuite/psd/ref/out.txt
@@ -805,6 +805,195 @@ Reading ../oiio-images/psd_rgba_8.psd
     stEvt:instanceID: "xmp.iid:037A91A22BCDE011A998CBE7B5CCEB92; xmp.iid:2793235262CFE011B8B8C52D9599FB9E"
     stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
     stEvt:when: "2011-08-22T22:07:44-04:00; 2011-08-25T17:39:28-04:00"
+Reading ../oiio-images/psd_123.psd
+../oiio-images/psd_123.psd :  257 x  126, 4 channel, uint8 psd
+    4 subimages: 257x126 [u8,u8,u8,u8], 33x98 [u8,u8,u8,u8], 63x100 [u8,u8,u8,u8], 61x102 [u8,u8,u8,u8]
+ subimage  0:  257 x  126, 4 channel, uint8 psd
+    SHA-1: 8BF46474973B454FF5C30BA129A75ECA98A03132
+    channel list: R, G, B, A
+    DateTime: "2011-08-22T22:14:43-04:00"
+    ICCProfile: 0, 0, 12, 72, 76, 105, 110, 111, 2, 16, 0, 0, 109, 110, 116, 114, ... [3144 x uint8]
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    Software: "Adobe Photoshop CS5.1 Windows"
+    thumbnail_height: 78
+    thumbnail_nchannels: 3
+    thumbnail_width: 160
+    XResolution: 72
+    YResolution: 72
+    Exif:ColorSpace: 1
+    Exif:PixelXDimension: 257
+    Exif:PixelYDimension: 126
+    IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:InstanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:MetadataDate: "2011-08-22T22:14:43-04:00"
+    IPTC:ModifyDate: "2011-08-22T22:14:43-04:00"
+    IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    oiio:ColorSpace: "sRGB"
+    oiio:UnassociatedAlpha: 1
+    photoshop:ColorMode: 3, 3
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
+    photoshop:LayerName: 1, 2, 3, 1, 2, 3
+    photoshop:LayerText: 1, 2, 3, 1, 2, 3
+    rdf:parseType: "Resource"
+    stEvt:action: "created"
+    stEvt:instanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
+    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
+    stEvt:when: "2011-08-22T22:14:43-04:00"
+ subimage  1:   33 x   98, 4 channel, uint8 psd
+    SHA-1: E99937CC4768F96DC58D9B4F11ED3083818E4D51
+    channel list: R, G, B, A
+    pixel data origin: x=15, y=15
+    DateTime: "2011-08-22T22:14:43-04:00"
+    ICCProfile: 0, 0, 12, 72, 76, 105, 110, 111, 2, 16, 0, 0, 109, 110, 116, 114, ... [3144 x uint8]
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    Software: "Adobe Photoshop CS5.1 Windows"
+    XResolution: 72
+    YResolution: 72
+    Exif:ColorSpace: 1
+    Exif:PixelXDimension: 257
+    Exif:PixelYDimension: 126
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Media-relative colorimetric"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
+    IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:InstanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:MetadataDate: "2011-08-22T22:14:43-04:00"
+    IPTC:ModifyDate: "2011-08-22T22:14:43-04:00"
+    IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    oiio:ColorSpace: "sRGB"
+    oiio:subimagename: "1"
+    oiio:UnassociatedAlpha: 1
+    photoshop:ColorMode: 3, 3
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
+    photoshop:LayerName: 1, 2, 3, 1, 2, 3
+    photoshop:LayerText: 1, 2, 3, 1, 2, 3
+    rdf:parseType: "Resource"
+    stEvt:action: "created"
+    stEvt:instanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
+    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
+    stEvt:when: "2011-08-22T22:14:43-04:00"
+ subimage  2:   63 x  100, 4 channel, uint8 psd
+    SHA-1: EB2ED42882FCD4BC1F0E11795B6B3E483158C1B4
+    channel list: R, G, B, A
+    pixel data origin: x=84, y=13
+    DateTime: "2011-08-22T22:14:43-04:00"
+    ICCProfile: 0, 0, 12, 72, 76, 105, 110, 111, 2, 16, 0, 0, 109, 110, 116, 114, ... [3144 x uint8]
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    Software: "Adobe Photoshop CS5.1 Windows"
+    XResolution: 72
+    YResolution: 72
+    Exif:ColorSpace: 1
+    Exif:PixelXDimension: 257
+    Exif:PixelYDimension: 126
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Media-relative colorimetric"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
+    IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:InstanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:MetadataDate: "2011-08-22T22:14:43-04:00"
+    IPTC:ModifyDate: "2011-08-22T22:14:43-04:00"
+    IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    oiio:ColorSpace: "sRGB"
+    oiio:subimagename: "2"
+    oiio:UnassociatedAlpha: 1
+    photoshop:ColorMode: 3, 3
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
+    photoshop:LayerName: 1, 2, 3, 1, 2, 3
+    photoshop:LayerText: 1, 2, 3, 1, 2, 3
+    rdf:parseType: "Resource"
+    stEvt:action: "created"
+    stEvt:instanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
+    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
+    stEvt:when: "2011-08-22T22:14:43-04:00"
+ subimage  3:   61 x  102, 4 channel, uint8 psd
+    SHA-1: 81D2828D49B81D99397544651501C3AB9696EF52
+    channel list: R, G, B, A
+    pixel data origin: x=175, y=14
+    DateTime: "2011-08-22T22:14:43-04:00"
+    ICCProfile: 0, 0, 12, 72, 76, 105, 110, 111, 2, 16, 0, 0, 109, 110, 116, 114, ... [3144 x uint8]
+    Orientation: 1 (normal)
+    PixelAspectRatio: 1
+    ResolutionUnit: "in"
+    Software: "Adobe Photoshop CS5.1 Windows"
+    XResolution: 72
+    YResolution: 72
+    Exif:ColorSpace: 1
+    Exif:PixelXDimension: 257
+    Exif:PixelYDimension: 126
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1281977967
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "Copyright (c) 1998 Hewlett-Packard Company"
+    ICCProfile:creation_date: "1998:02:09 06:49:00"
+    ICCProfile:creator_signature: "48502020"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:device_manufacturer_description: "IEC http://www.iec.ch"
+    ICCProfile:device_model_description: "IEC 61966-2.1 Default RGB colour space - sRGB"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "49454320"
+    ICCProfile:model: "73524742"
+    ICCProfile:platform_signature: "Microsoft Corporation"
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "sRGB IEC61966-2.1"
+    ICCProfile:profile_size: 3144
+    ICCProfile:profile_version: "2.1.0"
+    ICCProfile:rendering_intent: "Media-relative colorimetric"
+    ICCProfile:viewing_conditions_description: "Reference Viewing Condition in IEC61966-2.1"
+    IPTC:DocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:InstanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
+    IPTC:MetadataDate: "2011-08-22T22:14:43-04:00"
+    IPTC:ModifyDate: "2011-08-22T22:14:43-04:00"
+    IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
+    oiio:ColorSpace: "sRGB"
+    oiio:subimagename: "3"
+    oiio:UnassociatedAlpha: 1
+    photoshop:ColorMode: 3, 3
+    photoshop:ICCProfile: "sRGB IEC61966-2.1"
+    photoshop:LayerName: 1, 2, 3, 1, 2, 3
+    photoshop:LayerText: 1, 2, 3, 1, 2, 3
+    rdf:parseType: "Resource"
+    stEvt:action: "created"
+    stEvt:instanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
+    stEvt:softwareAgent: "Adobe Photoshop CS5.1 Windows"
+    stEvt:when: "2011-08-22T22:14:43-04:00"
 Reading src/different-mask-size.psd
 src/different-mask-size.psd :   30 x   90, 3 channel, uint8 psd
     4 subimages: 30x90 [u8,u8,u8], 30x90 [u8,u8,u8,u8], 4x93 [u8,u8,u8,u8], 4x93 [u8,u8,u8,u8]

--- a/testsuite/psd/run.py
+++ b/testsuite/psd/run.py
@@ -8,6 +8,9 @@ files = [ "psd_123.psd", "psd_123_nomaxcompat.psd", "psd_bitmap.psd",
 for f in files:
     command += info_command (OIIO_TESTSUITE_IMAGEDIR + "/" + f)
 
+# Test unassociated alpha metadata
+command += info_command (OIIO_TESTSUITE_IMAGEDIR + "/psd_123.psd", extraargs="--no-autopremult")
+
 command += info_command ("src/different-mask-size.psd")
 command += info_command ("src/layer-mask.psd")
 


### PR DESCRIPTION
## Description

Refactoring in #1641 incorrectly caused this to be set on the last layer rather than the composite image as before. Now set it on the composite image and every layer, as all of them use unassociated alpha.

## Tests

Test was added.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-CORPORATE)).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

