### PR TITLE
fix: ImageOutput::check_open error conditions

### DIFF
--- a/src/libOpenImageIO/imageoutput.cpp
+++ b/src/libOpenImageIO/imageoutput.cpp
@@ -962,19 +962,19 @@ ImageOutput::check_open(OpenMode mode, const ImageSpec& userspec, ROI range,
                 m_spec.z = 0;
             }
         }
-        if (m_spec.x < range.xbegin || m_spec.x + m_spec.width >= range.xend
-            || m_spec.y < range.ybegin || m_spec.y + m_spec.height >= range.yend
+        if (m_spec.x < range.xbegin || m_spec.x + m_spec.width > range.xend
+            || m_spec.y < range.ybegin || m_spec.y + m_spec.height > range.yend
             || m_spec.z < range.zbegin
-            || m_spec.z + m_spec.depth >= range.zend) {
+            || m_spec.z + m_spec.depth > range.zend) {
             if (m_spec.depth == 1)
                 errorfmt(
-                    "{} requested pixel data window ({}, {}] x ({}, {}] exceeds the allowable range of ({}, {}] x ({}, {}]",
+                    "{} requested pixel data window [{}, {}) x [{}, {}) exceeds the allowable range of [{}, {}) x [{}, {})",
                     format_name(), m_spec.x, m_spec.x + m_spec.width, m_spec.y,
                     m_spec.y + m_spec.height, range.xbegin, range.xend,
                     range.ybegin, range.yend);
             else
                 errorfmt(
-                    "{} requested pixel data window ({}, {}] x ({}, {}] x ({}, {}] exceeds the allowable range of ({}, {}] x ({}, {}] x ({}, {}]",
+                    "{} requested pixel data window [{}, {}) x [{}, {}) x [{}, {}) exceeds the allowable range of [{}, {}) x [{}, {}) x [{}, {})\n{} vs {}\n",
                     format_name(), m_spec.x, m_spec.x + m_spec.width, m_spec.y,
                     m_spec.y + m_spec.height, m_spec.z, m_spec.z + m_spec.depth,
                     range.xbegin, range.xend, range.ybegin, range.yend,


### PR DESCRIPTION
For non-0-origin images, we were checking the resolution range incorrectly (`>=` vs `>`).

Also were printing the error message with the wrong notation, should have shown a half-open range as `[beg,end)` and not `(beg,end]`.

