### PR TITLE
iff: Temporarily address breakage with optional IOProxy revert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 cmake_minimum_required (VERSION 3.12)
 
-set (OpenImageIO_VERSION "2.5.0.1")
+set (OpenImageIO_VERSION "2.5.0.2")
 set (OpenImageIO_VERSION_OVERRIDE "" CACHE STRING
      "Version override (use with caution)!")
 mark_as_advanced (OpenImageIO_VERSION_OVERRIDE)

--- a/src/iff.imageio/CMakeLists.txt
+++ b/src/iff.imageio/CMakeLists.txt
@@ -2,4 +2,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # https://github.com/OpenImageIO/oiio
 
-add_oiio_plugin (iffinput.cpp iffoutput.cpp)
+option (ENABLE_RLA_IOPROXY "(Temporarily) turn this off to switch back to the old pre-IOProxy RLA implementation to address a bug." ON)
+if (ENABLE_RLA_IOPROXY)
+    add_oiio_plugin (iffinput.cpp iffoutput.cpp)
+else ()
+    add_oiio_plugin (noproxy-iffinput.cpp noproxy-iffoutput.cpp noproxy-iff_pvt.cpp)
+endif ()

--- a/src/iff.imageio/noproxy-iff_pvt.cpp
+++ b/src/iff.imageio/noproxy-iff_pvt.cpp
@@ -1,0 +1,332 @@
+// Copyright 2008-present Contributors to the OpenImageIO project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/OpenImageIO/oiio
+#include "noproxy-iff_pvt.h"
+#include <OpenImageIO/dassert.h>
+
+OIIO_PLUGIN_NAMESPACE_BEGIN
+
+using namespace iff_pvt;
+
+#define STRINGIZE2(a) #a
+#define STRINGIZE(a) STRINGIZE2(a)
+
+
+
+bool
+IffFileHeader::read_header(FILE* fd, std::string& err)
+{
+    uint8_t type[4];
+    uint32_t size;
+    uint32_t chunksize;
+    uint32_t tbhdsize;
+    uint32_t flags;
+    uint16_t bytes;
+    uint16_t prnum;
+    uint16_t prden;
+
+    // read FOR4 <size> CIMG.
+    err.clear();
+    for (;;) {
+        // get type and length
+        if (!read_typesize(fd, type, size)) {
+            err = "could not read type/size @ L" STRINGIZE(__LINE__);
+            return false;
+        }
+
+        chunksize = align_size(size, 4);
+
+        if (type[0] == 'F' && type[1] == 'O' && type[2] == 'R'
+            && type[3] == '4') {
+            // get type
+            if (!fread(&type, 1, sizeof(type), fd)) {
+                err = "could not read FDR4 type @ L" STRINGIZE(__LINE__);
+                return false;
+            }
+
+            // check if CIMG
+            if (type[0] == 'C' && type[1] == 'I' && type[2] == 'M'
+                && type[3] == 'G') {
+                // read TBHD.
+                for (;;) {
+                    if (!read_typesize(fd, type, size)) {
+                        err = "could not read CIMG length @ L" STRINGIZE(
+                            __LINE__);
+                        return false;
+                    }
+
+                    chunksize = align_size(size, 4);
+
+                    if (type[0] == 'T' && type[1] == 'B' && type[2] == 'H'
+                        && type[3] == 'D') {
+                        tbhdsize = size;
+
+                        // test if table header size is correct
+                        if (tbhdsize != 24 && tbhdsize != 32) {
+                            err = "bad table header @ L" STRINGIZE(__LINE__);
+                            return false;  // bad table header
+                        }
+
+                        // get width and height
+                        if (!read(fd, width) || !read(fd, height)
+                            || !read(fd, prnum) || !read(fd, prden)
+                            || !read(fd, flags) || !read(fd, bytes)
+                            || !read(fd, tiles) || !read(fd, compression)) {
+                            err = "@ L" STRINGIZE(__LINE__);
+                            return false;
+                        }
+
+                        // get xy
+                        if (tbhdsize == 32) {
+                            if (!read(fd, x) || !read(fd, y)) {
+                                err = "could not get xy @ L" STRINGIZE(
+                                    __LINE__);
+                                return false;
+                            }
+                        } else {
+                            x = 0;
+                            y = 0;
+                        }
+
+                        // tiles
+                        if (tiles == 0) {
+                            err = "non-tiles not supported @ L" STRINGIZE(
+                                __LINE__);
+                            return false;
+                        }  // non-tiles not supported
+
+                        // 0 no compression
+                        // 1 RLE compression
+                        // 2 QRL (not supported)
+                        // 3 QR4 (not supported)
+                        if (compression > 1) {
+                            err = "only RLE compression is supported @ L" STRINGIZE(
+                                __LINE__);
+                            return false;
+                        }
+
+                        // test format.
+                        if (flags & RGBA) {
+                            // test if black is set
+                            OIIO_DASSERT(!(flags & BLACK));
+
+                            // test for RGB channels.
+                            if (flags & RGB)
+                                pixel_channels = 3;
+
+                            // test for alpha channel
+                            if (flags & ALPHA)
+                                pixel_channels++;
+
+                            // test pixel bits
+                            pixel_bits = bytes ? 16 : 8;
+                        }
+
+                        // Z format.
+                        else if (flags & ZBUFFER) {
+                            pixel_channels = 1;
+                            pixel_bits     = 32;  // 32bit
+                            // NOTE: Z_F32 support - not supported
+                            OIIO_DASSERT(bytes == 0);
+                        }
+
+                        // read AUTH, DATE or FOR4
+
+                        for (;;) {
+                            // get type
+                            if (!read_typesize(fd, type, size)) {
+                                err = "could not read type/size @ L" STRINGIZE(
+                                    __LINE__);
+                                return false;
+                            }
+
+                            chunksize = align_size(size, 4);
+
+                            if (type[0] == 'A' && type[1] == 'U'
+                                && type[2] == 'T' && type[3] == 'H') {
+                                std::vector<char> str(chunksize);
+                                if (!fread(&str[0], 1, chunksize, fd)) {
+                                    err = "could not read author @ L" STRINGIZE(
+                                        __LINE__);
+                                    return false;
+                                }
+                                author = std::string(&str[0], size);
+                            } else if (type[0] == 'D' && type[1] == 'A'
+                                       && type[2] == 'T' && type[3] == 'E') {
+                                std::vector<char> str(chunksize);
+                                if (!fread(&str[0], 1, chunksize, fd)) {
+                                    err = "could not read date @ L" STRINGIZE(
+                                        __LINE__);
+                                    return false;
+                                }
+                                date = std::string(&str[0], size);
+                            } else if (type[0] == 'F' && type[1] == 'O'
+                                       && type[2] == 'R' && type[3] == '4') {
+                                if (!fread(&type, 1, sizeof(type), fd)) {
+                                    err = "could not read FOR4 type @ L" STRINGIZE(
+                                        __LINE__);
+                                    return false;
+                                }
+
+                                // check if CIMG
+                                if (type[0] == 'T' && type[1] == 'B'
+                                    && type[2] == 'M' && type[3] == 'P') {
+                                    // tbmp position for later user in in
+                                    // read_native_tile
+
+                                    tbmp_start = ftell(fd);
+
+                                    // read first RGBA block to detect tile size.
+
+                                    for (unsigned int t = 0; t < tiles; t++) {
+                                        if (!read_typesize(fd, type, size)) {
+                                            err = "xxx @ L" STRINGIZE(__LINE__);
+                                            return false;
+                                        }
+                                        chunksize = align_size(size, 4);
+
+                                        // check if RGBA
+                                        if (type[0] == 'R' && type[1] == 'G'
+                                            && type[2] == 'B'
+                                            && type[3] == 'A') {
+                                            // get tile coordinates.
+                                            uint16_t xmin, xmax, ymin, ymax;
+                                            if (!read(fd, xmin)
+                                                || !read(fd, ymin)
+                                                || !read(fd, xmax)
+                                                || !read(fd, ymax)) {
+                                                err = "xxx @ L" STRINGIZE(
+                                                    __LINE__);
+                                                return false;
+                                            }
+
+                                            // check tile
+                                            if (xmin > xmax || ymin > ymax
+                                                || xmax >= width
+                                                || ymax >= height) {
+                                                err = "tile min/max nonsensical @ L" STRINGIZE(
+                                                    __LINE__);
+                                                return false;
+                                            }
+
+                                            // set tile width and height
+                                            tile_width  = xmax - xmin + 1;
+                                            tile_height = ymax - ymin + 1;
+
+                                            // done, return
+                                            return true;
+                                        }
+
+                                        // skip to the next block.
+                                        if (fseek(fd, chunksize, SEEK_CUR)) {
+                                            err = "could not fseek @ L" STRINGIZE(
+                                                __LINE__);
+                                            return false;
+                                        }
+                                    }
+                                } else {
+                                    // skip to the next block.
+                                    if (fseek(fd, chunksize, SEEK_CUR)) {
+                                        err = "could not fseek @ L" STRINGIZE(
+                                            __LINE__);
+                                        return false;
+                                    }
+                                }
+                            } else {
+                                // skip to the next block.
+                                if (fseek(fd, chunksize, SEEK_CUR)) {
+                                    err = "could not fseek @ L" STRINGIZE(
+                                        __LINE__);
+                                    return false;
+                                }
+                            }
+                        }
+                        // TBHD done, break
+                        break;
+                    }
+
+                    // skip to the next block.
+                    if (fseek(fd, chunksize, SEEK_CUR)) {
+                        err = "could not fseek @ L" STRINGIZE(__LINE__);
+                        return false;
+                    }
+                }
+            }
+        }
+        // skip to the next block.
+        if (fseek(fd, chunksize, SEEK_CUR)) {
+            err = "could not fseek @ L" STRINGIZE(__LINE__);
+            return false;
+        }
+    }
+    err = "unknown error, ended early @ L" STRINGIZE(__LINE__);
+    return false;
+}
+
+
+
+bool
+IffOutput::write_header(IffFileHeader& header)
+{
+    // write 'FOR4' type, with 0 length for now (to reserve it)
+    if (!(write_str("FOR4") && write_int(0)))
+        return false;
+
+    // write 'CIMG' type
+    if (!write_str("CIMG"))
+        return false;
+
+    // write 'TBHD' type
+    if (!write_str("TBHD"))
+        return false;
+
+    // 'TBHD' length, 32 bytes
+    if (!write_int(32))
+        return false;
+
+    if (!write_int(header.width) || !write_int(header.height))
+        return false;
+
+    // write prnum and prden (pixel aspect ratio? -- FIXME)
+    if (!write_short(1) || !write_short(1))  //NOSONAR
+        return false;
+
+    // write flags and channels
+    if (!write_int(header.pixel_channels == 3 ? RGB : RGBA)
+        || !write_short(header.pixel_bits == 8 ? 0 : 1)
+        || !write_short(header.tiles))
+        return false;
+
+    // write compression
+    // 0 no compression
+    // 1 RLE compression
+    // 2 QRL (not supported)
+    // 3 QR4 (not supported)
+    if (!write_int(header.compression))
+        return false;
+
+    // write x and y
+    if (!write_int(header.x) || !write_int(header.y))
+        return false;
+
+    // Write metadata
+    write_meta_string("AUTH", header.author);
+    write_meta_string("DATE", header.date);
+
+    // for4 position for later user in close
+    header.for4_start = ftell(m_fd);
+
+    // write 'FOR4' type, with 0 length to reserve it for now
+    if (!write_str("FOR4") || !write_int(0))
+        return false;
+
+    // write 'TBMP' type
+    if (!write_str("TBMP"))
+        return false;
+
+    return true;
+}
+
+
+
+OIIO_PLUGIN_NAMESPACE_END

