### PR TITLE
fix: Controlled shutdown of IlmThread pool in all apps in which we use it.

### DIFF
--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -19,7 +19,6 @@
 
 #include "oiiotool.h"
 
-#include <OpenEXR/IlmThreadPool.h>
 #include <OpenEXR/ImfTimeCode.h>
 #include <OpenImageIO/Imath.h>
 
@@ -7412,12 +7411,6 @@ main(int argc, char* argv[])
     ot.curimg = nullptr;
     ot.image_stack.clear();
     ot.image_labels.clear();
-
-    // Force the OpenEXR threadpool to shutdown because their destruction
-    // might cause us to hang on Windows when it tries to communicate with
-    // threads that would have already been terminated without releasing any
-    // held mutexes.
-    IlmThread::ThreadPool::globalThreadPool().setNumThreads(0);
 
     return ot.return_value;
 }


### PR DESCRIPTION
We know that there are some corner cases on Windows when it can be unsafe to exit because the Ilm thread pool (which is used implicitly by OpenEXR) hangs. The exact conditions that cause this are not well understood.

Some time back, in PR 3582, we added an explicit shutdown in oiiotool right before we exit, to alleviate the problem. But this doesn't help for other apps like idiff, nor for apps that use libOpenImageIO and aren't aware of the problem, so wouldn't know to do this.

This patch changes to a different strategy: In set_exr_threads(), which will always be called any time we use openexr files, use `std::atexit()` to ensure that when the program terminates -- any program using OpenImageIO in cases when openexr was used -- we set the IlmThread global thread pool size to 0 to shut it down cleanly. Hopefully, that will cover even more cases where this OpenEXR bug might be tickled.
