### PR TITLE
fix(python): improve error messages of bad python array sizes

### DIFF
--- a/src/python/py_oiio.cpp
+++ b/src/python/py_oiio.cpp
@@ -131,7 +131,7 @@ oiio_bufinfo::oiio_bufinfo(const py::buffer_info& pybuf, int nchans, int width,
             xstride = pybuf.strides[1];
             ystride = pybuf.strides[0];
         } else if (pybuf.ndim == 2) {
-            // Somebody collapsed a dimsision. Is it [pixel][c] with x&y
+            // Somebody collapsed a dimension. Is it [pixel][c] with x&y
             // combined, or is it [y][xpixel] with channels mushed together?
             if (pybuf.shape[0] == width * height && pybuf.shape[1] == nchans)
                 xstride = pybuf.strides[0];
@@ -152,8 +152,8 @@ oiio_bufinfo::oiio_bufinfo(const py::buffer_info& pybuf, int nchans, int width,
         } else {
             format = TypeUnknown;  // No idea what's going on -- error
             error  = Strutil::fmt::format(
-                "Can't figure out array shape (pixeldims={}, pydim={})",
-                pixeldims, pybuf.ndim);
+                "Python array shape is [{:,}] but expecting h={}, w={}, ch={}",
+                cspan<ssize_t>(pybuf.shape), height, width, nchans);
         }
     } else if (pixeldims == 1) {
         // Reading a 1D scanline span
@@ -176,7 +176,8 @@ oiio_bufinfo::oiio_bufinfo(const py::buffer_info& pybuf, int nchans, int width,
             pybuf.ndim);
     }
 
-    if (nchans > 1 && size_t(pybuf.strides.back()) != format.size()) {
+    if (nchans > 1 && format.size()
+        && size_t(pybuf.strides.back()) != format.size()) {
         format = TypeUnknown;  // can't handle noncontig channels
         error  = "Can't handle numpy array with noncontiguous channels";
     }


### PR DESCRIPTION
For cases of calls like `ImageOutput.write_image(array)`, this improves the error messages when the array dimensions don't match the size of the image we're writing, in two ways:

1. For the case of 2D images where the dims don't match, print what the array shape actually is and what was expected. That's more helpful than just saying "can't figure out array shape" and printing the number of dimensions (but not the shape).

2. A mistake caused a number of error messages to be substituted by a cryptic "can't handle numpy array with noncontiguous channels", but that was only supposed to be for one particular case; fix that.
