### PR TITLE
Don't use check_cxx_source_runs to make cross-compiling easier

### DIFF
--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -350,7 +350,7 @@ include (CheckLibraryExists)
 #
 if (NOT MSVC AND NOT APPLE AND NOT ANDROID)
     cmake_push_check_state ()
-    check_cxx_source_runs(
+    check_cxx_source_compiles(
        "#include <atomic>
         #include <cstdint>
         std::atomic<uint64_t> x {0};


### PR DESCRIPTION
## Description

Fix #3773

## Tests

I did test it on my local Linux system, and it properly detects that it doesn't need to link against . I also tested compiling the test source file in a system that needs linking against latomic (32-bit ubuntu 14.04 using clang, there is probably some other system that is this way as well) and the compile itsself did indeed fail with undefined reference errors, as expected. So this check should be just as robust. 

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

