### PR TITLE
fix(IC/TS): Avoid deadlock situations with file handle cache

### DIFF
--- a/src/include/OpenImageIO/imagecache.h
+++ b/src/include/OpenImageIO/imagecache.h
@@ -101,11 +101,13 @@ public:
     /// attribute/getattribute:
     ///
     /// - `int max_open_files` :
-    ///           The maximum number of file handles that the image cache
-    ///           will hold open simultaneously.  (Default = 100)
+    ///           The approximate maximum number of file handles that the
+    ///           image cache will hold open simultaneously. This is not an
+    ///           iron-clad guarantee; the number of handles may momentarily
+    ///           exceed this by a small percentage. (Default = 100)
     /// - `float max_memory_MB` :
-    ///           The maximum amount of memory (measured in MB) used for the
-    ///           internal "tile cache." (Default: 256.0 MB)
+    ///           The approximate maximum amount of memory (measured in MB)
+    ///           used for the internal "tile cache." (Default: 256.0 MB)
     /// - `string searchpath` :
     ///           The search path for images: a colon-separated list of
     ///           directories that will be searched in order for any image
@@ -193,6 +195,10 @@ public:
     ///           reads.  The default is 1 (de-duplication turned on). The
     ///           only reason to set it to 0 is if you specifically want to
     ///           disable the de-duplication optimization.
+    /// - `int max_open_files_strict` :
+    ///             If nonzero, work harder to make sure that we have
+    ///             smaller possible overages to the max open files limit.
+    ///             (Default: 0)
     /// - `string substitute_image` :
     ///           When set to anything other than the empty string, the
     ///           ImageCache will use the named image in place of *all*

--- a/src/include/OpenImageIO/texture.h
+++ b/src/include/OpenImageIO/texture.h
@@ -548,6 +548,9 @@ public:
     ///             How many times to retry a read failure.
     /// - `int deduplicate` :
     ///             If nonzero, detect duplicate textures (default=1).
+    /// - `int max_open_files_strict` :
+    ///             If nonzero, work harder to make sure that we have
+    ///             smaller possible overages to the max open files limit.
     /// - `string substitute_image` :
     ///             If supplied, an image to substatute for all texture
     ///             references.

--- a/src/include/OpenImageIO/thread.h
+++ b/src/include/OpenImageIO/thread.h
@@ -84,6 +84,7 @@ using std::recursive_mutex;
 using std::thread;
 typedef std::lock_guard<mutex> lock_guard;
 typedef std::lock_guard<recursive_mutex> recursive_lock_guard;
+typedef std::lock_guard<std::recursive_timed_mutex> recursive_timed_lock_guard;
 
 
 

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -396,8 +396,9 @@ private:
     mutable int m_errors_issued;         ///< Errors issued for this file
     std::vector<size_t> m_mipreadcount;  ///< Tile reads per mip level
     ImageCacheImpl& m_imagecache;        ///< Back pointer for ImageCache
-    mutable recursive_mutex m_input_mutex;  ///< Mutex protecting the ImageInput
-    std::time_t m_mod_time;                 ///< Time file was last updated
+    mutable std::recursive_timed_mutex
+        m_input_mutex;              ///< Mutex protecting the ImageInput
+    std::time_t m_mod_time;         ///< Time file was last updated
     ustring m_fingerprint;          ///< Optional cryptographic fingerprint
     ImageCacheFile* m_duplicate;    ///< Is this a duplicate?
     imagesize_t m_total_imagesize;  ///< Total size, uncompressed
@@ -1178,6 +1179,7 @@ private:
     bool m_unassociatedalpha;  ///< Keep unassociated alpha files as they are?
     bool m_latlong_y_up_default;  ///< Is +y the default "up" for latlong?
     bool m_trust_file_extensions = false;  ///< Assume file extensions don't lie?
+    bool m_max_open_files_strict = false;  ///< Be strict about open files limit?
     int m_failure_retries;                 ///< Times to re-try disk failures
     int m_max_mip_res = 1 << 30;  ///< Don't use MIP levels higher than this
     Imath::M44f m_Mw2c;           ///< world-to-"common" matrix


### PR DESCRIPTION
There turns out to be a way to get wedged into a mutual deadlock on the file handle cache, with how get_texture_info on a udim pattern checks to see if the attribute requested is present and equally valued in all constituent files of the udim set. This hits the handle set pretty hard, and if multiple threads are hammering the same sets and rapidly cycling textures out of the cache, there can be trouble, it seems.

Remedies in this patch:

* When it's trying to close files because the number of handles is too high, we already had it so that if we only exceeded the max_files limit by a little bit, we would simply try to get the lock, and abandon the attempt if somebody else is holding it, but if we are quite a bit over, then stay and wait for the lock to be released.

  In this patch, we make the that default behavior -- if we are over the limit and need to free some handles, simply try to get the lock, and if somebody else is holding it, leave it all up to them and return immediately. The pros of this are (a) snappier response by never waiting at this point, and (b) removing the possibility of a deadlock, because if you can't acquire the lock, you just move on. But the con is that lots of threads adding new files may run faster than the one thread who has the file and is trying to release files, so it's possible that the number of handles will exceed the limit by a wider margin now, but hopefully only momentarily.  (But note that this can be overridden with a new ImageCache attribute "max_open_files_strict", which if set to nonzero revert to the old behavior. At least for now, in case I am neglecting to understand some bad consequence of this change.)

* The recursive_mutex controlling access to the ImageInput in each tile cache record is changed to a recursive_timed_mutex, and when closing a handle by calling release(), instead of an unconditional lock, try acquiring a lock for 100ms. If it fails to do so, it may be in a possible deadlock, so just give up and move on. The only consequence is that maybe that handle isn't freed after all. It will then move on to the next one, not the end of the world, but at least it can't get stuck there.

* In find_file, eliminate the call to check_max_files -- it's not needed here, since it's also called by open(), which is the only time that new file handles might be opened. We just don't also need it again simply because we're adding a file to the cache.

