### PR TITLE
fix(fits): Make sure to close if open fails to find right magic number

### DIFF
--- a/src/fits.imageio/fits_pvt.h
+++ b/src/fits.imageio/fits_pvt.h
@@ -81,6 +81,8 @@ private:
         m_cur_subimage = 0;
         m_bitpix       = 0;
         m_naxes        = 0;
+        m_naxis.clear();
+        keys.clear();
         m_subimages.clear();
         m_comment.clear();
         m_history.clear();
@@ -145,6 +147,7 @@ private:
         m_bitpix = 0;
         m_simple = true;
         m_scratch.clear();
+        m_tilebuffer.clear();
         m_sep = '\n';
     }
 

--- a/src/fits.imageio/fitsinput.cpp
+++ b/src/fits.imageio/fitsinput.cpp
@@ -68,12 +68,7 @@ FitsInput::open(const std::string& name, ImageSpec& spec)
 
     // checking if the file is FITS file
     char magic[6] = { 0 };
-    if (fread(magic, 1, 6, m_fd) != 6) {
-        errorf("%s isn't a FITS file", m_filename);
-        return false;  // Read failed
-    }
-
-    if (strncmp(magic, "SIMPLE", 6)) {
+    if (fread(magic, 1, 6, m_fd) != 6 || strncmp(magic, "SIMPLE", 6)) {
         errorf("%s isn't a FITS file", m_filename);
         close();
         return false;


### PR DESCRIPTION
There are two ways to fail the FITS magic number check: fail to read the bytes, or the bytes don't match the magic number. It seemed suspicious that we call close() for the latter but not the former. Combine them into a single error response (they had the same message, anyway).

Also, make sure FitsInput::init() fully clears some other data structures.  Oversight?

I don't know if any of these things are real bugs, but they look sloppy and potentially problematic, so fixing them up.

