### PR TITLE
Spend less wasted time zeroing out ImageBuf

### DIFF
--- a/src/include/OpenImageIO/imagebufalgo_util.h
+++ b/src/include/OpenImageIO/imagebufalgo_util.h
@@ -134,6 +134,11 @@ IBAprep(ROI& roi, ImageBuf* dst, const ImageBuf* A, int prepflags)
 {
     return IBAprep(roi, dst, A, NULL, NULL, NULL, prepflags);
 }
+inline bool
+IBAprep(ROI& roi, ImageBuf* dst, int prepflags)
+{
+    return IBAprep(roi, dst, nullptr, nullptr, nullptr, nullptr, prepflags);
+}
 
 
 // clang-format off
@@ -155,6 +160,7 @@ enum IBAprep_flags {
     IBAprep_MINIMIZE_NCHANNELS = 1<<14, // Multi-inputs get min(nchannels)
     IBAprep_REQUIRE_MATCHING_CHANNELS = 1<<15, // Channel names must match
     IBAprep_MERGE_METADATA = 1 << 16,   // Merge all inputs' metadata
+    IBAprep_FILL_ZERO_ALLOC = 1 << 17,  // Fill with 0 if we alloc space
 };
 
 

--- a/src/libOpenImageIO/imagebufalgo.cpp
+++ b/src/libOpenImageIO/imagebufalgo.cpp
@@ -254,7 +254,9 @@ ImageBufAlgo::IBAprep(ROI& roi, ImageBuf* dst, const ImageBuf* A,
             }
         }
 
-        dst->reset(spec);
+        dst->reset(spec, (prepflags & IBAprep_FILL_ZERO_ALLOC)
+                             ? InitializePixels::Yes
+                             : InitializePixels::No);
 
         // If we just allocated more channels than the caller will write,
         // clear the extra channels.

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -3884,9 +3884,11 @@ action_create(int argc, const char* argv[])
     spec.full_height = spec.height;
     spec.full_depth  = spec.depth;
     ImageRecRef img(new ImageRec("new", spec, ot.imagecache));
-    bool ok = ImageBufAlgo::zero((*img)());
-    if (!ok)
-        ot.error(command, (*img)().geterror());
+    // No need to zero, the allocation of the IB in the call above it will
+    // automatically zero it.
+    // bool ok = ImageBufAlgo::zero((*img)());
+    // if (!ok)
+    //     ot.error(command, (*img)().geterror());
     if (ot.curimg)
         ot.image_stack.push_back(ot.curimg);
     ot.curimg = img;


### PR DESCRIPTION
Examining some timings and function call counts, I saw that a typical oiiotool command was spending a surprising amount of time in ImageBufAlgo::zero(), not just more runtime overall, but also calling it many more times than I thought it should.  For example,

    oiiotool -create 4096x4096 3 -colorconvert srgb acescg

called ImageBufAlgo::zero()... 4 times, totaling as much time as the colorconvert operation.

The idiom used in `IBA::op(dst, src, ...)` which initializes the `dst` IB if it's not already initialized will call the IB constructor that zeros out its contents (so you don't have every new IB full of garbage pixel values). But for IBA functions, this is almost never necessary, since the IBA function itself will tend to overwrite all pixel values. Not always, of course -- since IBA functions let you restrict the spatial area or channel range -- but in the cases where the destination starts out uninitialized and is allocated to exactly mtch the ROI, I *think* you can count on the calling IBA function filling in all those values.

So I changed IBAPrep() to call the IB constructor that says not to zero out the pixels.

Just in case we ever need the ability, I made a new flag value that lets you call IBAPrep and tell it, yes, do zero out any newly allocated buffers. But we pass the testsuite without needing that flag anywhere, so I think we're ok.

Also, the --create command itself would make new buffers (with the implied zeroing), and then explicitly zero it again!

So after these changes, the oiiotool example command line above only calls IBA::zero() ONCE (correctly, in the initial new image --create makes), eliminating three redundant calls.

I also hypothesized that each call to zero was taking too much time, because underneath it was calling IBA::fill which laboriously walked through the IB with iterators and copying a fixed pixel value that happened to contain 0 values. So I rewrote a special case where if the buffer had contiguous strides, it would just use memset instead. Surprisingly, it was not appreciably faster, and I'm guessing that the memory bandwidth necessary to touch every pixel in a 4k buffer is the limiting factor, and the other pixel-by-pixel iterator diddling was inconsequential compared to waiting for the memory bus. I'm still going to leave this "optimization" in, even though it was barely measurable for the case I was trying.
