### PR TITLE
Fix unresolved external symbol for MSVS 2017 (#3762)

### DIFF
--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -929,7 +929,7 @@ Strutil::utf16_to_utf8(const std::u16string& str) noexcept
         // There is a bug in MSVS 2017 causing an unresolved symbol if char16_t is used (see https://stackoverflow.com/a/35103224)
 #if defined _MSC_VER && _MSC_VER >= 1900 && _MSC_VER < 1930
         std::wstring_convert<std::codecvt_utf8_utf16<int16_t>, int16_t> convert;
-        auto p = reinterpret_cast<const int16_t *>(str.data());
+        auto p = reinterpret_cast<const int16_t*>(str.data());
         return convert.to_bytes(p, p + str.size());
 #else
         std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> conv;

--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -926,9 +926,16 @@ Strutil::utf16_to_utf8(const std::u16string& str) noexcept
     try {
         OIIO_PRAGMA_WARNING_PUSH
         OIIO_CLANG_PRAGMA(GCC diagnostic ignored "-Wdeprecated-declarations")
+        // There is a bug in MSVS 2017 causing an unresolved symbol if char16_t is used (see https://stackoverflow.com/a/35103224)
+#if defined _MSC_VER && _MSC_VER >= 1900 && _MSC_VER < 1930
+        std::wstring_convert<std::codecvt_utf8_utf16<int16_t>, int16_t> convert;
+        auto p = reinterpret_cast<const int16_t *>(str.data());
+        return convert.to_bytes(p, p + str.size());
+#else
         std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> conv;
-        OIIO_PRAGMA_WARNING_POP
         return conv.to_bytes(str);
+#endif
+        OIIO_PRAGMA_WARNING_POP
     } catch (const std::exception&) {
         return std::string();
     }


### PR DESCRIPTION
If char16_t is used as template argument, this leads to an unresolved symbol for MSVS 2017. Use int16_t instead of char16_t in this case. 

Fixes #3762

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [x] ~~If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-CORPORATE)).~~ This is just a small change
- [x] ~~I have updated the documentation, if applicable.~~ Not applicable.
- [x] ~~I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).~~ Not applicable.
- [x] My code follows the prevailing code style of this project.

