### PR TITLE
Add support for CDFs of bumpslopes channels

### DIFF
--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -1161,7 +1161,8 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
         src  = latlong;
     }
 
-    if (mode == ImageBufAlgo::MakeTxBumpWithSlopes) {
+    const bool is_bumpslopes = (mode == ImageBufAlgo::MakeTxBumpWithSlopes);
+    if (is_bumpslopes) {
         ImageSpec newspec  = src->spec();
         newspec.tile_width = newspec.tile_height = 0;
         newspec.set_format(TypeDesc::FLOAT);
@@ -1212,8 +1213,9 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
         const float c_sigma_inv = fast_erf(1.0f / (2.0f * M_SQRT2 * cdf_sigma));
 
         // If there are channels other than R,G,B,A, we probably shouldn't do
-        // anything to them.
-        const int channels = std::min(4, src->spec().nchannels);
+        // anything to them, unless they are bumpslopes channels.
+        const int channels = is_bumpslopes ? 6
+                                           : std::min(4, src->spec().nchannels);
 
         std::vector<float> invCDF(bins);
         std::vector<float> CDF(bins);

--- a/testsuite/maketx/ref/out.txt
+++ b/testsuite/maketx/ref/out.txt
@@ -460,6 +460,38 @@ cdf.exr              :   64 x   64, 1 channel, half openexr
     oiio:SHA-1: "00DFB31D0260CC466CDCF9FE42446D4896E655FE"
     oiio:subimages: 1
     openexr:roundingmode: 0
+Reading bumpslope-cdf.exr
+bumpslope-cdf.exr    :   64 x   64, 6 channel, half openexr
+    MIP-map levels: 64x64 32x32 16x16 8x8 4x4 2x2 1x1
+    SHA-1: 8A309ED5DD4C7ADC8B752735651BAEE9FA326B82
+    channel list: b0_h, b1_dhds, b2_dhdt, b3_dhds2, b4_dhdt2, b5_dh2dsdt
+    tile size: 64 x 64
+    CDF_0: 0.129412, 0.129412, 0.129412, 0.152941, 0.152941, 0.192157, 0.196078, 0.196078, 0.203922, 0.207843, 0.219608, 0.219608, 0.219608, 0.223529, 0.227451, 0.231373, ... [256 x float]
+    CDF_1: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... [256 x float]
+    CDF_2: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... [256 x float]
+    CDF_3: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... [256 x float]
+    CDF_4: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... [256 x float]
+    CDF_5: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... [256 x float]
+    CDF_bits: 8
+    compression: "zip"
+    fovcot: 1
+    invCDF_0: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... [256 x float]
+    invCDF_1: 0.517528, 0.53162, 0.546259, 0.56181, 0.577352, 0.592173, 0.60564, 0.618653, 0.631182, 0.646287, 0.659294, 0.671961, 0.688381, 0.702118, 0.715025, 0.729895, ... [256 x float]
+    invCDF_2: 0.51671, 0.531827, 0.547741, 0.563119, 0.578032, 0.594433, 0.607763, 0.62409, 0.638233, 0.654072, 0.668873, 0.685519, 0.701694, 0.717385, 0.731219, 0.749014, ... [256 x float]
+    invCDF_3: 0.662209, 0.775653, 0.862829, 0.93215, 0.961514, 0.977621, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, ... [256 x float]
+    invCDF_4: 0.680135, 0.789335, 0.863924, 0.929282, 0.966413, 0.991524, 0.991524, 1, 1, 1, 1, 1, 1, 1, 1, 1, ... [256 x float]
+    invCDF_5: 0.813865, 0.952769, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, ... [256 x float]
+    PixelAspectRatio: 1
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    textureformat: "Plain Texture"
+    uvslopes_scale: 0
+    wrapmodes: "black,black"
+    oiio:AverageColor: "0.499779,-0.000457942,-4.17233e-05,0.00197116,0.00178894,3.45764e-05"
+    oiio:ColorSpace: "Linear"
+    oiio:SHA-1: "49B533110A914CE89BE0B14753A6A4CC037C964F"
+    oiio:subimages: 1
+    openexr:roundingmode: 0
 Reading checker-attribs.tx
 checker-attribs.tx   :  128 x  128, 4 channel, uint8 tiff
     MIP-map levels: 128x128 64x64 32x32 16x16 8x8 4x4 2x2 1x1

--- a/testsuite/maketx/run.py
+++ b/testsuite/maketx/run.py
@@ -138,6 +138,9 @@ command += maketx_command ("noise.exr", "bumpslope.exr",
 command += maketx_command ("noise.exr", "cdf.exr",
                            "--cdf -d half", showinfo=True)
 
+command += maketx_command ("noise.exr", "bumpslope-cdf.exr",
+                           "--bumpslopes --cdf -d half", showinfo=True)
+
 # Test --sattrib, --attrib
 command += maketx_command ("checker.tif", "checker-attribs.tx",
                            "--sattrib sname sval " +

--- a/testsuite/oiiotool-maketx/ref/out-rhel7.txt
+++ b/testsuite/oiiotool-maketx/ref/out-rhel7.txt
@@ -453,3 +453,107 @@ bumpslope.exr        :   64 x   64, 6 channel, half openexr (+mipmap)
       Constant: Yes
       Constant Color: 0.499756 -0.000458 -0.000000 0.001970 0.001789 0.000000 (float)
       Monochrome: No
+bumpslope-cdf.exr    :   64 x   64, 6 channel, half openexr (+mipmap)
+    MIP 0 of 7 (64 x 64):
+      Stats Min: 0.131714 -0.154419 -0.147949 0.000000 0.000000 -0.013084 (float)
+      Stats Max: 0.823730 0.157471 0.165771 0.024780 0.027481 0.011482 (float)
+      Stats Avg: 0.499779 -0.000458 -0.000042 0.001968 0.001786 0.000035 (float)
+      Stats StdDev: 0.099583 0.044395 0.042296 0.002729 0.002599 0.001806 (float)
+      Stats NanCount: 0 0 0 0 0 0 
+      Stats InfCount: 0 0 0 0 0 0 
+      Stats FiniteCount: 4096 4096 4096 4096 4096 4096 
+      Constant: No
+      Monochrome: No
+    MIP 1 of 7 (32 x 32):
+      Stats Min: 0.353027 -0.084045 -0.111511 0.000000 0.000000 -0.006004 (float)
+      Stats Max: 0.648438 0.089783 0.089478 0.012108 0.012772 0.004528 (float)
+      Stats Avg: 0.499778 -0.000458 -0.000042 0.001971 0.001789 0.000034 (float)
+      Stats StdDev: 0.051041 0.027848 0.028019 0.001675 0.001653 0.000985 (float)
+      Stats NanCount: 0 0 0 0 0 0 
+      Stats InfCount: 0 0 0 0 0 0 
+      Stats FiniteCount: 1024 1024 1024 1024 1024 1024 
+      Constant: No
+      Monochrome: No
+    MIP 2 of 7 (16 x 16):
+      Stats Min: 0.408203 -0.036224 -0.035797 0.000372 0.000212 -0.001590 (float)
+      Stats Max: 0.571777 0.025070 0.038147 0.006088 0.007252 0.001852 (float)
+      Stats Avg: 0.499782 -0.000458 -0.000042 0.001971 0.001789 0.000035 (float)
+      Stats StdDev: 0.025250 0.011677 0.012831 0.001030 0.001042 0.000522 (float)
+      Stats NanCount: 0 0 0 0 0 0 
+      Stats InfCount: 0 0 0 0 0 0 
+      Stats FiniteCount: 256 256 256 256 256 256 
+      Constant: No
+      Monochrome: No
+    MIP 3 of 7 (8 x 8):
+      Stats Min: 0.476562 -0.008881 -0.008530 0.000738 0.000785 -0.000559 (float)
+      Stats Max: 0.521973 0.007755 0.008484 0.003994 0.002920 0.000860 (float)
+      Stats Avg: 0.499767 -0.000457 -0.000042 0.001971 0.001789 0.000032 (float)
+      Stats StdDev: 0.011861 0.003779 0.004230 0.000654 0.000485 0.000289 (float)
+      Stats NanCount: 0 0 0 0 0 0 
+      Stats InfCount: 0 0 0 0 0 0 
+      Stats FiniteCount: 64 64 64 64 64 64 
+      Constant: No
+      Monochrome: No
+    MIP 4 of 7 (4 x 4):
+      Stats Min: 0.493896 -0.003515 -0.003843 0.001540 0.001336 -0.000275 (float)
+      Stats Max: 0.506836 0.003309 0.003777 0.002357 0.002382 0.000297 (float)
+      Stats Avg: 0.499771 -0.000458 -0.000042 0.001971 0.001789 0.000035 (float)
+      Stats StdDev: 0.003707 0.001690 0.002319 0.000262 0.000282 0.000149 (float)
+      Stats NanCount: 0 0 0 0 0 0 
+      Stats InfCount: 0 0 0 0 0 0 
+      Stats FiniteCount: 16 16 16 16 16 16 
+      Constant: No
+      Monochrome: No
+    MIP 5 of 7 (2 x 2):
+      Stats Min: 0.497070 -0.001317 -0.000958 0.001850 0.001672 -0.000000 (float)
+      Stats Max: 0.501953 0.000820 0.000466 0.002174 0.001898 0.000156 (float)
+      Stats Avg: 0.499756 -0.000458 -0.000042 0.001971 0.001789 0.000039 (float)
+      Stats StdDev: 0.002028 0.000785 0.000576 0.000123 0.000084 0.000068 (float)
+      Stats NanCount: 0 0 0 0 0 0 
+      Stats InfCount: 0 0 0 0 0 0 
+      Stats FiniteCount: 4 4 4 4 4 4 
+      Constant: No
+      Monochrome: No
+    MIP 6 of 7 (1 x 1):
+      Stats Min: 0.499756 -0.000458 -0.000000 0.001970 0.001789 0.000000 (float)
+      Stats Max: 0.499756 -0.000458 -0.000000 0.001970 0.001789 0.000000 (float)
+      Stats Avg: 0.499756 -0.000458 0.000000 0.001970 0.001789 0.000000 (float)
+      Stats StdDev: 0.000000 0.000000 0.000000 0.000000 0.000000 0.000000 (float)
+      Stats NanCount: 0 0 0 0 0 0 
+      Stats InfCount: 0 0 0 0 0 0 
+      Stats FiniteCount: 1 1 1 1 1 1 
+      Constant: Yes
+      Constant Color: 0.499756 -0.000458 -0.000000 0.001970 0.001789 0.000000 (float)
+      Monochrome: No
+Reading bumpslope-cdf.exr
+bumpslope-cdf.exr    :   64 x   64, 6 channel, half openexr
+    MIP-map levels: 64x64 32x32 16x16 8x8 4x4 2x2 1x1
+    SHA-1: 8A309ED5DD4C7ADC8B752735651BAEE9FA326B82
+    channel list: b0_h, b1_dhds, b2_dhdt, b3_dhds2, b4_dhdt2, b5_dh2dsdt
+    tile size: 64 x 64
+    CDF_0: 0.129412, 0.129412, 0.129412, 0.152941, 0.152941, 0.192157, 0.196078, 0.196078, 0.203922, 0.207843, 0.219608, 0.219608, 0.219608, 0.223529, 0.227451, 0.231373, ... [256 x float]
+    CDF_1: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... [256 x float]
+    CDF_2: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... [256 x float]
+    CDF_3: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... [256 x float]
+    CDF_4: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... [256 x float]
+    CDF_5: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... [256 x float]
+    CDF_bits: 8
+    compression: "zip"
+    fovcot: 1
+    invCDF_0: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... [256 x float]
+    invCDF_1: 0.517528, 0.53162, 0.546259, 0.56181, 0.577352, 0.592173, 0.60564, 0.618653, 0.631182, 0.646287, 0.659294, 0.671961, 0.688381, 0.702118, 0.715025, 0.729895, ... [256 x float]
+    invCDF_2: 0.51671, 0.531827, 0.547741, 0.563119, 0.578032, 0.594433, 0.607763, 0.62409, 0.638233, 0.654072, 0.668873, 0.685519, 0.701694, 0.717385, 0.731219, 0.749014, ... [256 x float]
+    invCDF_3: 0.662209, 0.775653, 0.862829, 0.93215, 0.961514, 0.977621, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, ... [256 x float]
+    invCDF_4: 0.680135, 0.789335, 0.863924, 0.929282, 0.966413, 0.991524, 0.991524, 1, 1, 1, 1, 1, 1, 1, 1, 1, ... [256 x float]
+    invCDF_5: 0.813865, 0.952769, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, ... [256 x float]
+    PixelAspectRatio: 1
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    textureformat: "Plain Texture"
+    uvslopes_scale: 0
+    wrapmodes: "black,black"
+    oiio:AverageColor: "0.499779,-0.000457942,-4.17233e-05,0.00197116,0.00178894,3.45764e-05"
+    oiio:ColorSpace: "Linear"
+    oiio:SHA-1: "49B533110A914CE89BE0B14753A6A4CC037C964F"
+    oiio:subimages: 1
+    openexr:roundingmode: 0

--- a/testsuite/oiiotool-maketx/ref/out-win.txt
+++ b/testsuite/oiiotool-maketx/ref/out-win.txt
@@ -498,3 +498,107 @@ bumpslope.exr        :   64 x   64, 6 channel, half openexr (+mipmap)
       Constant: Yes
       Constant Color: 0.499756 -0.000458 -0.000042 0.001970 0.001789 0.000035 (float)
       Monochrome: No
+bumpslope-cdf.exr    :   64 x   64, 6 channel, half openexr (+mipmap)
+    MIP 0 of 7 (64 x 64):
+      Stats Min: 0.131714 -0.154419 -0.147949 0.000000 0.000000 -0.013084 (float)
+      Stats Max: 0.823730 0.157471 0.165771 0.024780 0.027481 0.011482 (float)
+      Stats Avg: 0.499779 -0.000458 -0.000042 0.001971 0.001789 0.000035 (float)
+      Stats StdDev: 0.099583 0.044395 0.042296 0.002727 0.002597 0.001806 (float)
+      Stats NanCount: 0 0 0 0 0 0 
+      Stats InfCount: 0 0 0 0 0 0 
+      Stats FiniteCount: 4096 4096 4096 4096 4096 4096 
+      Constant: No
+      Monochrome: No
+    MIP 1 of 7 (32 x 32):
+      Stats Min: 0.353027 -0.084045 -0.111511 0.000016 0.000022 -0.006004 (float)
+      Stats Max: 0.648438 0.089783 0.089478 0.012108 0.012772 0.004528 (float)
+      Stats Avg: 0.499778 -0.000458 -0.000042 0.001971 0.001789 0.000035 (float)
+      Stats StdDev: 0.051041 0.027848 0.028019 0.001675 0.001653 0.000985 (float)
+      Stats NanCount: 0 0 0 0 0 0 
+      Stats InfCount: 0 0 0 0 0 0 
+      Stats FiniteCount: 1024 1024 1024 1024 1024 1024 
+      Constant: No
+      Monochrome: No
+    MIP 2 of 7 (16 x 16):
+      Stats Min: 0.408203 -0.036224 -0.035797 0.000372 0.000212 -0.001590 (float)
+      Stats Max: 0.571777 0.025070 0.038147 0.006088 0.007252 0.001852 (float)
+      Stats Avg: 0.499782 -0.000458 -0.000042 0.001971 0.001789 0.000035 (float)
+      Stats StdDev: 0.025250 0.011677 0.012831 0.001030 0.001042 0.000522 (float)
+      Stats NanCount: 0 0 0 0 0 0 
+      Stats InfCount: 0 0 0 0 0 0 
+      Stats FiniteCount: 256 256 256 256 256 256 
+      Constant: No
+      Monochrome: No
+    MIP 3 of 7 (8 x 8):
+      Stats Min: 0.476563 -0.008881 -0.008530 0.000738 0.000785 -0.000559 (float)
+      Stats Max: 0.521973 0.007755 0.008484 0.003994 0.002920 0.000860 (float)
+      Stats Avg: 0.499767 -0.000458 -0.000042 0.001971 0.001789 0.000035 (float)
+      Stats StdDev: 0.011861 0.003779 0.004230 0.000654 0.000485 0.000289 (float)
+      Stats NanCount: 0 0 0 0 0 0 
+      Stats InfCount: 0 0 0 0 0 0 
+      Stats FiniteCount: 64 64 64 64 64 64 
+      Constant: No
+      Monochrome: No
+    MIP 4 of 7 (4 x 4):
+      Stats Min: 0.493896 -0.003515 -0.003843 0.001540 0.001336 -0.000275 (float)
+      Stats Max: 0.506836 0.003309 0.003777 0.002357 0.002382 0.000297 (float)
+      Stats Avg: 0.499771 -0.000458 -0.000042 0.001971 0.001789 0.000035 (float)
+      Stats StdDev: 0.003707 0.001690 0.002319 0.000262 0.000282 0.000150 (float)
+      Stats NanCount: 0 0 0 0 0 0 
+      Stats InfCount: 0 0 0 0 0 0 
+      Stats FiniteCount: 16 16 16 16 16 16 
+      Constant: No
+      Monochrome: No
+    MIP 5 of 7 (2 x 2):
+      Stats Min: 0.497070 -0.001317 -0.000958 0.001850 0.001672 -0.000017 (float)
+      Stats Max: 0.501953 0.000820 0.000466 0.002174 0.001898 0.000156 (float)
+      Stats Avg: 0.499756 -0.000458 -0.000042 0.001971 0.001789 0.000035 (float)
+      Stats StdDev: 0.002028 0.000785 0.000576 0.000123 0.000084 0.000071 (float)
+      Stats NanCount: 0 0 0 0 0 0 
+      Stats InfCount: 0 0 0 0 0 0 
+      Stats FiniteCount: 4 4 4 4 4 4 
+      Constant: No
+      Monochrome: No
+    MIP 6 of 7 (1 x 1):
+      Stats Min: 0.499756 -0.000458 -0.000042 0.001970 0.001789 0.000035 (float)
+      Stats Max: 0.499756 -0.000458 -0.000042 0.001970 0.001789 0.000035 (float)
+      Stats Avg: 0.499756 -0.000458 -0.000042 0.001970 0.001789 0.000035 (float)
+      Stats StdDev: 0.000000 0.000000 0.000000 0.000000 0.000000 0.000000 (float)
+      Stats NanCount: 0 0 0 0 0 0 
+      Stats InfCount: 0 0 0 0 0 0 
+      Stats FiniteCount: 1 1 1 1 1 1 
+      Constant: Yes
+      Constant Color: 0.499756 -0.000458 -0.000042 0.001970 0.001789 0.000035 (float)
+      Monochrome: No
+Reading bumpslope-cdf.exr
+bumpslope-cdf.exr    :   64 x   64, 6 channel, half openexr
+    MIP-map levels: 64x64 32x32 16x16 8x8 4x4 2x2 1x1
+    SHA-1: 8A309ED5DD4C7ADC8B752735651BAEE9FA326B82
+    channel list: b0_h, b1_dhds, b2_dhdt, b3_dhds2, b4_dhdt2, b5_dh2dsdt
+    tile size: 64 x 64
+    CDF_0: 0.129412, 0.129412, 0.129412, 0.152941, 0.152941, 0.192157, 0.196078, 0.196078, 0.203922, 0.207843, 0.219608, 0.219608, 0.219608, 0.223529, 0.227451, 0.231373, ... [256 x float]
+    CDF_1: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... [256 x float]
+    CDF_2: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... [256 x float]
+    CDF_3: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... [256 x float]
+    CDF_4: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... [256 x float]
+    CDF_5: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... [256 x float]
+    CDF_bits: 8
+    compression: "zip"
+    fovcot: 1
+    invCDF_0: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... [256 x float]
+    invCDF_1: 0.517528, 0.53162, 0.546259, 0.56181, 0.577352, 0.592173, 0.60564, 0.618653, 0.631182, 0.646287, 0.659294, 0.671961, 0.688381, 0.702118, 0.715025, 0.729895, ... [256 x float]
+    invCDF_2: 0.51671, 0.531827, 0.547741, 0.563119, 0.578032, 0.594433, 0.607763, 0.62409, 0.638233, 0.654072, 0.668873, 0.685519, 0.701694, 0.717385, 0.731219, 0.749014, ... [256 x float]
+    invCDF_3: 0.662209, 0.775653, 0.862829, 0.93215, 0.961514, 0.977621, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, ... [256 x float]
+    invCDF_4: 0.680135, 0.789335, 0.863924, 0.929282, 0.966413, 0.991524, 0.991524, 1, 1, 1, 1, 1, 1, 1, 1, 1, ... [256 x float]
+    invCDF_5: 0.813865, 0.952769, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, ... [256 x float]
+    PixelAspectRatio: 1
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    textureformat: "Plain Texture"
+    uvslopes_scale: 0
+    wrapmodes: "black,black"
+    oiio:AverageColor: "0.499779,-0.000457942,-4.17233e-05,0.00197116,0.00178894,3.45764e-05"
+    oiio:ColorSpace: "Linear"
+    oiio:SHA-1: "49B533110A914CE89BE0B14753A6A4CC037C964F"
+    oiio:subimages: 1
+    openexr:roundingmode: 0

--- a/testsuite/oiiotool-maketx/ref/out.txt
+++ b/testsuite/oiiotool-maketx/ref/out.txt
@@ -498,3 +498,107 @@ bumpslope.exr        :   64 x   64, 6 channel, half openexr (+mipmap)
       Constant: Yes
       Constant Color: 0.499756 -0.000458 -0.000042 0.001970 0.001789 0.000035 (float)
       Monochrome: No
+bumpslope-cdf.exr    :   64 x   64, 6 channel, half openexr (+mipmap)
+    MIP 0 of 7 (64 x 64):
+      Stats Min: 0.131714 -0.154419 -0.147949 0.000000 0.000000 -0.013084 (float)
+      Stats Max: 0.823730 0.157471 0.165771 0.024780 0.027481 0.011482 (float)
+      Stats Avg: 0.499779 -0.000458 -0.000042 0.001971 0.001789 0.000035 (float)
+      Stats StdDev: 0.099583 0.044395 0.042296 0.002727 0.002597 0.001806 (float)
+      Stats NanCount: 0 0 0 0 0 0 
+      Stats InfCount: 0 0 0 0 0 0 
+      Stats FiniteCount: 4096 4096 4096 4096 4096 4096 
+      Constant: No
+      Monochrome: No
+    MIP 1 of 7 (32 x 32):
+      Stats Min: 0.353027 -0.084045 -0.111511 0.000016 0.000022 -0.006004 (float)
+      Stats Max: 0.648438 0.089783 0.089478 0.012108 0.012772 0.004528 (float)
+      Stats Avg: 0.499778 -0.000458 -0.000042 0.001971 0.001789 0.000035 (float)
+      Stats StdDev: 0.051041 0.027848 0.028019 0.001675 0.001653 0.000985 (float)
+      Stats NanCount: 0 0 0 0 0 0 
+      Stats InfCount: 0 0 0 0 0 0 
+      Stats FiniteCount: 1024 1024 1024 1024 1024 1024 
+      Constant: No
+      Monochrome: No
+    MIP 2 of 7 (16 x 16):
+      Stats Min: 0.408203 -0.036224 -0.035797 0.000372 0.000212 -0.001590 (float)
+      Stats Max: 0.571777 0.025070 0.038147 0.006088 0.007252 0.001852 (float)
+      Stats Avg: 0.499782 -0.000458 -0.000042 0.001971 0.001789 0.000035 (float)
+      Stats StdDev: 0.025250 0.011677 0.012831 0.001030 0.001042 0.000522 (float)
+      Stats NanCount: 0 0 0 0 0 0 
+      Stats InfCount: 0 0 0 0 0 0 
+      Stats FiniteCount: 256 256 256 256 256 256 
+      Constant: No
+      Monochrome: No
+    MIP 3 of 7 (8 x 8):
+      Stats Min: 0.476562 -0.008881 -0.008530 0.000738 0.000785 -0.000559 (float)
+      Stats Max: 0.521973 0.007755 0.008484 0.003994 0.002920 0.000860 (float)
+      Stats Avg: 0.499767 -0.000458 -0.000042 0.001971 0.001789 0.000035 (float)
+      Stats StdDev: 0.011861 0.003779 0.004230 0.000654 0.000485 0.000289 (float)
+      Stats NanCount: 0 0 0 0 0 0 
+      Stats InfCount: 0 0 0 0 0 0 
+      Stats FiniteCount: 64 64 64 64 64 64 
+      Constant: No
+      Monochrome: No
+    MIP 4 of 7 (4 x 4):
+      Stats Min: 0.493896 -0.003515 -0.003843 0.001540 0.001336 -0.000275 (float)
+      Stats Max: 0.506836 0.003309 0.003777 0.002357 0.002382 0.000297 (float)
+      Stats Avg: 0.499771 -0.000458 -0.000042 0.001971 0.001789 0.000035 (float)
+      Stats StdDev: 0.003707 0.001690 0.002319 0.000262 0.000282 0.000150 (float)
+      Stats NanCount: 0 0 0 0 0 0 
+      Stats InfCount: 0 0 0 0 0 0 
+      Stats FiniteCount: 16 16 16 16 16 16 
+      Constant: No
+      Monochrome: No
+    MIP 5 of 7 (2 x 2):
+      Stats Min: 0.497070 -0.001317 -0.000958 0.001850 0.001672 -0.000017 (float)
+      Stats Max: 0.501953 0.000820 0.000466 0.002174 0.001898 0.000156 (float)
+      Stats Avg: 0.499756 -0.000458 -0.000042 0.001971 0.001789 0.000035 (float)
+      Stats StdDev: 0.002028 0.000785 0.000576 0.000123 0.000084 0.000071 (float)
+      Stats NanCount: 0 0 0 0 0 0 
+      Stats InfCount: 0 0 0 0 0 0 
+      Stats FiniteCount: 4 4 4 4 4 4 
+      Constant: No
+      Monochrome: No
+    MIP 6 of 7 (1 x 1):
+      Stats Min: 0.499756 -0.000458 -0.000042 0.001970 0.001789 0.000035 (float)
+      Stats Max: 0.499756 -0.000458 -0.000042 0.001970 0.001789 0.000035 (float)
+      Stats Avg: 0.499756 -0.000458 -0.000042 0.001970 0.001789 0.000035 (float)
+      Stats StdDev: 0.000000 0.000000 0.000000 0.000000 0.000000 0.000000 (float)
+      Stats NanCount: 0 0 0 0 0 0 
+      Stats InfCount: 0 0 0 0 0 0 
+      Stats FiniteCount: 1 1 1 1 1 1 
+      Constant: Yes
+      Constant Color: 0.499756 -0.000458 -0.000042 0.001970 0.001789 0.000035 (float)
+      Monochrome: No
+Reading bumpslope-cdf.exr
+bumpslope-cdf.exr    :   64 x   64, 6 channel, half openexr
+    MIP-map levels: 64x64 32x32 16x16 8x8 4x4 2x2 1x1
+    SHA-1: 8A309ED5DD4C7ADC8B752735651BAEE9FA326B82
+    channel list: b0_h, b1_dhds, b2_dhdt, b3_dhds2, b4_dhdt2, b5_dh2dsdt
+    tile size: 64 x 64
+    CDF_0: 0.129412, 0.129412, 0.129412, 0.152941, 0.152941, 0.192157, 0.196078, 0.196078, 0.203922, 0.207843, 0.219608, 0.219608, 0.219608, 0.223529, 0.227451, 0.231373, ... [256 x float]
+    CDF_1: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... [256 x float]
+    CDF_2: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... [256 x float]
+    CDF_3: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... [256 x float]
+    CDF_4: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... [256 x float]
+    CDF_5: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... [256 x float]
+    CDF_bits: 8
+    compression: "zip"
+    fovcot: 1
+    invCDF_0: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... [256 x float]
+    invCDF_1: 0.517528, 0.53162, 0.546259, 0.56181, 0.577352, 0.592173, 0.60564, 0.618653, 0.631182, 0.646287, 0.659294, 0.671961, 0.688381, 0.702118, 0.715025, 0.729895, ... [256 x float]
+    invCDF_2: 0.51671, 0.531827, 0.547741, 0.563119, 0.578032, 0.594433, 0.607763, 0.62409, 0.638233, 0.654072, 0.668873, 0.685519, 0.701694, 0.717385, 0.731219, 0.749014, ... [256 x float]
+    invCDF_3: 0.662209, 0.775653, 0.862829, 0.93215, 0.961514, 0.977621, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, ... [256 x float]
+    invCDF_4: 0.680135, 0.789335, 0.863924, 0.929282, 0.966413, 0.991524, 0.991524, 1, 1, 1, 1, 1, 1, 1, 1, 1, ... [256 x float]
+    invCDF_5: 0.813865, 0.952769, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, ... [256 x float]
+    PixelAspectRatio: 1
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    textureformat: "Plain Texture"
+    uvslopes_scale: 0
+    wrapmodes: "black,black"
+    oiio:AverageColor: "0.499779,-0.000457942,-4.17233e-05,0.00197116,0.00178894,3.45764e-05"
+    oiio:ColorSpace: "Linear"
+    oiio:SHA-1: "49B533110A914CE89BE0B14753A6A4CC037C964F"
+    oiio:subimages: 1
+    openexr:roundingmode: 0

--- a/testsuite/oiiotool-maketx/run.py
+++ b/testsuite/oiiotool-maketx/run.py
@@ -143,6 +143,11 @@ command += omaketx_command ("bump.exr", "bumpslope.exr",
                             extraargs="-d half",
                             output_cmd="-obump", showinfo=False)
 command += oiiotool ("--stats -a bumpslope.exr")
+command += omaketx_command ("bump.exr", "bumpslope-cdf.exr",
+                            extraargs="-d half",
+                            output_cmd="-obump", options=":cdf=1", showinfo=False)
+command += oiiotool ("--stats -a bumpslope-cdf.exr")
+command += info_command ("bumpslope-cdf.exr", safematch=1)
 
 
 outputs = [ "out.txt" ]


### PR DESCRIPTION
## Description

Currently, if you run `oiiotool` with `--bumpslopes` and `--cdf` at the same time (or `-obump:cdf=1`), the CDF is only produced for the first four (of six) channels. The techniques described in Burley (2019) actually do apply reasonably to the squared derivative channels, so it's useful to allow all six channels to have CDFs here.

## Tests

`maketx` and `oiiotool-maketx` tests updated with new relevant tests.

## Checklist:

- [x] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-CORPORATE)).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.
