### PR TITLE
Fix float128 compilation of NVPTX backend for LLVM

### DIFF
--- a/src/include/OpenImageIO/detail/fmt.h
+++ b/src/include/OpenImageIO/detail/fmt.h
@@ -30,8 +30,8 @@
 #    define FMT_DEPRECATED_OSTREAM 1
 #endif
 
-// fmt 9 started using the __float128 type, which is not supported by the 
-// nvptx backend for llvm, so we disable its usage on this target, which 
+// fmt 9 started using the __float128 type, which is not supported by the
+// nvptx backend for llvm, so we disable its usage on this target, which
 // can be identified by the combination of __CUDA_ARCH__ and __clang__
 #if defined(__CUDA_ARCH__) && defined(__clang__) && !defined(FMT_USE_FLOAT128)
 #    define FMT_USE_FLOAT128 0

--- a/src/include/OpenImageIO/detail/fmt.h
+++ b/src/include/OpenImageIO/detail/fmt.h
@@ -30,6 +30,13 @@
 #    define FMT_DEPRECATED_OSTREAM 1
 #endif
 
+// fmt 9 started using the __float128 type, which is not supported by the 
+// nvptx backend for llvm, so we disable its usage on this target, which 
+// can be identified by the combination of __CUDA_ARCH__ and __clang__
+#if defined(__CUDA_ARCH__) && defined(__clang__) && !defined(FMT_USE_FLOAT128)
+#    define FMT_USE_FLOAT128 0
+#endif
+
 OIIO_PRAGMA_WARNING_PUSH
 #if OIIO_GNUC_VERSION >= 70000
 #    pragma GCC diagnostic ignored "-Wmaybe-uninitialized"


### PR DESCRIPTION
## Description

The latest version of libfmt began using the `__float128` type but this is [not supported in the NVPTX backend for LLVM](https://discourse.llvm.org/t/compiling-cuda-code-fails/61240/13). A way to detect this particular platform seems to be to check both `__CUDA_ARCH__` and  `__clang__`.
I am not disabling it entirely on any CUDA target because NVCC 10+ understands `_float128` and generates instructions for it when tested on godbolt. 

Following up from https://github.com/OpenImageIO/oiio/issues/3809.
             

## Checklist:

- [x] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [x] My code follows the prevailing code style of this project.

