### PR TITLE
Fix incorrect branch name when cloning openexr-images for the tests

### DIFF
--- a/src/cmake/testing.cmake
+++ b/src/cmake/testing.cmake
@@ -360,15 +360,18 @@ function (oiio_get_test_data name)
        # Arguments: <prefix> <options> <one_value_keywords> <multi_value_keywords> args...
     if (IS_DIRECTORY "${OIIO_LOCAL_TESTDATA_ROOT}/${name}"
         AND NOT EXISTS "${CMAKE_BINARY_DIR}/testsuite/${name}")
+        set (_ogtd_LINK_RESULT "")
         if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.14)
             # Just make a link if we can
-            message (STATUS "Linking ${name} from ${OIIO_LOCAL_TESTDATA_ROOT}/../${name}")
+            message (STATUS "Linking ${name} from ${OIIO_LOCAL_TESTDATA_ROOT}/${name}")
             file (CREATE_LINK "${OIIO_LOCAL_TESTDATA_ROOT}/${name}"
                               "${CMAKE_BINARY_DIR}/testsuite/${name}"
-                              SYMBOLIC COPY_ON_ERROR)
-        else ()
-            # Older cmake -- copy
-            message (STATUS "Copying ${name} from ${OIIO_LOCAL_TESTDATA_ROOT}/../${name}")
+                              SYMBOLIC RESULT _ogtd_LINK_RESULT)
+            message (STATUS "Link result ${_ogtd_LINK_RESULT}")
+        endif ()
+        if (NOT _ogtd_LINK_RESULT EQUAL 0)
+            # Older cmake or failure to link -- copy
+            message (STATUS "Copying ${name} from ${OIIO_LOCAL_TESTDATA_ROOT}/${name}")
             file (COPY "${OIIO_LOCAL_TESTDATA_ROOT}/${name}"
                   DESTINATION "${CMAKE_BINARY_DIR}/testsuite")
         endif ()

--- a/src/cmake/testing.cmake
+++ b/src/cmake/testing.cmake
@@ -397,7 +397,8 @@ function (oiio_setup_test_data)
     oiio_get_test_data (oiio-images
                         REPO https://github.com/OpenImageIO/oiio-images.git)
     oiio_get_test_data (openexr-images
-                        REPO https://github.com/AcademySoftwareFoundation/openexr-images.git)
+                        REPO https://github.com/AcademySoftwareFoundation/openexr-images.git
+                        BRANCH main)
     oiio_get_test_data (fits-images)
     oiio_get_test_data (j2kp4files_v1_5)
 endfunction ()

--- a/src/cmake/testing.cmake
+++ b/src/cmake/testing.cmake
@@ -367,6 +367,10 @@ function (oiio_get_test_data name)
             file (CREATE_LINK "${OIIO_LOCAL_TESTDATA_ROOT}/${name}"
                               "${CMAKE_BINARY_DIR}/testsuite/${name}"
                               SYMBOLIC RESULT _ogtd_LINK_RESULT)
+            # Note: Using 'COPY_ON_ERROR' in the above command should have prevented the need to
+            # have the manual fall-back below. However, there's been at least one case where a user
+            # noticed that copying did not happen if creating the link failed (CMake 3.24). We can
+            # adjust this in the future if CMake behavior improves.
             message (STATUS "Link result ${_ogtd_LINK_RESULT}")
         endif ()
         if (NOT _ogtd_LINK_RESULT EQUAL 0)


### PR DESCRIPTION
## Description

The `openexr-images` repo was never updated after the default branch was renamed to `main`. This will fix the following silent errors in CI:
```
Cloning into '/__w/oiio/oiio/build/testsuite/openexr-images'...
warning: Could not find remote branch master to clone.
fatal: Remote branch master not found in upstream origin
```

Additionally, the cmake attempted to symbolically link local repos like `oiio-images` if they were found. Unfortunately this type of link will fail unless running as admin on Windows (which is rare) and the COPY_ON_ERROR directive did _not_ work here (cmake 3.24; weird; sigh...).  The output will now look something like the following:
```
-- Linking oiio-images from C:/Users/jesse/source/oiio-images
-- Link result failed to create symbolic link 'C:/Users/jesse/source/oiio/build/testsuite/oiio-images': A required privilege is not held by the client.
-- Copying oiio-images from C:/Users/jesse/source/oiio-images
```

## Tests

These were found while trying to get the test suite running on Windows here in preparation for some development. Sadly the suite is still not running correctly at all so I may have to rely on the CI.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-CORPORATE)).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

