### PR TITLE
fix: Add one level of recursion to font search

### DIFF
--- a/src/libOpenImageIO/imagebufalgo_draw.cpp
+++ b/src/libOpenImageIO/imagebufalgo_draw.cpp
@@ -744,10 +744,17 @@ static const char* font_extensions[]   = { "", ".ttf", ".ttc", ".pfa", ".pfb" };
 
 // Add one dir to font_search_dirs, if the dir exists.
 static void
-fontpath_add_one_dir(string_view dir)
+fontpath_add_one_dir(string_view dir, int recursion = 1)
 {
     if (dir.size() && Filesystem::is_directory(dir)) {
         font_search_dirs.emplace_back(dir);
+        if (recursion) {
+            std::vector<std::string> files;
+            if (Filesystem::get_directory_entries(dir, files, false)) {
+                for (auto&& subdir : files)
+                    fontpath_add_one_dir(subdir, recursion - 1);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Not long ago, we removed recursion from the font searching, for performance reasons. But now I see at there are some systems where none of the font directories likely in the searchpath have any of the font files directly there, but instead they are in subdirectories one level further down.

To compromise, then, I'm adding ONE level of recurson to our font search. If you need to search deeper than that, you should directly add the paths to the OPENIMAGEIO_FONTS searchpath.

