### PR TITLE
Add cmake option to disable the stacktrace functionality.

### DIFF
--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -78,6 +78,8 @@ endif ()
 include_directories (SYSTEM "${Boost_INCLUDE_DIRS}")
 link_directories ("${Boost_LIBRARY_DIRS}")
 
+option (OIIO_DISABLE_BOOST_STACKTRACE "Disable use of Boost stacktrace." OFF)
+
 # end Boost setup
 ###########################################################################
 

--- a/src/libutil/CMakeLists.txt
+++ b/src/libutil/CMakeLists.txt
@@ -39,6 +39,10 @@ if (NOT BUILD_SHARED_LIBS)
     target_compile_definitions (OpenImageIO_Util PUBLIC OIIO_STATIC_DEFINE=1)
 endif ()
 
+if (OIIO_DISABLE_BOOST_STACKTRACE)
+    target_compile_definitions (OpenImageIO_Util PRIVATE OIIO_DISABLE_BOOST_STACKTRACE)
+endif ()
+
 # Propagate C++ minimum to downstream consumers
 target_compile_features (OpenImageIO_Util
                          INTERFACE cxx_std_${DOWNSTREAM_CXX_STANDARD})

--- a/src/libutil/sysutil.cpp
+++ b/src/libutil/sysutil.cpp
@@ -74,7 +74,9 @@
 #    ifndef _GNU_SOURCE
 #        define _GNU_SOURCE
 #    endif
-#    include <boost/stacktrace.hpp>
+#    if !defined(OIIO_DISABLE_BOOST_STACKTRACE)
+#       include <boost/stacktrace.hpp>
+#    endif
 #endif
 
 // clang 7.0 (rc2) has errors when including boost thread!
@@ -662,7 +664,7 @@ aligned_free(void* ptr)
 std::string
 Sysutil::stacktrace()
 {
-#if BOOST_VERSION >= 106500
+#if BOOST_VERSION >= 106500 && !defined(OIIO_DISABLE_BOOST_STACKTRACE)
     std::stringstream out;
     out << boost::stacktrace::stacktrace();
     return out.str();
@@ -673,7 +675,7 @@ Sysutil::stacktrace()
 
 
 
-#if BOOST_VERSION >= 106500
+#if BOOST_VERSION >= 106500 && !defined(OIIO_DISABLE_BOOST_STACKTRACE)
 
 static std::string stacktrace_filename;
 static std::mutex stacktrace_filename_mutex;
@@ -688,7 +690,7 @@ stacktrace_signal_handler(int signum)
         else if (stacktrace_filename == "stderr")
             std::cerr << Sysutil::stacktrace();
         else {
-#    if BOOST_VERSION >= 106500
+#    if BOOST_VERSION >= 106500 && !defined(OIIO_DISABLE_BOOST_STACKTRACE)
             boost::stacktrace::safe_dump_to(stacktrace_filename.c_str());
 #    endif
         }
@@ -703,7 +705,7 @@ stacktrace_signal_handler(int signum)
 bool
 Sysutil::setup_crash_stacktrace(string_view filename)
 {
-#if BOOST_VERSION >= 106500
+#if BOOST_VERSION >= 106500 && !defined(OIIO_DISABLE_BOOST_STACKTRACE)
     std::lock_guard<std::mutex> lock(stacktrace_filename_mutex);
     stacktrace_filename = filename;
     ::signal(SIGSEGV, &stacktrace_signal_handler);


### PR DESCRIPTION
Setting the cmake option OIIO_DISABLE_BOOST_STACKTRACE to ON disables the use of Boost stacktrace at compile time. This avoids dependencies on helper libraries like dbgeng.dll.

See issue #3776.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

