### PR TITLE
Initialize OpenEXROutput::m_levelmode() in init().

### DIFF
--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -190,6 +190,7 @@ private:
         m_tiled_output_part.reset();
         m_deep_scanline_output_part.reset();
         m_deep_tiled_output_part.reset();
+        m_levelmode = Imf::ONE_LEVEL;
         m_subimage = -1;
         m_miplevel = -1;
         m_subimagespecs.clear();


### PR DESCRIPTION
Avoids conditional jump on uninitialised values in close(). Not sure whether ONE_LEVEL is the best value here ...

## Description

Without that fix, valgrind reports a conditional jump on uninitialised values on code like
```
auto out = OIIO::ImageOutput::create( "exr");
```

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

