### PR TITLE
Remove SonarCloud cache setup as it is now offered by default

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -19,7 +19,4 @@ sonar.cfamily.build-wrapper-output=build/bw_output
 sonar.cfamily.gcov.reportsPath=_coverage
 sonar.coverage.exclusions=src/iv/**,src/include/OpenImageIO/detail/pugixml/**,src/include/OpenImageIO/detail/fmt/**,src/libOpenImageIO/kissfft.hh
 
-sonar.cfamily.cache.enabled=true
-sonar.cfamily.cache.path=/tmp/sonarcache
-
 sonar.verbose=false


### PR DESCRIPTION
## Description

No need to configure the cache anymore,
SonarCloud now has automatic analysis caching.See:
https://docs.sonarcloud.io/advanced-setup/languages/c-c-objective-c/#analysis-cache.

Also, the filesystem cache was not persisted.

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-CORPORATE)).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