--- a/src/iff.imageio/noproxy-iff_pvt.h
+++ b/src/iff.imageio/noproxy-iff_pvt.h
@@ -1,0 +1,303 @@
+// Copyright 2008-present Contributors to the OpenImageIO project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/OpenImageIO/oiio
+
+#pragma once
+
+// Format reference: Affine Toolkit (Thomas E. Burge), riff.h and riff.c
+//                   Autodesk Maya documentation, ilib.h
+
+#include <cstdio>
+
+#include <OpenImageIO/filesystem.h>
+#include <OpenImageIO/fmath.h>
+#include <OpenImageIO/imageio.h>
+
+#include "imageio_pvt.h"
+
+
+OIIO_PLUGIN_NAMESPACE_BEGIN
+
+namespace iff_pvt {
+
+// compression numbers
+const uint32_t NONE = 0;
+const uint32_t RLE  = 1;
+const uint32_t QRL  = 2;
+const uint32_t QR4  = 3;
+
+const uint32_t RGB     = 0x00000001;
+const uint32_t ALPHA   = 0x00000002;
+const uint32_t RGBA    = RGB | ALPHA;
+const uint32_t ZBUFFER = 0x00000004;
+const uint32_t BLACK   = 0x00000010;
+
+// store information about IFF file
+class IffFileHeader {
+public:
+    // reads information about IFF file
+    bool read_header(FILE* fd, std::string& err);
+
+    // header information
+    uint32_t x;
+    uint32_t y;
+    uint32_t width;
+    uint32_t height;
+    uint32_t compression;
+    uint8_t pixel_bits;
+    uint8_t pixel_channels;
+    uint16_t tiles;
+    uint16_t tile_width;
+    uint16_t tile_height;
+
+    // author string
+    std::string author;
+
+    // date string
+    std::string date;
+
+    // tbmp start
+    uint32_t tbmp_start;
+
+    // for4 start
+    uint32_t for4_start;
+
+private:
+    // Read a uint32_t, swap endian if necessary
+    bool read(FILE* fd, uint32_t& data)
+    {
+        bool ok = (fread(&data, 1, sizeof(data), fd) == sizeof(data));
+        if (littleendian())
+            swap_endian(&data);
+        return ok;
+    }
+    // Read a uint16_t, swap endian if necessary
+    bool read(FILE* fd, uint16_t& data)
+    {
+        bool ok = (fread(&data, 1, sizeof(data), fd) == sizeof(data));
+        if (littleendian())
+            swap_endian(&data);
+        return ok;
+    }
+    // Read a 4-byte code (no endian swap), and if that succeeds (beware of EOF or
+    // other errors), then also read a 32 bit size (subject to endian swap).
+    bool read_typesize(FILE* fd, uint8_t type[4], uint32_t& size)
+    {
+        return (fread(type, 1, 4, fd) == 4) && read(fd, size);
+    }
+};
+
+
+
+// align size
+inline uint32_t
+align_size(uint32_t size, uint32_t alignment)
+{
+    uint32_t mod = size % alignment;
+    if (mod) {
+        mod = alignment - mod;
+        size += mod;
+    }
+    return size;
+}
+
+// tile width
+inline const int&
+tile_width()
+{
+    static int tile_w = 64;
+    return tile_w;
+}
+
+// tile height
+inline const int&
+tile_height()
+{
+    static int tile_h = 64;
+    return tile_h;
+}
+
+// tile width size
+inline uint32_t
+tile_width_size(uint32_t width)
+{
+    uint32_t tw = tile_width();
+    return (width + tw - 1) / tw;
+}
+
+// tile height size
+inline uint32_t
+tile_height_size(uint32_t height)
+{
+    uint32_t th = tile_height();
+    return (height + th - 1) / th;
+}
+
+}  // namespace iff_pvt
+
+
+
+class IffInput final : public ImageInput {
+public:
+    IffInput() { init(); }
+    ~IffInput() override
+    {
+        try {
+            close();
+        } catch (const std::exception& e) {
+            OIIO::pvt::errorfmt("{}", e.what());
+        }
+    }
+    const char* format_name(void) const override { return "iff"; }
+    bool open(const std::string& name, ImageSpec& spec) override;
+    bool close(void) override;
+    bool read_native_scanline(int subimage, int miplevel, int y, int z,
+                              void* data) override;
+    bool read_native_tile(int subimage, int miplevel, int x, int y, int z,
+                          void* data) override;
+
+private:
+    FILE* m_fd;
+    std::string m_filename;
+    iff_pvt::IffFileHeader m_iff_header;
+    std::vector<uint8_t> m_buf;
+
+    uint32_t m_tbmp_start;
+
+    // init to initialize state
+    void init(void)
+    {
+        m_fd = NULL;
+        m_filename.clear();
+        m_buf.clear();
+    }
+
+    // helper to read an image
+    bool readimg(void);
+
+    // helper to uncompress a rle channel
+    size_t uncompress_rle_channel(const uint8_t* in, uint8_t* out, int size);
+
+    bool read_short(uint16_t& val)
+    {
+        bool ok = fread(&val, sizeof(val), 1, m_fd);
+        if (littleendian())
+            swap_endian(&val);
+        return ok;
+    }
+
+    bool read_int(uint32_t& val)
+    {
+        bool ok = fread(&val, sizeof(val), 1, m_fd);
+        if (littleendian())
+            swap_endian(&val);
+        return ok;
+    }
+
+    bool read_str(std::string& val, uint32_t len, uint32_t round = 4)
+    {
+        const uint32_t big = 1024;
+        char strbuf[big];
+        len     = std::min(len, big);
+        bool ok = fread(strbuf, len, 1, m_fd);
+        val.assign(strbuf, len);
+        for (uint32_t pad = len % round; pad; --pad)
+            fgetc(m_fd);
+        return ok;
+    }
+
+    bool read_type_len(std::string& type, uint32_t& len)
+    {
+        return read_str(type, 4) && read_int(len);
+    }
+
+    bool read_meta_string(std::string& name, std::string& val)
+    {
+        uint32_t len = 0;
+        return read_type_len(name, len) && read_str(val, len);
+    }
+};
+
+
+
+class IffOutput final : public ImageOutput {
+public:
+    IffOutput() { init(); }
+    ~IffOutput() override
+    {
+        try {
+            close();
+        } catch (const std::exception& e) {
+            OIIO::pvt::errorfmt("{}", e.what());
+        }
+    }
+    const char* format_name(void) const override { return "iff"; }
+    int supports(string_view feature) const override;
+    bool open(const std::string& name, const ImageSpec& spec,
+              OpenMode mode) override;
+    bool close(void) override;
+    bool write_scanline(int y, int z, TypeDesc format, const void* data,
+                        stride_t xstride) override;
+    bool write_tile(int x, int y, int z, TypeDesc format, const void* data,
+                    stride_t xstride, stride_t ystride,
+                    stride_t zstride) override;
+
+private:
+    FILE* m_fd;
+    std::string m_filename;
+    iff_pvt::IffFileHeader m_iff_header;
+    std::vector<uint8_t> m_buf;
+    unsigned int m_dither;
+    std::vector<uint8_t> scratch;
+
+    void init(void)
+    {
+        m_fd = NULL;
+        m_filename.clear();
+    }
+
+    // writes information about iff file to give file
+    bool write_header(iff_pvt::IffFileHeader& header);
+
+    bool write_short(uint16_t val)
+    {
+        if (littleendian())
+            swap_endian(&val);
+        return fwrite(&val, sizeof(val), 1, m_fd);
+    }
+    bool write_int(uint32_t val)
+    {
+        if (littleendian())
+            swap_endian(&val);
+        return fwrite(&val, sizeof(val), 1, m_fd);
+    }
+
+    bool write_str(string_view val, size_t round = 4)
+    {
+        bool ok = fwrite(val.data(), val.size(), 1, m_fd);
+        for (size_t i = val.size(); i < round_to_multiple(val.size(), round);
+             ++i)
+            ok &= (fputc(' ', m_fd) != EOF);
+        return ok;
+    }
+
+    bool write_meta_string(string_view name, string_view val,
+                           bool write_if_empty = false)
+    {
+        if (val.empty() && !write_if_empty)
+            return true;
+        return write_str(name) && write_int(int(val.size()))
+               && (val.size() == 0 || write_str(val));
+    }
+
+    // helper to compress verbatim
+    void compress_verbatim(const uint8_t*& in, uint8_t*& out, int size);
+
+    // helper to compress duplicate
+    void compress_duplicate(const uint8_t*& in, uint8_t*& out, int size);
+
+    // helper to compress a rle channel
+    size_t compress_rle_channel(const uint8_t* in, uint8_t* out, int size);
+};
+
+OIIO_PLUGIN_NAMESPACE_END

