### PR TITLE
Disable writing TIFF with jpeg compression

### DIFF
--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -52,6 +52,8 @@
 #    define OIIO_TIFFLIB_VERSION 40200
 #elif TIFFLIB_VERSION >= 20191103
 #    define OIIO_TIFFLIB_VERSION 40100
+#elif TIFFLIB_VERSION >= 20120922
+#    define OIIO_TIFFLIB_VERSION 40003
 #elif TIFFLIB_VERSION >= 20111221
 #    define OIIO_TIFFLIB_VERSION 40000
 #elif TIFFLIB_VERSION >= 20090820
@@ -644,7 +646,7 @@ static std::pair<int, const char*>  tiff_input_compressions[] = {
     { COMPRESSION_SGILOG,        "sgilog" },      // SGI log luminance RLE
     { COMPRESSION_SGILOG24,      "sgilog24" },    // SGI log 24bit
     { COMPRESSION_JP2000,        "jp2000" },      // Leadtools JPEG2000
-#if defined(TIFF_VERSION_BIG) && TIFFLIB_VERSION >= 20120922
+#if defined(TIFF_VERSION_BIG) && OIIO_TIFFLIB_VERSION >= 40003
     // Others supported in more recent TIFF library versions.
     { COMPRESSION_T85,           "T85" },         // TIFF/FX T.85 JBIG
     { COMPRESSION_T43,           "T43" },         // TIFF/FX T.43 color layered JBIG


### PR DESCRIPTION
TIFF output using JPEG compression seems unreliable, and after several hours trying to chase it down, I'm not making much progress.  As far as I can tell, this has always (or at least for a long time) been broken, and nobody noticed, which is strong circumstantial evidence that it's not something people need or are trying to use, and therefore it doesn't seem like a good use of more time to fix a feature that no one uses.

So I'm hiding all the TIFF output with jpeg compression support behind `#if` guards and disabling them for now. This will cause requests to use jpeg compression for TIFF output to just revert to the default zip compression.

Reading TIFF files that are jpeg-compressed seems fine, this doesn't disable our ability to read the files, just to produce them.

It is also worth noting: It's one thing to write an actual .jpg file as *final* output for web display, viewing, or other "terminal" uses. But JPEG-compressed image data should never ever be used as input to further image computation operations, since each read/write/read cycle with jpeg compression can lead to further data loss.  So I think for this reason also, this patch should help avoid the temptation or inadvertent ability to use this lossy compression method when writing TIFFs.
