### PR TITLE
ci: updates to runners, dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,7 +238,7 @@ jobs:
             cxx_compiler: g++-11
             cxx_std: 17
             fmt_ver: 9.1.0
-            openexr_ver: v3.1.5
+            openexr_ver: v3.1.6
             pybind11_ver: v2.10.0
             python_ver: "3.10"
             simd: avx2,f16c
@@ -248,9 +248,9 @@ jobs:
                             OPENIMAGEIO_OPTIONS="openexr:core=1"
                             OPENJPEG_VERSION=v2.4.0
                             PTEX_VERSION=v2.4.0
-                            PUGIXML_VERSION=v1.12.1
+                            PUGIXML_VERSION=v1.13
                             USE_OPENVDB=0
-                            WEBP_VERSION=v1.2.4
+                            WEBP_VERSION=v1.3.0
                             # The installed OpenVDB has a TLS conflict with Python 3.8
           - desc: bleeding edge gcc12 C++20 py3.10 OCIO/libtiff/exr-master boost1.74 avx2
             nametag: linux-bleeding-edge
@@ -292,7 +292,9 @@ jobs:
                             # The installed OpenVDB has a TLS conflict with Python 3.8
           - desc: debug gcc7/C++14, sse4.2, exr2.4
             nametag: linux-gcc7-cpp14-debug
-            os: ubuntu-18.04
+            os: ubuntu-20.04
+            container:
+              image: ubuntu-18.04
             cxx_compiler: g++-7
             cxx_std: 14
             python_ver: 2.7
@@ -305,7 +307,9 @@ jobs:
 
           - desc: gcc8 C++17 avx exr2.5
             nametag: linux-gcc8
-            os: ubuntu-18.04
+            os: ubuntu-20.04
+            container:
+              image: ubuntu-18.04
             cc_compiler: gcc-8
             cxx_compiler: g++-8
             cxx_std: 17
@@ -314,7 +318,9 @@ jobs:
             simd: avx
           - desc: static libs gcc7 C++14 exr2.4
             nametag: linux-static
-            os: ubuntu-18.04
+            os: ubuntu-20.04
+            container:
+              image: ubuntu-18.04
             cxx_compiler: g++-7
             cxx_std: 14
             openexr_ver: v2.4.3

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,12 +19,12 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
        CMake configuration flag: `-DCMAKE_CXX_STANDARD=17`, etc.
  * Compilers: **gcc 6.1 - 12.1**, **clang 3.4 - 15**, **MSVS 2017 - 2019**,
    **Intel icc 17+**, **Intel OneAPI C++ compiler 2022+**.
- * CMake >= 3.12 (tested through 3.24)
- * OpenEXR/Imath >= 2.3 (recommended: 2.4 or higher; tested through 3.2)
+ * CMake >= 3.12 (tested through 3.25)
+ * OpenEXR/Imath >= 2.3 (recommended: 2.4 or higher; tested through 3.1 and main)
  * libTIFF >= 3.9 (recommended: 4.0+; tested through 4.5)
  * libjpeg >= 8, or libjpeg-turbo >= 1.1 (tested through jpeg9d and jpeg-turbo
    2.1)
- * Boost >= 1.53 (recommended: at least 1.66; tested through 1.80)
+ * Boost >= 1.53 (recommended: at least 1.66; tested through 1.81)
  * [fmtlib](https://github.com/fmtlib/fmt) >= 6.1.2 (tested through 9.1). If
    not found at build time, this will be automatically downloaded unless the
    build sets `-DBUILD_MISSING_FMT=OFF`.
@@ -65,7 +65,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
  * If you want support for DICOM medical image files:
      * DCMTK >= 3.6.1 (tested through 3.6.7)
  * If you want support for WebP images:
-     * WebP >= 0.6.1 (tested through 1.2.1)
+     * WebP >= 0.6.1 (tested through 1.3.1)
  * If you want support for OpenColorIO color transformations:
      * OpenColorIO >= 1.1 (tested through 2.2; 2.0+ is recommended)
  * If you want support for Ptex:
@@ -74,7 +74,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
    tree, but if you want to use an external, system-installed version (as
    may be required by some software distributions with policies against
    embedding other projects), then just build with `-DUSE_EXTERNAL_PUGIXML=1`.
-   Any PugiXML >= 1.8 should be fine (we have tested through 1.12).
+   Any PugiXML >= 1.8 should be fine (we have tested through 1.13).
 
 
 

--- a/testsuite/python-colorconfig/ref/out-ocio111-python27.txt
+++ b/testsuite/python-colorconfig/ref/out-ocio111-python27.txt
@@ -1,0 +1,30 @@
+getNumColorSpaces = 14
+getColorSpaceNames = [u'linear', u'sRGB', u'sRGBf', u'rec709', u'Cineon', u'Gamma1.8', u'Gamma2.2', u'Panalog', u'REDLog', u'ViperLog', u'AlexaV3LogC', u'PLogLin', u'SLog', u'raw']
+Index of 'lin_srgb' = 0
+Index of 'unknown' = -1
+Name of color space 2 = sRGBf
+getNumLooks = 0
+getLookNames = []
+getNumDisplays = 1
+getDisplayNames = [u'default']
+getDefaultDisplayName = default
+getNumViews = 3
+getViewNames = [u'None', u'sRGB', u'rec709']
+getDefaultViewName = sRGB
+getNumRoles = 9
+getRoles = [u'color_picking', u'color_timing', u'compositing_log', u'data', u'default', u'matte_paint', u'reference', u'scene_linear', u'texture_paint']
+aliases of 'scene_linear' are []
+resolve('foo'): foo
+resolve('linear'): linear
+resolve('scene_linear'): linear
+resolve('lin_srgb'): linear
+resolve('srgb'): sRGB
+resolve('ACEScg'): ACEScg
+equivalent('lin_srgb', 'srgb'): False
+equivalent('scene_linear', 'srgb'): False
+equivalent('linear', 'lin_srgb'): True
+equivalent('scene_linear', 'lin_srgb'): True
+equivalent('ACEScg', 'scene_linear'): False
+equivalent('lnf', 'scene_linear'): False
+
+Done.


### PR DESCRIPTION
* Don't use deprecated, soon to be disabled, ubuntu-18.04 runner. Switch to running on ubuntu-20.04, but use docker containers that supply ubundu-18,04.

* Bump 'latest' version of openexr, webp, pugixml.
