### PR TITLE
test: Better testing of python IBA functions

### DIFF
--- a/testsuite/python-imagebufalgo/src/test_imagebufalgo.py
+++ b/testsuite/python-imagebufalgo/src/test_imagebufalgo.py
@@ -42,6 +42,28 @@ def dumpimg (image, fmt="{:.3f}", msg="") :
             print ("")
 
 
+# Test an ImageBufAlgo function `func`, with a given set of arguments, running
+# both the variety that returns an ImageBuf with the result, and also the kind
+# that modifies an existing ImageBuf in place. An error is printed if the
+# results differ. The "returned" IB is returned from the function.
+def test_iba (func, *args, **kwargs) :
+    # Test the version of func that returns an IB
+    # func = getattr(ImageBufAlgo, funcname)
+    b = func(*args, **kwargs)
+    # if filename is not None :
+    #     write (b, filename)
+    # Test the version of func that writes to an existing IB and make
+    # sure it matches.
+    b2 = ImageBuf()
+    func (b2, *args, **kwargs)
+    compresults = ImageBufAlgo.compare (b, b2, 0.0, 0.0)
+    if compresults.nfail > 0 :
+        print ("FAILURE:", func.__name__, ": IB-returning and in-place versions differed")
+        b.write (func.__name__ + "-1.tif")
+        b2.write (func.__name__ + "-2.tif")
+        exit (1)
+    return b
+
 
 ######################################################################
 # main test starts here
@@ -58,7 +80,9 @@ try:
 
     # black
     # b = ImageBuf (ImageSpec(320,240,3,oiio.UINT8))
-    b = ImageBufAlgo.zero (roi=oiio.ROI(0,320,0,240,0,1,0,3))
+    # b = ImageBufAlgo.zero (roi=oiio.ROI(0,320,0,240,0,1,0,3))
+    # b = test_iba ("black.tif", "zero", roi=oiio.ROI(0,320,0,240,0,1,0,3))
+    b = test_iba (ImageBufAlgo.zero, roi=oiio.ROI(0,320,0,240,0,1,0,3))
     write (b, "black.tif", oiio.UINT8)
 
     # fill (including use of ROI)
@@ -81,11 +105,11 @@ try:
     write (b, "noise-blue3.tif", oiio.UINT8)
 
     # noise-gaussian
-    b = ImageBufAlgo.noise ("gaussian", 0.5, 0.1, roi=ROI(0,64,0,64,0,1,0,3));
+    b = ImageBufAlgo.noise ("gaussian", 0.5, 0.1, roi=ROI(0,64,0,64,0,1,0,3))
     write (b, "noise-gauss.tif", oiio.UINT8)
 
     # noise-salt
-    b = ImageBufAlgo.noise ("salt", 1, 0.01, roi=ROI(0,64,0,64,0,1,0,3));
+    b = ImageBufAlgo.noise ("salt", 1, 0.01, roi=ROI(0,64,0,64,0,1,0,3))
     write (b, "noise-salt.tif", oiio.UINT8)
 
     # bluenoise_image
@@ -101,24 +125,24 @@ try:
     write (b, "ch-rgba.exr")
     b = ImageBufAlgo.channels (ImageBuf(OIIO_TESTSUITE_ROOT+"/oiiotool/src/rgbaz.exr"), ("Z",))
     write (b, "ch-z.exr")
-    b = ImageBufAlgo.channel_append (ImageBuf("ch-rgba.exr"),
-                                     ImageBuf("ch-z.exr"))
+    b = test_iba (ImageBufAlgo.channel_append, ImageBuf("ch-rgba.exr"),
+                  ImageBuf("ch-z.exr"))
     write (b, "chappend-rgbaz.exr")
 
     # flatten
-    b = ImageBufAlgo.flatten (ImageBuf(OIIO_TESTSUITE_ROOT+"/oiiotool-deep/src/deepalpha.exr"))
+    b = test_iba (ImageBufAlgo.flatten, ImageBuf(OIIO_TESTSUITE_ROOT+"/oiiotool-deep/src/deepalpha.exr"))
     write (b, "flat.exr")
 
     # deepen