--- a/src/iff.imageio/noproxy-iffinput.cpp
+++ b/src/iff.imageio/noproxy-iffinput.cpp
@@ -1,102 +1,13 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
-#include "iff_pvt.h"
+#include "noproxy-iff_pvt.h"
 
 #include <cmath>
 
 OIIO_PLUGIN_NAMESPACE_BEGIN
 
 using namespace iff_pvt;
-
-class IffInput final : public ImageInput {
-public:
-    IffInput() { init(); }
-    ~IffInput() override { close(); }
-    const char* format_name(void) const override { return "iff"; }
-    int supports(string_view feature) const override
-    {
-        return feature == "ioproxy";
-    }
-    bool open(const std::string& name, ImageSpec& spec) override;
-    bool open(const std::string& name, ImageSpec& newspec,
-              const ImageSpec& config) override;
-    bool close(void) override;
-    bool read_native_scanline(int subimage, int miplevel, int y, int z,
-                              void* data) override;
-    bool read_native_tile(int subimage, int miplevel, int x, int y, int z,
-                          void* data) override;
-
-private:
-    std::string m_filename;
-    iff_pvt::IffFileHeader m_iff_header;
-    std::vector<uint8_t> m_buf;
-
-    uint32_t m_tbmp_start;
-
-    // init to initialize state
-    void init(void)
-    {
-        ioproxy_clear();
-        m_filename.clear();
-        m_buf.clear();
-    }
-
-    // Reads information about IFF file. If errors are encountereed,
-    // read_header wil. issue error messages and return false.
-    bool read_header();
-
-    // helper to read an image
-    bool readimg(void);
-
-    // helper to uncompress a rle channel
-    size_t uncompress_rle_channel(const uint8_t* in, uint8_t* out, int size);
-
-    /// Helper: read buf[0..nitems-1], swap endianness if necessary
-    template<typename T> bool read(T* buf, size_t nitems = 1)
-    {
-        if (!ioread(buf, sizeof(T), nitems))
-            return false;
-        if (littleendian()
-            && (is_same<T, uint16_t>::value || is_same<T, int16_t>::value
-                || is_same<T, uint32_t>::value || is_same<T, int32_t>::value)) {
-            swap_endian(buf, nitems);
-        }
-        return true;
-    }
-
-    bool read_str(std::string& val, uint32_t len, uint32_t round = 4)
-    {
-        const uint32_t big = 1024;
-        char strbuf[big];
-        len     = std::min(len, big);
-        bool ok = ioread(strbuf, len);
-        val.assign(strbuf, len);
-        ok &= ioseek(len % round, SEEK_CUR);
-        return ok;
-    }
-
-    bool read_type_len(std::string& type, uint32_t& len)
-    {
-        return read_str(type, 4) && read(&len);
-    }
-
-    bool read_meta_string(std::string& name, std::string& val)
-    {
-        uint32_t len = 0;
-        return read_type_len(name, len) && read_str(val, len);
-    }
-
-    // Read a 4-byte type code (no endian swap), and if that succeeds (beware
-    // of EOF or other errors), then also read a 32 bit size (subject to
-    // endian swap).
-    bool read_typesize(uint8_t type[4], uint32_t& size)
-    {
-        return ioread(type, 1, 4) && read(&size);
-    }
-};
-
-
 
 // Obligatory material to make this a recognizable imageio plugin
 OIIO_PLUGIN_EXPORTS_BEGIN
