### PR TITLE
Support HIF extension

### DIFF
--- a/src/heif.imageio/heifinput.cpp
+++ b/src/heif.imageio/heifinput.cpp
@@ -76,7 +76,7 @@ heif_input_imageio_create()
     return new HeifInput;
 }
 
-OIIO_EXPORT const char* heif_input_extensions[] = { "heic",  "heif", 
+OIIO_EXPORT const char* heif_input_extensions[] = { "heic",  "heif",
                                                     "heics", "hif",
 #if LIBHEIF_HAVE_VERSION(1, 7, 0)
                                                     "avif",

--- a/src/heif.imageio/heifinput.cpp
+++ b/src/heif.imageio/heifinput.cpp
@@ -76,7 +76,8 @@ heif_input_imageio_create()
     return new HeifInput;
 }
 
-OIIO_EXPORT const char* heif_input_extensions[] = { "heic", "heif", "heics", "hif",
+OIIO_EXPORT const char* heif_input_extensions[] = { "heic",  "heif", 
+                                                    "heics", "hif",
 #if LIBHEIF_HAVE_VERSION(1, 7, 0)
                                                     "avif",
 #endif

--- a/src/heif.imageio/heifinput.cpp
+++ b/src/heif.imageio/heifinput.cpp
@@ -76,7 +76,7 @@ heif_input_imageio_create()
     return new HeifInput;
 }
 
-OIIO_EXPORT const char* heif_input_extensions[] = { "heic", "heif", "heics",
+OIIO_EXPORT const char* heif_input_extensions[] = { "heic", "heif", "heics", "hif",
 #if LIBHEIF_HAVE_VERSION(1, 7, 0)
                                                     "avif",
 #endif

--- a/src/heif.imageio/heifoutput.cpp
+++ b/src/heif.imageio/heifoutput.cpp
@@ -78,7 +78,7 @@ heif_output_imageio_create()
     return new HeifOutput;
 }
 
-OIIO_EXPORT const char* heif_output_extensions[] = { "heif", "heic", "heics",
+OIIO_EXPORT const char* heif_output_extensions[] = { "heif", "heic", "heics", "hif",
 #if LIBHEIF_HAVE_VERSION(1, 7, 0)
                                                      "avif",
 #endif

--- a/src/heif.imageio/heifoutput.cpp
+++ b/src/heif.imageio/heifoutput.cpp
@@ -78,7 +78,8 @@ heif_output_imageio_create()
     return new HeifOutput;
 }
 
-OIIO_EXPORT const char* heif_output_extensions[] = { "heif", "heic", "heics", "hif",
+OIIO_EXPORT const char* heif_output_extensions[] = { "heif",  "heic",
+                                                     "heics", "hif",
 #if LIBHEIF_HAVE_VERSION(1, 7, 0)
                                                      "avif",
 #endif


### PR DESCRIPTION
## Description

I've come across some unsupported files from Canon cameras that have a .hif extension. These are HEIC/HEIF files with a slightly changed extension. I have no idea why Canon decided to do this. Without any changes I am able to open the images, probably because it checks the header, but I am unable to write to paths with a hif extension.

Some random articles/forum posts mentioning the HIF format in relation to Canon cameras:
https://www.cameralabs.com/jpeg-vs-heif-canon-hif-comparison/
https://www.dpreview.com/forums/thread/4558661
https://www.reddit.com/r/canon/comments/kjc6xl/new_eos_r6_owner_here_photo_files_show_up_as_hif/

## Tests

I did not add tests to the project, but I did compile the library into our application on Windows and Mac environments and verified that the old version does not support writing to paths with a "hif" extension and the updated code does. Can provide more info if needed.


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

