### PR TITLE
Minor Timer and LoggedTimer class tweaks

### DIFF
--- a/src/include/OpenImageIO/timer.h
+++ b/src/include/OpenImageIO/timer.h
@@ -63,27 +63,32 @@ class OIIO_UTIL_API Timer {
 public:
     typedef int64_t ticks_t;
     enum StartNowVal { DontStartNow, StartNow };
-    enum PrintDtrVal { DontPrintDtr, PrintDtr };
+    enum PrintDtrVal { DontPrintDtr, PrintDtr, PrintCtrDtr };
 
     /// Constructor -- reset at zero, and start timing unless optional
     /// 'startnow' argument is false.
-    Timer(StartNowVal startnow = StartNow, PrintDtrVal printdtr = DontPrintDtr,
+    Timer(StartNowVal startnow, PrintDtrVal printdtr = DontPrintDtr,
           const char* name = NULL)
         : m_ticking(false)
-        , m_printdtr(printdtr == PrintDtr)
+        , m_printdtr(printdtr == PrintDtr || printdtr == PrintCtrDtr)
         , m_starttime(0)
         , m_elapsed_ticks(0)
         , m_name(name)
     {
-        if (startnow == StartNow)
+        if (startnow == StartNow) {
             start();
+            if (printdtr == PrintCtrDtr) {
+                Strutil::print("Starting timer {}\n", (m_name ? m_name : ""),
+                               seconds(ticks()));
+            }
+        }
     }
 
     /// Constructor -- reset at zero, and start timing unless optional
     /// 'startnow' argument is false.
-    Timer(bool startnow)
+    Timer(bool startnow = true)
         : m_ticking(false)
-        , m_printdtr(DontPrintDtr)
+        , m_printdtr(false)
         , m_starttime(0)
         , m_elapsed_ticks(0)
         , m_name(NULL)
@@ -95,9 +100,9 @@ public:
     /// Destructor.
     ~Timer()
     {
-        if (m_printdtr == PrintDtr)
-            Strutil::printf("Timer %s: %gs\n", (m_name ? m_name : ""),
-                            seconds(ticks()));
+        if (m_printdtr)
+            Strutil::print("Timer {}: {:g}s\n", (m_name ? m_name : ""),
+                           seconds(ticks()));
     }
 
     /// Start (or restart) ticking, if we are not currently.

--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -1819,7 +1819,7 @@ ImageBufAlgo::colorconvert(ImageBuf& dst, const ImageBuf& src, string_view from,
         }
     }
 
-    logtime.stop();  // transition to other colorconvert
+    logtime.stop(-1);  // transition to other colorconvert
     bool ok = colorconvert(dst, src, processor.get(), unpremult, roi, nthreads);
     if (ok) {
         // DBG("done, setting output colorspace to {}\n", to);

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -80,18 +80,20 @@ public:
             std::cout << report();
     }
 
-    // Call like a function to record times (but only if oiio_log_times > 0)
-    void operator()(string_view key, const Timer& timer)
+    // Call like a function to record times (but only if oiio_log_times > 0).
+    // The `count` parameter is the number of times the operation was invoked,
+    // as tallied by the timer (defaulting to 1).
+    void operator()(string_view key, const Timer& timer, int count = 1)
     {
         if (oiio_log_times) {
             auto t = timer();
             spin_lock lock(mutex);
             auto entry = timing_map.find(key);
             if (entry == timing_map.end())
-                timing_map[key] = std::make_pair(t, size_t(1));
+                timing_map[key] = std::make_pair(t, size_t(count));
             else {
                 entry->second.first += t;
-                entry->second.second += 1;
+                entry->second.second += count;
             }
         }
     }
@@ -269,9 +271,9 @@ debug(string_view message)
 
 
 void
-pvt::log_time(string_view key, const Timer& timer)
+pvt::log_time(string_view key, const Timer& timer, int count)
 {
-    timing_log(key, timer);
+    timing_log(key, timer, count);
 }
 
 

--- a/src/libOpenImageIO/imageio_pvt.h.in
+++ b/src/libOpenImageIO/imageio_pvt.h.in
@@ -113,7 +113,7 @@ OIIO_API bool check_texture_metadata_sanity (ImageSpec &spec);
 /// Internal function to log time recorded by an OIIO::timer(). It will only
 /// trigger a read of the time if the "log_times" attribute is set or the
 /// OPENIMAGEIO_LOG_TIMES env variable is set.
-OIIO_API void log_time (string_view key, const Timer& timer);
+OIIO_API void log_time(string_view key, const Timer& timer, int count = 1);
 
 /// Get the timing report from log_time entries.
 OIIO_API std::string timing_report ();
@@ -128,14 +128,21 @@ public:
     }
     ~LoggedTimer () {
         if (oiio_log_times)
-            log_time (m_name, m_timer);
+            log_time (m_name, m_timer, m_count);
     }
-    void stop () { m_timer.stop(); }
+    // Stop the timer. An optional count_offset will be added to the
+    // "invocations count" of the underlying timer, if a single invocation
+    // does not correctly describe the thing being timed.
+    void stop(int count_offset = 0) {
+        m_timer.stop();
+        m_count += count_offset;
+    }
     void start () { m_timer.start(); }
     void rename (string_view name) { m_name = name; }
 private:
     Timer m_timer;
     std::string m_name;
+    int m_count = 1;
 };
 
 


### PR DESCRIPTION
Timer:

* Fix goof where m_printdtr was a bool but was tested for equality to an enum. It happened to work like that, but only coincidentally.

* Add another enum value that allows a debugging message to be printed upon construction of the timer, in addition to its destruction.

* Switch from printf style to std::print style formatting of the debugging messages.

LoggedTimer:

* Modify to allow modifying the call count.  This turns out to be helpful for times when one logged function calls another logged function (like if a special case is broken out) and they both log to the same timer -- it makes it look like just one invocation instead of two.
