### PR TITLE
perf(exr): change to using exr-core for reading by default

### DIFF
--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -2863,7 +2863,8 @@ OIIO_API std::string geterror(bool clear = true);
 /// - `int openexr:core`
 ///
 ///    When nonzero, use the new "OpenEXR core C library" when available,
-///    for OpenEXR >= 3.1. This is experimental, and currently defaults to 0.
+///    for OpenEXR >= 3.1. This currently defaults to 1. Set to 0 to disable
+///    use of the newer OpenEXR code path.
 ///
 /// - `int limits:channels` (1024)
 ///

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -41,7 +41,7 @@ atomic_int oiio_threads(threads_default());
 atomic_int oiio_exr_threads(threads_default());
 atomic_int oiio_read_chunk(256);
 atomic_int oiio_try_all_readers(1);
-int openexr_core(0);  // Should we use "Exr core C library"?
+int openexr_core(1);  // Should we use "Exr core C library"?
 int tiff_half(0);
 int tiff_multithread(1);
 int dds_bc5normal(0);


### PR DESCRIPTION
When we build against OpenEXR >= 3.1, default to using the new "exrcore" APIs unless disabled at build time with `-DOIIO_USE_EXR_C_API=OFF` or at runtime through the global openexr:core attribute.