@@ -118,17 +29,6 @@ iff_input_imageio_create()
 OIIO_EXPORT const char* iff_input_extensions[] = { "iff", "z", nullptr };
 
 OIIO_PLUGIN_EXPORTS_END
-
-
-
-bool
-IffInput::open(const std::string& name, ImageSpec& newspec,
-               const ImageSpec& config)
-{
-    // Check 'config' for any special requests
-    ioproxy_retrieve_from_config(config);
-    return open(name, newspec);
-}
 
 
 
@@ -160,12 +60,17 @@ IffInput::open(const std::string& name, ImageSpec& spec)
     // saving 'name' for later use
     m_filename = name;
 
-    if (!ioproxy_use_or_open(name))
+    m_fd = Filesystem::fopen(m_filename, "rb");
+    if (!m_fd) {
+        errorf("Could not open file \"%s\"", name);
         return false;
-    ioseek(0);
+    }
 
     // we read header of the file that we think is IFF file
-    if (!read_header()) {
+    std::string err;
+    if (!m_iff_header.read_header(m_fd, err)) {
+        errorf("\"%s\": could not read iff header (%s)", m_filename,
+               err.size() ? err : std::string("unknown"));
         close();
         return false;
     }
@@ -184,13 +89,13 @@ IffInput::open(const std::string& name, ImageSpec& spec)
     m_spec.full_height = m_iff_header.height;
 
     // tiles
-    if (m_iff_header.tile_width > 0 && m_iff_header.tile_height > 0) {
+    if (m_iff_header.tile_width > 0 || m_iff_header.tile_height > 0) {
         m_spec.tile_width  = m_iff_header.tile_width;
         m_spec.tile_height = m_iff_header.tile_height;
         // only 1 subimage for IFF
         m_spec.tile_depth = 1;
     } else {
-        errorfmt("\"{}\": wrong tile size", m_filename);
+        errorf("\"%s\": wrong tile size", m_filename);
         close();
         return false;
     }
@@ -218,216 +123,6 @@ IffInput::open(const std::string& name, ImageSpec& spec)
 
     spec = m_spec;
     return true;
-}
-
-
-
-bool
-IffInput::read_header()
-{
-    uint8_t type[4];
-    uint32_t size;
-    uint32_t chunksize;
-    uint32_t tbhdsize;
-    uint32_t flags;
-    uint16_t bytes;
-    uint16_t prnum;
-    uint16_t prden;
-
-    // read FOR4 <size> CIMG.
-    for (;;) {
-        // get type and length
-        if (!read_typesize(type, size))
-            return false;
-
-        chunksize = align_size(size, 4);
-
-        if (type[0] == 'F' && type[1] == 'O' && type[2] == 'R'
-            && type[3] == '4') {
-            // get type
-            if (!ioread(&type, 1, sizeof(type)))
-                return false;
-
-            // check if CIMG
-            if (type[0] == 'C' && type[1] == 'I' && type[2] == 'M'
-                && type[3] == 'G') {
-                // read TBHD.
-                for (;;) {
-                    if (!read_typesize(type, size))
-                        return false;
-
-                    chunksize = align_size(size, 4);
-
-                    if (type[0] == 'T' && type[1] == 'B' && type[2] == 'H'
-                        && type[3] == 'D') {
-                        tbhdsize = size;
-
-                        // test if table header size is correct
-                        if (tbhdsize != 24 && tbhdsize != 32) {
-                            errorfmt("Bad table ehader size {}", tbhdsize);
-                            return false;  // bad table header
-                        }
-
-                        // get width and height
-                        if (!read(&m_iff_header.width)
-                            || !read(&m_iff_header.height) || !read(&prnum)
-                            || !read(&prden) || !read(&flags) || !read(&bytes)
-                            || !read(&m_iff_header.tiles)
-                            || !read(&m_iff_header.compression)) {
-                            return false;
-                        }
-
-                        // get xy
-                        if (tbhdsize == 32) {
-                            if (!read(&m_iff_header.x)
-                                || !read(&m_iff_header.y)) {
-                                return false;
-                            }
-                        } else {
-                            m_iff_header.x = 0;
-                            m_iff_header.y = 0;
-                        }
-
-                        // tiles
-                        if (m_iff_header.tiles == 0) {
-                            errorfmt("non-tiles are not supported");
-                            return false;
-                        }
-
-                        // 0 no compression
-                        // 1 RLE compression
-                        // 2 QRL (not supported)
-                        // 3 QR4 (not supported)
-                        if (m_iff_header.compression > 1) {
-                            errorfmt("only RLE compression is supported");
-                            return false;
-                        }
-
-                        // test format.
-                        if (flags & RGBA) {
-                            // test if black is set
-                            OIIO_DASSERT(!(flags & BLACK));
-
-                            // test for RGB channels.
-                            if (flags & RGB)
-                                m_iff_header.pixel_channels = 3;
-
-                            // test for alpha channel
-                            if (flags & ALPHA)
-                                m_iff_header.pixel_channels++;
-
-                            // test pixel bits
-                            m_iff_header.pixel_bits = bytes ? 16 : 8;
-                        }
-
-                        // Z format.
-                        else if (flags & ZBUFFER) {
-                            m_iff_header.pixel_channels = 1;
-                            m_iff_header.pixel_bits     = 32;  // 32bit
-                            // NOTE: Z_F32 support - not supported
-                            OIIO_DASSERT(bytes == 0);
-                        }
-
-                        // read AUTH, DATE or FOR4
-
-                        for (;;) {
-                            // get type
-                            if (!read_typesize(type, size))
-                                return false;
-
-                            chunksize = align_size(size, 4);
-
-                            if (type[0] == 'A' && type[1] == 'U'
-                                && type[2] == 'T' && type[3] == 'H') {
-                                std::vector<char> str(chunksize);
-                                if (!ioread(&str[0], 1, chunksize))
-                                    return false;
-                                m_iff_header.author = std::string(&str[0],
-                                                                  size);
-                            } else if (type[0] == 'D' && type[1] == 'A'
-                                       && type[2] == 'T' && type[3] == 'E') {
-                                std::vector<char> str(chunksize);
-                                if (!ioread(&str[0], 1, chunksize))
-                                    return false;
-                                m_iff_header.date = std::string(&str[0], size);
-                            } else if (type[0] == 'F' && type[1] == 'O'
-                                       && type[2] == 'R' && type[3] == '4') {
-                                if (!ioread(&type, 1, sizeof(type)))
-                                    return false;
-
-                                // check if CIMG
-                                if (type[0] == 'T' && type[1] == 'B'
-                                    && type[2] == 'M' && type[3] == 'P') {
-                                    // tbmp position for later user in in
-                                    // read_native_tile
-
-                                    m_iff_header.tbmp_start = iotell();
-
-                                    // read first RGBA block to detect tile size.
-
-                                    for (unsigned int t = 0;
-                                         t < m_iff_header.tiles; t++) {
-                                        if (!read_typesize(type, size))
-                                            return false;
-                                        chunksize = align_size(size, 4);
-
-                                        // check if RGBA
-                                        if (type[0] == 'R' && type[1] == 'G'
-                                            && type[2] == 'B'
-                                            && type[3] == 'A') {
-                                            // get tile coordinates.
-                                            uint16_t xmin, xmax, ymin, ymax;
-                                            if (!read(&xmin) || !read(&ymin)
-                                                || !read(&xmax) || !read(&ymax))
-                                                return false;
-
-                                            // check tile
-                                            if (xmin > xmax || ymin > ymax
-                                                || xmax >= m_iff_header.width
-                                                || ymax >= m_iff_header.height)
-                                                return false;
-
-                                            // set tile width and height
-                                            m_iff_header.tile_width
-                                                = xmax - xmin + 1;
-                                            m_iff_header.tile_height
-                                                = ymax - ymin + 1;
-
-                                            // done, return
-                                            return true;
-                                        }
-
-                                        // skip to the next block.
-                                        if (!ioseek(chunksize, SEEK_CUR))
-                                            return false;
-                                    }
-                                } else {
-                                    // skip to the next block.
-                                    if (!ioseek(chunksize, SEEK_CUR))
-                                        return false;
-                                }
-                            } else {
-                                // skip to the next block.
-                                if (!ioseek(chunksize, SEEK_CUR))
-                                    return false;
-                            }
-                        }
-                        // TBHD done, break
-                        break;
-                    }
-
-                    // skip to the next block.
-                    if (!ioseek(chunksize, SEEK_CUR))
-                        return false;
-                }
-            }
-        }
-        // skip to the next block.
-        if (!ioseek(chunksize, SEEK_CUR))
-            return false;
-    }
-    errorfmt("unknown error reading header");
-    return false;
 }
 
 
@@ -478,6 +173,10 @@ IffInput::read_native_tile(int subimage, int miplevel, int x, int y, int /*z*/,
 
 bool inline IffInput::close(void)
 {
+    if (m_fd) {
+        fclose(m_fd);
+        m_fd = NULL;
+    }
     init();
     return true;
 }
@@ -493,15 +192,20 @@ IffInput::readimg()
 
     // seek pos
     // set position tile may be called randomly
-    ioseek(m_tbmp_start);
+    fseek(m_fd, m_tbmp_start, SEEK_SET);
 
     // resize buffer
     m_buf.resize(m_spec.image_bytes());
 
     for (unsigned int t = 0; t < m_iff_header.tiles;) {
-        // get type and length
-        if (!ioread(&type, 1, sizeof(type)) || !read(&size))
+        // get type
+        if (!fread(&type, 1, sizeof(type), m_fd) ||
+            // get length
+            !fread(&size, 1, sizeof(size), m_fd))
             return false;
+
+        if (littleendian())
+            swap_endian(&size);
 
         chunksize = align_size(size, 4);
 
@@ -510,8 +214,19 @@ IffInput::readimg()
             && type[3] == 'A') {
             // get tile coordinates.
             uint16_t xmin, xmax, ymin, ymax;
-            if (!read(&xmin) || !read(&ymin) || !read(&xmax) || !read(&ymax))
+            if (!fread(&xmin, 1, sizeof(xmin), m_fd)
+                || !fread(&ymin, 1, sizeof(ymin), m_fd)
+                || !fread(&xmax, 1, sizeof(xmax), m_fd)
+                || !fread(&ymax, 1, sizeof(ymax), m_fd))
                 return false;
+
+            // swap endianness
+            if (littleendian()) {
+                swap_endian(&xmin);
+                swap_endian(&ymin);
+                swap_endian(&xmax);
+                swap_endian(&ymax);
+            }
 
             // get tile width/height
             uint32_t tw = xmax - xmin + 1;
@@ -553,7 +268,7 @@ IffInput::readimg()
                 // set bytes.
                 scratch.resize(image_size);
 
-                if (!ioread(scratch.data(), 1, scratch.size()))
+                if (!fread(&scratch[0], 1, scratch.size(), m_fd))
                     return false;
 
                 // set tile data
@@ -615,7 +330,7 @@ IffInput::readimg()
                 // set bytes.
                 scratch.resize(image_size);
 
-                if (!ioread(scratch.data(), 1, scratch.size()))
+                if (!fread(&scratch[0], 1, scratch.size(), m_fd))
                     return false;
 
                 // set tile data
@@ -706,8 +421,8 @@ IffInput::readimg()
                 }
 
             } else {
-                errorfmt("\"{}\": unsupported number of bits per pixel for tile",
-                         m_filename);
+                errorf("\"%s\": unsupported number of bits per pixel for tile",
+                       m_filename);
                 return false;
             }
 
@@ -716,7 +431,7 @@ IffInput::readimg()
 
         } else {
             // skip to the next block
-            if (!ioseek(chunksize))
+            if (fseek(m_fd, chunksize, SEEK_CUR))
                 return false;
         }
     }