-    b = ImageBufAlgo.deepen (ImageBuf(OIIO_TESTSUITE_ROOT+"/oiiotool-deep/src/az.exr"))
+    b = test_iba (ImageBufAlgo.deepen, ImageBuf(OIIO_TESTSUITE_ROOT+"/oiiotool-deep/src/az.exr"))
     write (b, "deepen.exr")
 
     # crop
-    b = ImageBufAlgo.crop (grid, oiio.ROI(50,150,200,600))
+    b = test_iba (ImageBufAlgo.crop, grid, oiio.ROI(50,150,200,600))
     write (b, "crop.tif")
 
     # cut
-    b = ImageBufAlgo.cut (grid, oiio.ROI(50,150,200,600))
+    b = test_iba (ImageBufAlgo.cut, grid, oiio.ROI(50,150,200,600))
     write (b, "cut.tif")
 
     # paste
@@ -128,23 +152,23 @@ try:
     write (b, "pasted.tif")
 
     # rotate90
-    b = ImageBufAlgo.rotate90 (ImageBuf(OIIO_TESTSUITE_ROOT+"/oiiotool/src/image.tif"))
+    b = test_iba (ImageBufAlgo.rotate90, ImageBuf(OIIO_TESTSUITE_ROOT+"/oiiotool/src/image.tif"))
     write (b, "rotate90.tif")
 
     # rotate180
-    b = ImageBufAlgo.rotate180 (ImageBuf(OIIO_TESTSUITE_ROOT+"/oiiotool/src/image.tif"))
+    b = test_iba (ImageBufAlgo.rotate180, ImageBuf(OIIO_TESTSUITE_ROOT+"/oiiotool/src/image.tif"))
     write (b, "rotate180.tif")
 
     # rotate270
-    b = ImageBufAlgo.rotate270 (ImageBuf(OIIO_TESTSUITE_ROOT+"/oiiotool/src/image.tif"))
+    b = test_iba (ImageBufAlgo.rotate270, ImageBuf(OIIO_TESTSUITE_ROOT+"/oiiotool/src/image.tif"))
     write (b, "rotate270.tif")
 
     # flip
-    b = ImageBufAlgo.flip (ImageBuf(OIIO_TESTSUITE_ROOT+"/oiiotool/src/image.tif"))
+    b = test_iba (ImageBufAlgo.flip, ImageBuf(OIIO_TESTSUITE_ROOT+"/oiiotool/src/image.tif"))
     write (b, "flip.tif")
 
     # flop
-    b = ImageBufAlgo.flop (ImageBuf(OIIO_TESTSUITE_ROOT+"/oiiotool/src/image.tif"))
+    b = test_iba (ImageBufAlgo.flop, ImageBuf(OIIO_TESTSUITE_ROOT+"/oiiotool/src/image.tif"))
     write (b, "flop.tif")
 
     # reorient
@@ -152,16 +176,16 @@ try:
     ImageBufAlgo.resample (image_small, ImageBuf(OIIO_TESTSUITE_ROOT+"/oiiotool/src/image.tif"),  roi=oiio.ROI(0,160,0,120))
     image_small = ImageBufAlgo.rotate90 (image_small)
     image_small.specmod().attribute ("Orientation", 8)
-    b = ImageBufAlgo.reorient (image_small)
+    b = test_iba (ImageBufAlgo.reorient, image_small)
     write (b, "reorient1.tif")
     image_small = ImageBuf()
 
     # transpose
-    b = ImageBufAlgo.transpose (ImageBuf(OIIO_TESTSUITE_ROOT+"/oiiotool/src/image.tif"))
+    b = test_iba (ImageBufAlgo.transpose, ImageBuf(OIIO_TESTSUITE_ROOT+"/oiiotool/src/image.tif"))
     write (b, "transpose.tif")
 
     # circular_shift
-    b = ImageBufAlgo.circular_shift (ImageBuf(OIIO_TESTSUITE_ROOT+"/oiiotool/src/image.tif"), 100, 50)
+    b = test_iba (ImageBufAlgo.circular_shift, ImageBuf(OIIO_TESTSUITE_ROOT+"/oiiotool/src/image.tif"), 100, 50)
     write (b, "cshift.tif")
 
     # clamp
@@ -174,19 +198,19 @@ try:
     write (b, "clamped-with-float.exr", "half")
 
     # add