--- a/src/iff.imageio/noproxy-iffoutput.cpp
+++ b/src/iff.imageio/noproxy-iffoutput.cpp
@@ -1,0 +1,600 @@
+// Copyright 2008-present Contributors to the OpenImageIO project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/OpenImageIO/oiio
+
+#include "noproxy-iff_pvt.h"
+
+OIIO_PLUGIN_NAMESPACE_BEGIN
+
+using namespace iff_pvt;
+
+
+// Obligatory material to make this a recognizable imageio plugin
+OIIO_PLUGIN_EXPORTS_BEGIN
+
+OIIO_EXPORT ImageOutput*
+iff_output_imageio_create()
+{
+    return new IffOutput;
+}
+
+OIIO_EXPORT const char* iff_output_extensions[] = { "iff", "z", nullptr };
+
+OIIO_PLUGIN_EXPORTS_END
+
+
+
+int
+IffOutput::supports(string_view feature) const
+{
+    return (feature == "tiles" || feature == "alpha" || feature == "nchannels");
+}
+
+
+
+bool
+IffOutput::open(const std::string& name, const ImageSpec& spec, OpenMode mode)
+{
+    // Autodesk Maya documentation:
+    // "Maya Image File Format - IFF
+    //
+    // Maya supports images in the Interchange File Format (IFF).
+    // IFF is a generic structured file access mechanism, and is not only
+    // limited to images.
+    //
+    // The openimageio IFF implementation deals specifically with Maya IFF
+    // images with it's data blocks structured as follows:
+    //
+    // Header:
+    // FOR4 <size> CIMG
+    //  TBHD <size> flags, width, height, compression ...
+    //    AUTH <size> attribute ...
+    //    DATE <size> attribute ...
+    //    FOR4 <size> TBMP
+    // Tiles:
+    //       RGBA <size> tile pixels
+    //       RGBA <size> tile pixels
+    //       RGBA <size> tile pixels
+    //       ...
+
+    if (mode != Create) {
+        errorf("%s does not support subimages or MIP levels", format_name());
+        return false;
+    }
+
+    close();  // Close any already-opened file
+    // saving 'name' and 'spec' for later use
+    m_filename = name;
+    m_spec     = spec;
+
+    // tiles
+    m_spec.tile_width  = tile_width();
+    m_spec.tile_height = tile_height();
+    m_spec.tile_depth  = 1;
+
+    m_fd = Filesystem::fopen(m_filename, "wb");
+    if (!m_fd) {
+        errorf("Could not open \"%s\"", m_filename);
+        return false;
+    }
+
+    // IFF image files only supports UINT8 and UINT16.  If something
+    // else was requested, revert to the one most likely to be readable
+    // by any IFF reader: UINT8
+    if (m_spec.format != TypeDesc::UINT8 && m_spec.format != TypeDesc::UINT16)
+        m_spec.set_format(TypeDesc::UINT8);
+
+    m_dither = (m_spec.format == TypeDesc::UINT8)
+                   ? m_spec.get_int_attribute("oiio:dither", 0)
+                   : 0;
+
+    // check if the client wants the image to be run length encoded
+    // currently only RGB RLE compression is supported, we default to RLE
+    // as Maya does not handle non-compressed IFF's very well.
+    m_iff_header.compression
+        = (m_spec.get_string_attribute("compression") == "none") ? NONE : RLE;
+
+    uint64_t xtiles = tile_width_size(m_spec.width);
+    uint64_t ytiles = tile_height_size(m_spec.height);
+    if (xtiles * ytiles >= (1 << 16)) {  // The format can't store it!
+        errorf(
+            "Too high a resolution (%dx%d), exceeds maximum of 64k tiles in the image\n",
+            m_spec.width, m_spec.height);
+        close();
+        return false;
+    }
+
+    // we write the header of the file
+    m_iff_header.x              = m_spec.x;
+    m_iff_header.y              = m_spec.y;
+    m_iff_header.width          = m_spec.width;
+    m_iff_header.height         = m_spec.height;
+    m_iff_header.tiles          = xtiles * ytiles;
+    m_iff_header.pixel_bits     = m_spec.format == TypeDesc::UINT8 ? 8 : 16;
+    m_iff_header.pixel_channels = m_spec.nchannels;
+    m_iff_header.author         = m_spec.get_string_attribute("Artist");
+    m_iff_header.date           = m_spec.get_string_attribute("DateTime");
+
+    if (!write_header(m_iff_header)) {
+        errorf("\"%s\": could not write iff header", m_filename);
+        close();
+        return false;
+    }
+
+    m_buf.resize(m_spec.image_bytes());
+
+    return true;
+}
+
+
+
+bool
+IffOutput::write_scanline(int y, int z, TypeDesc format, const void* data,
+                          stride_t xstride)
+{
+    // scanline not used for Maya IFF, uses tiles instead.
+    // Emulate by copying the scanline to the buffer we're accumulating.
+    std::vector<unsigned char> scratch;
+    data = to_native_scanline(format, data, xstride, scratch, m_dither, y, z);
+    size_t scanlinesize = spec().scanline_bytes(true);
+    size_t offset       = scanlinesize * (y - spec().y)
+                    + scanlinesize * spec().height * (z - spec().z);
+    memcpy(&m_buf[offset], data, scanlinesize);
+    return false;
+}
+
+
+
+bool
+IffOutput::write_tile(int x, int y, int z, TypeDesc format, const void* data,
+                      stride_t xstride, stride_t ystride, stride_t zstride)
+{
+    // auto stride
+    m_spec.auto_stride(xstride, ystride, zstride, format, spec().nchannels,
+                       spec().tile_width, spec().tile_height);
+
+    // native tile
+    data = to_native_tile(format, data, xstride, ystride, zstride, scratch,
+                          m_dither, x, y, z);
+
+    x -= m_spec.x;  // Account for offset, so x,y are file relative, not
+    y -= m_spec.y;  // image relative
+
+    // tile size
+    int w  = m_spec.width;
+    int tw = std::min(x + m_spec.tile_width, m_spec.width) - x;
+    int th = std::min(y + m_spec.tile_height, m_spec.height) - y;
+
+    // tile data
+    int iy = 0;
+    for (int oy = y; oy < y + th; oy++) {
+        // in
+        uint8_t* in_p = (uint8_t*)data
+                        + (iy * m_spec.tile_width) * m_spec.pixel_bytes();
+        // out
+        uint8_t* out_p = &m_buf[0] + (oy * w + x) * m_spec.pixel_bytes();
+        // copy
+        memcpy(out_p, in_p, tw * m_spec.pixel_bytes());
+        iy++;
+    }
+
+    return true;
+}
+
+
+
+inline bool
+IffOutput::close(void)
+{
+    if (m_fd && m_buf.size()) {
+        // flip buffer to make write tile easier,
+        // from tga.imageio:
+
+        int bytespp = m_spec.pixel_bytes();
+
+        std::vector<unsigned char> flip(m_spec.width * bytespp);
+        unsigned char *src, *dst, *tmp = &flip[0];
+        for (int y = 0; y < m_spec.height / 2; y++) {
+            src = &m_buf[(m_spec.height - y - 1) * m_spec.width * bytespp];
+            dst = &m_buf[y * m_spec.width * bytespp];
+
+            memcpy(tmp, src, m_spec.width * bytespp);
+            memcpy(src, dst, m_spec.width * bytespp);
+            memcpy(dst, tmp, m_spec.width * bytespp);
+        }
+
+        // write y-tiles
+        for (uint32_t ty = 0; ty < tile_height_size(m_spec.height); ty++) {
+            // write x-tiles
+            for (uint32_t tx = 0; tx < tile_width_size(m_spec.width); tx++) {
+                // channels
+                uint8_t channels = m_iff_header.pixel_channels;
+
+                // set tile coordinates
+                uint16_t xmin, xmax, ymin, ymax;
+
+                // set xmin and xmax
+                xmin = tx * tile_width();
+                xmax = std::min(xmin + tile_width(), m_spec.width) - 1;
+
+                // set ymin and ymax
+                ymin = ty * tile_height();
+                ymax = std::min(ymin + tile_height(), m_spec.height) - 1;
+
+                // set width and height
+                uint32_t tw = xmax - xmin + 1;
+                uint32_t th = ymax - ymin + 1;
+
+                // write 'RGBA' type
+                std::string tmpstr = "RGBA";
+                if (!fwrite(tmpstr.c_str(), tmpstr.length(), 1, m_fd))
+                    return false;
+
+                // length.
+                uint32_t length = tw * th * m_spec.pixel_bytes();
+
+                // tile length.
+                uint32_t tile_length = length;
+
+                // align.
+                length = align_size(length, 4);
+
+                // append xmin, xmax, ymin and ymax.
+                length += 8;
+
+                // tile compression.
+                bool tile_compress = (m_iff_header.compression == RLE);
+
+                // set bytes.
+                std::vector<uint8_t> scratch;
+                scratch.resize(tile_length);
+
+                uint8_t* out_p = static_cast<uint8_t*>(&scratch[0]);
+
+                // handle 8-bit data
+                if (m_spec.format == TypeDesc::UINT8) {
+                    if (tile_compress) {
+                        uint32_t index = 0, size = 0;
+                        std::vector<uint8_t> tmp;
+
+                        // set bytes.
+                        tmp.resize(tile_length * 2);
+
+                        // map: RGB(A) to BGRA
+                        for (int c = (channels * m_spec.channel_bytes()) - 1;
+                             c >= 0; --c) {
+                            std::vector<uint8_t> in(tw * th);
+                            uint8_t* in_p = &in[0];
+
+                            // set tile
+                            for (uint16_t py = ymin; py <= ymax; py++) {
+                                const uint8_t* in_dy
+                                    = &m_buf[0]
+                                      + (py * m_spec.width)
+                                            * m_spec.pixel_bytes();
+
+                                for (uint16_t px = xmin; px <= xmax; px++) {
+                                    // get pixel
+                                    uint8_t pixel;
+                                    const uint8_t* in_dx
+                                        = in_dy + px * m_spec.pixel_bytes() + c;
+                                    memcpy(&pixel, in_dx, 1);
+                                    // set pixel
+                                    *in_p++ = pixel;
+                                }
+                            }
+
+                            // compress rle channel
+                            size = compress_rle_channel(&in[0], &tmp[0] + index,
+                                                        tw * th);
+                            index += size;
+                        }
+
+                        // if size exceeds tile length write uncompressed
+
+                        if (index < tile_length) {
+                            memcpy(&scratch[0], &tmp[0], index);
+
+                            // set tile length
+                            tile_length = index;
+
+                            // append xmin, xmax, ymin and ymax
+                            length = index + 8;
+
+                            // set length
+                            uint32_t align = align_size(length, 4);
+                            if (align > length) {
+                                out_p = &scratch[0] + index;
+                                // Pad.
+                                for (uint32_t i = 0; i < align - length; i++) {
+                                    *out_p++ = '\0';
+                                    tile_length++;
+                                }
+                            }
+                        } else {
+                            tile_compress = false;
+                        }
+                    }
+                    if (!tile_compress) {
+                        for (uint16_t py = ymin; py <= ymax; py++) {
+                            const uint8_t* in_dy = &m_buf[0]
+                                                   + (py * m_spec.width)
+                                                         * m_spec.pixel_bytes();
+
+                            for (uint16_t px = xmin; px <= xmax; px++) {
+                                // Map: RGB(A)8 RGBA to BGRA
+                                for (int c = channels - 1; c >= 0; --c) {
+                                    // get pixel
+                                    uint8_t pixel;
+                                    const uint8_t* in_dx
+                                        = in_dy + px * m_spec.pixel_bytes()
+                                          + c * m_spec.channel_bytes();
+                                    memcpy(&pixel, in_dx, 1);
+                                    // set pixel
+                                    *out_p++ = pixel;
+                                }
+                            }
+                        }
+                    }
+                }
+                // handle 16-bit data
+                else if (m_spec.format == TypeDesc::UINT16) {
+                    if (tile_compress) {
+                        uint32_t index = 0, size = 0;
+                        std::vector<uint8_t> tmp;
+
+                        // set bytes.
+                        tmp.resize(tile_length * 2);
+
+                        // set map
+                        std::vector<uint8_t> map;
+                        if (littleendian()) {
+                            int rgb16[]  = { 0, 2, 4, 1, 3, 5 };
+                            int rgba16[] = { 0, 2, 4, 7, 1, 3, 5, 6 };
+                            if (m_iff_header.pixel_channels == 3) {
+                                map = std::vector<uint8_t>(rgb16, &rgb16[6]);
+                            } else {
+                                map = std::vector<uint8_t>(rgba16, &rgba16[8]);
+                            }
+
+                        } else {
+                            int rgb16[]  = { 1, 3, 5, 0, 2, 4 };
+                            int rgba16[] = { 1, 3, 5, 7, 0, 2, 4, 6 };
+                            if (m_iff_header.pixel_channels == 3) {
+                                map = std::vector<uint8_t>(rgb16, &rgb16[6]);
+                            } else {
+                                map = std::vector<uint8_t>(rgba16, &rgba16[8]);
+                            }
+                        }
+
+                        // map: RRGGBB(AA) to BGR(A)BGR(A)
+                        for (int c = (channels * m_spec.channel_bytes()) - 1;
+                             c >= 0; --c) {
+                            int mc = map[c];
+
+                            std::vector<uint8_t> in(tw * th);
+                            uint8_t* in_p = &in[0];
+
+                            // set tile
+                            for (uint16_t py = ymin; py <= ymax; py++) {
+                                const uint8_t* in_dy
+                                    = &m_buf[0]
+                                      + (py * m_spec.width)
+                                            * m_spec.pixel_bytes();
+
+                                for (uint16_t px = xmin; px <= xmax; px++) {
+                                    // get pixel
+                                    uint8_t pixel;
+                                    const uint8_t* in_dx
+                                        = in_dy + px * m_spec.pixel_bytes()
+                                          + mc;
+                                    memcpy(&pixel, in_dx, 1);
+                                    // set pixel.
+                                    *in_p++ = pixel;
+                                }
+                            }
+
+                            // compress rle channel
+                            size = compress_rle_channel(&in[0], &tmp[0] + index,
+                                                        tw * th);
+                            index += size;
+                        }
+
+                        // if size exceeds tile length write uncompressed
+
+                        if (index < tile_length) {
+                            memcpy(&scratch[0], &tmp[0], index);
+
+                            // set tile length
+                            tile_length = index;
+
+                            // append xmin, xmax, ymin and ymax
+                            length = index + 8;
+
+                            // set length
+                            uint32_t align = align_size(length, 4);
+                            if (align > length) {
+                                out_p = &scratch[0] + index;
+                                // Pad.
+                                for (uint32_t i = 0; i < align - length; i++) {
+                                    *out_p++ = '\0';
+                                    tile_length++;
+                                }
+                            }
+                        } else {
+                            tile_compress = false;
+                        }
+                    }
+
+                    if (!tile_compress) {
+                        for (uint16_t py = ymin; py <= ymax; py++) {
+                            const uint8_t* in_dy = &m_buf[0]
+                                                   + (py * m_spec.width)
+                                                         * m_spec.pixel_bytes();
+
+                            for (uint16_t px = xmin; px <= xmax; px++) {
+                                // map: RGB(A) to BGRA
+                                for (int c = channels - 1; c >= 0; --c) {
+                                    uint16_t pixel;
+                                    const uint8_t* in_dx
+                                        = in_dy + px * m_spec.pixel_bytes()
+                                          + c * m_spec.channel_bytes();
+                                    memcpy(&pixel, in_dx, 2);
+                                    if (littleendian()) {
+                                        swap_endian(&pixel);
+                                    }
+                                    // set pixel
+                                    *out_p++ = pixel & 0xff;
+                                    *out_p++ = pixel >> 8;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // write 'RGBA' length
+                if (littleendian())
+                    swap_endian(&length);
+
+                if (!fwrite(&length, sizeof(length), 1, m_fd))
+                    return false;
+
+                // write xmin, xmax, ymin and ymax
+                if (littleendian()) {
+                    swap_endian(&xmin);
+                    swap_endian(&ymin);
+                    swap_endian(&xmax);
+                    swap_endian(&ymax);
+                }
+
+                if (!fwrite(&xmin, sizeof(xmin), 1, m_fd)
+                    || !fwrite(&ymin, sizeof(ymin), 1, m_fd)
+                    || !fwrite(&xmax, sizeof(xmax), 1, m_fd)
+                    || !fwrite(&ymax, sizeof(ymax), 1, m_fd))
+                    return false;
+
+                // write tile
+                if (!fwrite(&scratch[0], tile_length, 1, m_fd))
+                    return false;
+            }
+        }
+
+        // set sizes
+        uint32_t pos, tmppos;
+        pos = ftell(m_fd);
+
+        uint32_t p0 = pos - 8;
+        uint32_t p1 = p0 - m_iff_header.for4_start;
+
+        // set pos
+        tmppos = 4;
+        fseek(m_fd, tmppos, SEEK_SET);
+
+        // write FOR4 <size> CIMG
+        if (littleendian()) {
+            swap_endian(&p0);
+        }
+
+        if (!fwrite(&p0, sizeof(p0), 1, m_fd))
+            return false;
+
+        // set pos
+        tmppos = m_iff_header.for4_start + 4;
+        fseek(m_fd, tmppos, SEEK_SET);
+
+        // write FOR4 <size> TBMP
+        if (littleendian()) {
+            swap_endian(&p1);
+        }
+
+        if (!fwrite(&p1, sizeof(p1), 1, m_fd))
+            return false;
+
+        m_buf.resize(0);
+        m_buf.shrink_to_fit();
+    }
+    if (m_fd) {
+        // close the stream
+        fclose(m_fd);
+        m_fd = NULL;
+    }
+    return true;
+}
+
+
+
+void
+IffOutput::compress_verbatim(const uint8_t*& in, uint8_t*& out, int size)
+{
+    int count          = 1;
+    unsigned char byte = 0;
+
+    // two in a row or count
+    for (; count < size; ++count) {
+        if (in[count - 1] == in[count]) {
+            if (byte == in[count - 1]) {
+                count -= 2;
+                break;
+            }
+        }
+        byte = in[count - 1];
+    }
+
+    // copy
+    *out++ = count - 1;
+    memcpy(out, in, count);
+
+    out += count;
+    in += count;
+}
+
+
+
+void
+IffOutput::compress_duplicate(const uint8_t*& in, uint8_t*& out, int size)
+{
+    int count = 1;
+    for (; count < size; ++count) {
+        if (in[count - 1] != in[count])
+            break;
+    }
+
+    const bool run   = count > 1;
+    const int length = run ? 1 : count;
+
+    // copy
+    *out++ = ((count - 1) & 0x7f) | (run << 7);
+    *out   = *in;
+
+    out += length;
+    in += count;
+}
+
+
+
+size_t
+IffOutput::compress_rle_channel(const uint8_t* in, uint8_t* out, int size)
+{
+    const uint8_t* const _out = out;
+    const uint8_t* const end  = in + size;
+
+    while (in < end) {
+        // find runs
+        const int max = std::min(0x7f + 1, static_cast<int>(end - in));
+        if (max > 0) {
+            if (in < (end - 1) && in[0] == in[1]) {
+                // compress duplicate
+                compress_duplicate(in, out, max);
+            } else {
+                // compress verbatim
+                compress_verbatim(in, out, max);
+            }
+        }
+    }
+    const size_t r = out - _out;
+    return r;
+}
+
+
+
+OIIO_PLUGIN_NAMESPACE_END


### PR DESCRIPTION
When we recently added IOProxy support to the Maya iff file reader in PR 3647, something broke for certain (but not all) iff files, and I have productions stumbling over this.

It's proving tricky to track down and I have shows needing a fix immediatly, so this change sets up a CMake variable ENABLE_RLA_IOPROXY, default to ON, but when set to OFF, it switches back to the old "no proxy" versions of the iff reader.

Disabling this will get me out of my current emergency -- at the cost of not having IOProxy for iff, which I don't need at this moment anyway -- and give me some breathing room to fix the problem for real, at which point I will re-remove the old code.