-    b = ImageBufAlgo.add (gray128, 0.25)
+    b = test_iba (ImageBufAlgo.add, gray128, 0.25)
     write (b, "cadd1.exr")
     b = ImageBufAlgo.add (gray128, (0, 0.25, -0.25))
     write (b, "cadd2.exr")
-    b = ImageBufAlgo.add (make_constimage(64,64,3,oiio.HALF,(.1,.2,.3)),
+    b = test_iba(ImageBufAlgo.add, make_constimage(64, 64, 3, oiio.HALF, (.1, .2, .3)),
                           make_constimage(64,64,3,oiio.HALF,(.1,.1,.1),20,20))
     write (b, "add.exr")
 
     # sub
-    b = ImageBufAlgo.sub (make_constimage(64,64,3,oiio.HALF,(.1,.2,.3)),
+    b = test_iba (ImageBufAlgo.sub, make_constimage(64,64,3,oiio.HALF,(.1,.2,.3)),
                           make_constimage(64,64,3,oiio.HALF,(.1,.1,.1),20,20))
     write (b, "sub.exr")
-    b = ImageBufAlgo.sub (gray128, (0.125, 0.5, 0.25))
+    b = test_iba (ImageBufAlgo.sub, gray128, (0.125, 0.5, 0.25))
     write (b, "csub2.exr")
 
     # Test --absdiff and --abs
@@ -194,9 +218,9 @@ try:
     a = ImageBuf (ImageSpec(128,128,3,oiio.HALF))
     ImageBufAlgo.fill (a, (0.5,0.5,0.5))
     ImageBufAlgo.fill (a, (-0.25,-0.25,-0.25), oiio.ROI(0,64,0,128))
-    b = ImageBufAlgo.abs (a)
+    b = test_iba (ImageBufAlgo.abs, a)
     write (b, "abs.exr", oiio.HALF)
-    b = ImageBufAlgo.absdiff (a, (0.2,0.2,0.2))
+    b = test_iba (ImageBufAlgo.absdiff, a, (0.2,0.2,0.2))
     write (b, "absdiff.exr", oiio.HALF)
     a = ImageBuf()
 
@@ -205,26 +229,26 @@ try:
     write (b, "cmul1.exr")
     b = ImageBufAlgo.mul (gray128, (1.5,1,0.5))
     write (b, "cmul2.exr")
-    b = ImageBufAlgo.mul (make_constimage(64,64,3,oiio.HALF,(.5,.5,.5)),
+    b = test_iba (ImageBufAlgo.mul, make_constimage(64,64,3,oiio.HALF,(.5,.5,.5)),
                           make_constimage(64,64,3,oiio.HALF,(1.5,1,0.5)))
     write (b, "mul.exr", oiio.HALF)
 
     # mad
-    b = ImageBufAlgo.mad (make_constimage(64,64,3,oiio.HALF,(.5,.5,.5)),
+    b = test_iba (ImageBufAlgo.mad, make_constimage(64,64,3,oiio.HALF,(.5,.5,.5)),
                           make_constimage(64,64,3,oiio.HALF,(1.5,1,0.5)),
                           make_constimage(64,64,3,oiio.HALF,(0.1,0.1,0.1)))
     write (b, "mad.exr", oiio.HALF)
-    b = ImageBufAlgo.mad (make_constimage(64,64,3,oiio.HALF,(.5,.5,.5)),
+    b = test_iba (ImageBufAlgo.mad, make_constimage(64,64,3,oiio.HALF,(.5,.5,.5)),
                           (1.5,1,0.5),
                           (0.1,0.1,0.1))
     write (b, "mad2.exr", oiio.HALF)
-    b = ImageBufAlgo.mad (make_constimage(64,64,3,oiio.HALF,(.5,.5,.5)),
+    b = test_iba (ImageBufAlgo.mad, make_constimage(64,64,3,oiio.HALF,(.5,.5,.5)),
                           (1.5,1,0.5),
                           make_constimage(64,64,3,oiio.HALF,(0.1,0.1,0.1)))
     write (b, "mad3.exr", oiio.HALF)
 
     # div
-    b = ImageBufAlgo.div (gray64, make_constimage (64, 64, 3, oiio.HALF, (2.0,1,0.5)))
+    b = test_iba (ImageBufAlgo.div, gray64, make_constimage (64, 64, 3, oiio.HALF, (2.0,1,0.5)))
     write (b, "div.exr", oiio.HALF)
     b = ImageBufAlgo.div (gray64, 2.0)
     write (b, "divc1.exr", oiio.HALF)
@@ -233,7 +257,7 @@ try:
 
     # invert
     a = ImageBuf (OIIO_TESTSUITE_ROOT+"/common/tahoe-small.tif")
-    b = ImageBufAlgo.invert (a)
+    b = test_iba (ImageBufAlgo.invert, a)
     write (b, "invert.tif", oiio.UINT8)
 
     # pow
@@ -243,27 +267,28 @@ try:
     write (b, "cpow2.exr")
 
     # channel_sum
-    b = ImageBufAlgo.channel_sum (ImageBuf(OIIO_TESTSUITE_ROOT+"/common/tahoe-small.tif"),
-                                  (.2126,.7152,.0722))
+    b = test_iba (ImageBufAlgo.channel_sum,
+                  ImageBuf(OIIO_TESTSUITE_ROOT+"/common/tahoe-small.tif"),
+                  (.2126,.7152,.0722))
     write (b, "chsum.tif", oiio.UINT8)
 
     # min, max (per element)
     lrramp64 = ImageBufAlgo.fill((0,0,0), (1,1,1), (0,0,0), (1,1,1),
                                  oiio.ROI(0, 64, 0, 64, 0, 1, 0, 3))
-    b = ImageBufAlgo.max (lrramp64, gray64)
+    b = test_iba (ImageBufAlgo.max, lrramp64, gray64)
     write (b, "maximg.tif", oiio.UINT8)
-    b = ImageBufAlgo.max (lrramp64, (0.25, 0.25, 0.25))
+    b = test_iba (ImageBufAlgo.max, lrramp64, (0.25, 0.25, 0.25))
     write (b, "maxval.tif", oiio.UINT8)
-    b = ImageBufAlgo.min (lrramp64, gray64)
+    b = test_iba (ImageBufAlgo.min, lrramp64, gray64)
     write (b, "minimg.tif", oiio.UINT8)
-    b = ImageBufAlgo.min (lrramp64, (0.25, 0.25, 0.25))
+    b = test_iba (ImageBufAlgo.min, lrramp64, (0.25, 0.25, 0.25))
     write (b, "minval.tif", oiio.UINT8)
 
     # minchan, maxchan
-    b = ImageBufAlgo.maxchan (ImageBufAlgo.fill((0,0,0.2), (1,0,0.2), (0,1,0.2), (1,1,0.2),
+    b = test_iba (ImageBufAlgo.maxchan, ImageBufAlgo.fill((0,0,0.2), (1,0,0.2), (0,1,0.2), (1,1,0.2),
                                                 ROI(0,100,0,100,0,1,0,3)))
     write (b, "maxchan.tif", oiio.UINT8)
-    b = ImageBufAlgo.minchan (ImageBufAlgo.fill((0,0,0.8), (1,0,0.8), (0,1,0.8), (1,1,0.8),
+    b = test_iba (ImageBufAlgo.minchan, ImageBufAlgo.fill((0,0,0.8), (1,0,0.8), (0,1,0.8), (1,1,0.8),
                                                 ROI(0,100,0,100,0,1,0,3)))
     write (b, "minchan.tif", oiio.UINT8)
 
@@ -276,9 +301,9 @@ try:
     # premult/unpremult
     b = make_constimage(100,100,4,oiio.FLOAT,(.1,.1,.1,1))
     ImageBufAlgo.fill (b, (.2,.2,.2,.5), oiio.ROI(50,80,50,80))
-    b = ImageBufAlgo.unpremult (b)
+    b = test_iba (ImageBufAlgo.unpremult, b)
     write (b, "unpremult.tif")
-    b = ImageBufAlgo.premult (b)
+    b = test_iba (ImageBufAlgo.premult, b)
     write (b, "premult.tif")
 
     b = ImageBufAlgo.contrast_remap (tahoetiny, black=0.1, white=0.75)
@@ -290,23 +315,23 @@ try:
 
     b = ImageBufAlgo.saturate (tahoetiny, scale = 0.0)
     write (b, "saturate-0.tif")
-    b = ImageBufAlgo.saturate (tahoetiny, scale = 2.0)
+    b = test_iba (ImageBufAlgo.saturate, tahoetiny, scale = 2.0)
     write (b, "saturate-2.tif")
 
     b = ImageBuf (OIIO_TESTSUITE_ROOT+"/common/tahoe-small.tif")
-    b = ImageBufAlgo.rangecompress (b)
+    b = test_iba (ImageBufAlgo.rangecompress, b)
     write (b, "rangecompress.tif", oiio.UINT8)
-    b = ImageBufAlgo.rangeexpand (b)
+    b = test_iba (ImageBufAlgo.rangeexpand, b)
     write (b, "rangeexpand.tif", oiio.UINT8)
 
-    # FIXME - colorconvert, ociolook need tests
+    # FIXME - ociolook, ociodisplay, ociofiletransform need tests
     print ("\nTesting color conversions:")
     b = make_constimage (2,2,4,oiio.FLOAT,(0,0,0,1))
     b.setpixel(1, 0, (.25,.25,.25,1))
     b.setpixel(0, 1, (.5,.5,.5,1))
     b.setpixel(1, 1, (1,1,1,1))
     dumpimg (b, msg="linear src=")
-    r = ImageBufAlgo.colorconvert(b, "Linear", "sRGB")
+    r = test_iba (ImageBufAlgo.colorconvert, b, "Linear", "sRGB")
     dumpimg (r, msg="to srgb =")
     r = ImageBufAlgo.colorconvert(r, "sRGB", "Linear")
     dumpimg (r, msg="back to linear =")
@@ -377,24 +402,24 @@ try:
     print ("Nonzero region is: ", ImageBufAlgo.nonzero_region(b))
 
     # resize
-    b = ImageBufAlgo.resize (grid, roi=oiio.ROI(0,256,0,256))
+    b = test_iba (ImageBufAlgo.resize, grid, roi=oiio.ROI(0,256,0,256))
     write (b, "resize.tif")
 
     # resample
-    b = ImageBufAlgo.resample (grid, roi=oiio.ROI(0,128,0,128))
+    b = test_iba (ImageBufAlgo.resample, grid, roi=oiio.ROI(0,128,0,128))
     write (b, "resample.tif")
 
     # fit
-    b = ImageBufAlgo.fit (grid, roi=oiio.ROI(0,360,0,240))
+    b = test_iba (ImageBufAlgo.fit, grid, roi=oiio.ROI(0,360,0,240))
     write (b, "fit.tif")
 
     # warp
     Mwarp = (0.7071068, 0.7071068, 0, -0.7071068, 0.7071068, 0, 128, -53.01933, 1)
-    b = ImageBufAlgo.warp (ImageBuf("resize.tif"), Mwarp)
+    b = test_iba (ImageBufAlgo.warp, ImageBuf("resize.tif"), Mwarp)
     write (b, "warped.tif")
 
     # rotate
-    b = ImageBufAlgo.rotate (ImageBuf("resize.tif"), math.radians(45.0))
+    b = test_iba (ImageBufAlgo.rotate, ImageBuf("resize.tif"), math.radians(45.0))
     write (b, "rotated.tif")
     b = ImageBufAlgo.rotate (ImageBuf("resize.tif"), math.radians(45.0), 50.0, 50.0)
     write (b, "rotated-offcenter.tif")
@@ -404,24 +429,24 @@ try:
     write (bsplinekernel, "bsplinekernel.exr")
 
     # convolve -- test with bspline blur
-    b = ImageBufAlgo.convolve (ImageBuf(OIIO_TESTSUITE_ROOT+"/common/tahoe-small.tif"),
+    b = test_iba (ImageBufAlgo.convolve, ImageBuf(OIIO_TESTSUITE_ROOT+"/common/tahoe-small.tif"),
                                bsplinekernel)
     write (b, "bspline-blur.tif", oiio.UINT8)
 
     # median filter
-    b = ImageBufAlgo.median_filter (ImageBuf(OIIO_TESTSUITE_ROOT+"/common/tahoe-small.tif"), 5, 5)
+    b = test_iba (ImageBufAlgo.median_filter, ImageBuf(OIIO_TESTSUITE_ROOT+"/common/tahoe-small.tif"), 5, 5)
     write (b, "tahoe-median.tif", oiio.UINT8)
 
     # Dilate/erode
     undilated = ImageBuf(OIIO_TESTSUITE_ROOT+"/oiiotool/src/morphsource.tif")
-    b = ImageBufAlgo.dilate (undilated, 3, 3)
+    b = test_iba (ImageBufAlgo.dilate, undilated, 3, 3)
     write (b, "dilate.tif", oiio.UINT8)
-    b = ImageBufAlgo.erode (undilated, 3, 3)
+    b = test_iba (ImageBufAlgo.erode, undilated, 3, 3)
     write (b, "erode.tif", oiio.UINT8)
     undilated = None
 
     # unsharp_mask
-    b = ImageBufAlgo.unsharp_mask (ImageBuf(OIIO_TESTSUITE_ROOT+"/common/tahoe-small.tif"),
+    b = test_iba (ImageBufAlgo.unsharp_mask, ImageBuf(OIIO_TESTSUITE_ROOT+"/common/tahoe-small.tif"),
                                    "gaussian", 3.0, 1.0, 0.0)
     write (b, "unsharp.tif", oiio.UINT8)
 
@@ -431,7 +456,7 @@ try:
     write (b, "unsharp-median.tif", oiio.UINT8)
 
     # laplacian
-    b = ImageBufAlgo.laplacian (ImageBuf(OIIO_TESTSUITE_ROOT+"/common/tahoe-tiny.tif"))
+    b = test_iba (ImageBufAlgo.laplacian, ImageBuf(OIIO_TESTSUITE_ROOT+"/common/tahoe-tiny.tif"))
     write (b, "tahoe-laplacian.tif", oiio.UINT8)
 
     # computePixelHashSHA1
@@ -440,17 +465,17 @@ try:
 
     # fft, ifft
     blue = ImageBufAlgo.channels (ImageBuf(OIIO_TESTSUITE_ROOT+"/common/tahoe-tiny.tif"), (2,))
-    fft = ImageBufAlgo.fft (blue)
+    fft = test_iba (ImageBufAlgo.fft, blue)
     write (fft, "fft.exr", oiio.FLOAT)
-    inv = ImageBufAlgo.ifft (fft)
+    inv = test_iba (ImageBufAlgo.ifft, fft)
     b = ImageBufAlgo.channels (inv, (0,))
     write (b, "ifft.exr", oiio.FLOAT)
     inv.clear()
     fft.clear()
 
     fft = ImageBuf("fft.exr")
-    polar = ImageBufAlgo.complex_to_polar (fft)
-    b = ImageBufAlgo.polar_to_complex (polar)
+    polar = test_iba (ImageBufAlgo.complex_to_polar, fft)
+    b = test_iba (ImageBufAlgo.polar_to_complex, polar)
     write (polar, "polar.exr", oiio.FLOAT)
     write (b, "unpolar.exr", oiio.FLOAT)
     fft.clear()
@@ -463,11 +488,11 @@ try:
     bad.clear()
 
     # fillholes_pushpull
-    b = ImageBufAlgo.fillholes_pushpull (ImageBuf(OIIO_TESTSUITE_ROOT+"/oiiotool/ref/hole.tif"))
+    b = test_iba (ImageBufAlgo.fillholes_pushpull, ImageBuf(OIIO_TESTSUITE_ROOT+"/oiiotool/ref/hole.tif"))
     write (b, "tahoe-filled.tif", oiio.UINT8)
 
     # over
-    b = ImageBufAlgo.over (ImageBuf(OIIO_TESTSUITE_ROOT+"/oiiotool-composite/src/a.exr"),
+    b = test_iba (ImageBufAlgo.over, ImageBuf(OIIO_TESTSUITE_ROOT+"/oiiotool-composite/src/a.exr"),
                            ImageBuf(OIIO_TESTSUITE_ROOT+"/oiiotool-composite/src/b.exr"))
     write (b, "a_over_b.exr")
 
@@ -488,6 +513,8 @@ try:
         y = broi.ybegin + broi.height//2 - (textsize.ybegin + textsize.height//2)
         ImageBufAlgo.render_text (b, x, y, "Centered", 40)
     write (b, "textcentered.tif", oiio.UINT8)
+
+    # FIXME - need tests for render_point, render_line, render_box
 
     # histogram, histogram_draw,
     b = make_constimage (100, 100, 3, oiio.UINT8, (.1, .2, .3))


### PR DESCRIPTION
Add a shim that can run both the "returns an IB" and "modifies an IB" version of each IBA function for better test coverage.
