### PR TITLE
Add an ImageInput::valid_file(IOProxy) overload

### DIFF
--- a/src/bmp.imageio/bmpinput.cpp
+++ b/src/bmp.imageio/bmpinput.cpp
@@ -23,7 +23,7 @@ public:
     {
         return feature == "ioproxy";
     }
-    bool valid_file(const std::string& filename) const override;
+    bool valid_file(Filesystem::IOProxy* io) const override;
     bool open(const std::string& name, ImageSpec& newspec) override;
     bool open(const std::string& name, ImageSpec& newspec,
               const ImageSpec& config) override;
@@ -94,11 +94,13 @@ OIIO_PLUGIN_EXPORTS_END
 
 
 bool
-BmpInput::valid_file(const std::string& filename) const
+BmpInput::valid_file(Filesystem::IOProxy* io) const
 {
+    if (!io || io->mode() != Filesystem::IOProxy::Mode::Read)
+        return false;
+
     bmp_pvt::BmpFileHeader header;
-    Filesystem::IOFile file(filename, Filesystem::IOProxy::Read);
-    return file.opened() && header.read_header(&file) && header.isBmp();
+    return header.read_header(io) && header.isBmp();
 }
 
 

--- a/src/bmp.imageio/bmpinput.cpp
+++ b/src/bmp.imageio/bmpinput.cpp
@@ -23,7 +23,7 @@ public:
     {
         return feature == "ioproxy";
     }
-    bool valid_file(Filesystem::IOProxy* io) const override;
+    bool valid_file(Filesystem::IOProxy* ioproxy) const override;
     bool open(const std::string& name, ImageSpec& newspec) override;
     bool open(const std::string& name, ImageSpec& newspec,
               const ImageSpec& config) override;
@@ -94,13 +94,13 @@ OIIO_PLUGIN_EXPORTS_END
 
 
 bool
-BmpInput::valid_file(Filesystem::IOProxy* io) const
+BmpInput::valid_file(Filesystem::IOProxy* ioproxy) const
 {
-    if (!io || io->mode() != Filesystem::IOProxy::Mode::Read)
+    if (!ioproxy || ioproxy->mode() != Filesystem::IOProxy::Mode::Read)
         return false;
 
     bmp_pvt::BmpFileHeader header;
-    return header.read_header(io) && header.isBmp();
+    return header.read_header(ioproxy) && header.isBmp();
 }
 
 

--- a/src/dpx.imageio/dpxinput.cpp
+++ b/src/dpx.imageio/dpxinput.cpp
@@ -29,7 +29,7 @@ public:
     {
         return (feature == "ioproxy");
     }
-    bool valid_file(const std::string& filename) const override;
+    bool valid_file(Filesystem::IOProxy* io) const override;
     bool open(const std::string& name, ImageSpec& newspec) override;
     bool open(const std::string& name, ImageSpec& newspec,
               const ImageSpec& config) override;
@@ -107,11 +107,8 @@ OIIO_PLUGIN_EXPORTS_END
 
 
 bool
-DPXInput::valid_file(const std::string& filename) const
+DPXInput::valid_file(Filesystem::IOProxy* io) const
 {
-    Filesystem::IOProxy* io
-        = new Filesystem::IOFile(filename, Filesystem::IOProxy::Mode::Read);
-    std::unique_ptr<Filesystem::IOProxy> io_uptr(io);
     if (!io || io->mode() != Filesystem::IOProxy::Mode::Read)
         return false;
 
@@ -121,7 +118,7 @@ DPXInput::valid_file(const std::string& filename) const
 
     dpx::Reader dpx;
     dpx.SetInStream(stream_uptr.get());
-    return dpx.ReadHeader();  // IOFile is automatically closed when destructed
+    return dpx.ReadHeader();
 }
 
 

--- a/src/dpx.imageio/dpxinput.cpp
+++ b/src/dpx.imageio/dpxinput.cpp
@@ -29,7 +29,7 @@ public:
     {
         return (feature == "ioproxy");
     }
-    bool valid_file(Filesystem::IOProxy* io) const override;
+    bool valid_file(Filesystem::IOProxy* ioproxy) const override;
     bool open(const std::string& name, ImageSpec& newspec) override;
     bool open(const std::string& name, ImageSpec& newspec,
               const ImageSpec& config) override;
@@ -107,12 +107,12 @@ OIIO_PLUGIN_EXPORTS_END
 
 
 bool
-DPXInput::valid_file(Filesystem::IOProxy* io) const
+DPXInput::valid_file(Filesystem::IOProxy* ioproxy) const
 {
-    if (!io || io->mode() != Filesystem::IOProxy::Mode::Read)
+    if (!ioproxy || ioproxy->mode() != Filesystem::IOProxy::Mode::Read)
         return false;
 
-    std::unique_ptr<InStream> stream_uptr(new InStream(io));
+    std::unique_ptr<InStream> stream_uptr(new InStream(ioproxy));
     if (!stream_uptr)
         return false;
 

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -1024,9 +1024,11 @@ public:
     /// @returns
     ///         `true` upon success, or `false` upon failure.
     virtual bool valid_file (const std::string& filename) const;
+
+    /// Check valid file using an IOProxy.
     virtual bool valid_file (Filesystem::IOProxy* io) const;
 
-    /// Check valid vile using a UTF-16 encoded wstring filename.
+    /// Check valid file using a UTF-16 encoded wstring filename.
     bool valid_file (const std::wstring& filename) const {
         return valid_file(Strutil::utf16_to_utf8(filename));
     }

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -1024,6 +1024,7 @@ public:
     /// @returns
     ///         `true` upon success, or `false` upon failure.
     virtual bool valid_file (const std::string& filename) const;
+    virtual bool valid_file (Filesystem::IOProxy* io) const;
 
     /// Check valid vile using a UTF-16 encoded wstring filename.
     bool valid_file (const std::wstring& filename) const {

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -1025,13 +1025,23 @@ public:
     ///         `true` upon success, or `false` upon failure.
     virtual bool valid_file (const std::string& filename) const;
 
-    /// Check valid file using an IOProxy.
-    virtual bool valid_file (Filesystem::IOProxy* io) const;
-
     /// Check valid file using a UTF-16 encoded wstring filename.
     bool valid_file (const std::wstring& filename) const {
         return valid_file(Strutil::utf16_to_utf8(filename));
     }
+
+    /// Return true if the `ioproxy` represents a file of the type for this
+    /// ImageInput.  The implementation will try to determine this as
+    /// efficiently as possible, in most cases much less expensively than
+    /// doing a full `open()`.  Note that there can be false positives: a
+    /// file can appear to be of the right type (i.e., `valid_file()`
+    /// returning `true`) but still fail a subsequent call to `open()`, such
+    /// as if the contents of the file are truncated, nonsensical, or
+    /// otherwise corrupted.
+    ///
+    /// @returns
+    ///         `true` upon success, or `false` upon failure.
+    virtual bool valid_file (Filesystem::IOProxy* ioproxy) const;
 
     /// Opens the file with given name and seek to the first subimage in the
     /// file.  Various file attributes are put in `newspec` and a copy

--- a/src/jpeg.imageio/jpeg_pvt.h
+++ b/src/jpeg.imageio/jpeg_pvt.h
@@ -62,7 +62,7 @@ public:
     {
         return (feature == "exif" || feature == "iptc" || feature == "ioproxy");
     }
-    bool valid_file(Filesystem::IOProxy* io) const override;
+    bool valid_file(Filesystem::IOProxy* ioproxy) const override;
 
     bool open(const std::string& name, ImageSpec& spec) override;
     bool open(const std::string& name, ImageSpec& spec,

--- a/src/jpeg.imageio/jpeg_pvt.h
+++ b/src/jpeg.imageio/jpeg_pvt.h
@@ -62,10 +62,8 @@ public:
     {
         return (feature == "exif" || feature == "iptc" || feature == "ioproxy");
     }
-    bool valid_file(const std::string& filename) const override
-    {
-        return valid_file(filename, nullptr);
-    }
+    bool valid_file(Filesystem::IOProxy* io) const override;
+
     bool open(const std::string& name, ImageSpec& spec) override;
     bool open(const std::string& name, ImageSpec& spec,
               const ImageSpec& config) override;
@@ -118,8 +116,6 @@ private:
     void jpeg_decode_iptc(const unsigned char* buf);
 
     bool read_icc_profile(j_decompress_ptr cinfo, ImageSpec& spec);
-
-    bool valid_file(const std::string& filename, Filesystem::IOProxy* io) const;
 
     void close_file() { init(); }
 

--- a/src/jpeg.imageio/jpeginput.cpp
+++ b/src/jpeg.imageio/jpeginput.cpp
@@ -138,14 +138,14 @@ JpgInput::jpegerror(my_error_ptr /*myerr*/, bool fatal)
 
 
 bool
-JpgInput::valid_file(Filesystem::IOProxy* io) const
+JpgInput::valid_file(Filesystem::IOProxy* ioproxy) const
 {
     // Check magic number to assure this is a JPEG file
-    if (!io || io->mode() != Filesystem::IOProxy::Read)
+    if (!ioproxy || ioproxy->mode() != Filesystem::IOProxy::Read)
         return false;
 
     uint8_t magic[2] {};
-    const size_t numRead = io->pread(magic, sizeof(magic), 0);
+    const size_t numRead = ioproxy->pread(magic, sizeof(magic), 0);
     return numRead == sizeof(magic) && magic[0] == JPEG_MAGIC1
            && magic[1] == JPEG_MAGIC2;
 }

--- a/src/jpeg.imageio/jpeginput.cpp
+++ b/src/jpeg.imageio/jpeginput.cpp
@@ -138,26 +138,16 @@ JpgInput::jpegerror(my_error_ptr /*myerr*/, bool fatal)
 
 
 bool
-JpgInput::valid_file(const std::string& filename, Filesystem::IOProxy* io) const
+JpgInput::valid_file(Filesystem::IOProxy* io) const
 {
     // Check magic number to assure this is a JPEG file
-    uint8_t magic[2] = { 0, 0 };
-    bool ok          = true;
+    if (!io || io->mode() != Filesystem::IOProxy::Read)
+        return false;
 
-    if (io) {
-        ok = (io->pread(magic, sizeof(magic), 0) == sizeof(magic));
-    } else {
-        FILE* fd = Filesystem::fopen(filename, "rb");
-        if (!fd)
-            return false;
-        ok = (::fread(magic, sizeof(magic), 1, fd) == 1);
-        fclose(fd);
-    }
-
-    if (magic[0] != JPEG_MAGIC1 || magic[1] != JPEG_MAGIC2) {
-        ok = false;
-    }
-    return ok;
+    uint8_t magic[2] {};
+    const size_t numRead = io->pread(magic, sizeof(magic), 0);
+    return numRead == sizeof(magic) && magic[0] == JPEG_MAGIC1
+           && magic[1] == JPEG_MAGIC2;
 }
 
 

--- a/src/libOpenImageIO/imageinput.cpp
+++ b/src/libOpenImageIO/imageinput.cpp
@@ -93,10 +93,39 @@ ImageInput::~ImageInput() {}
 bool
 ImageInput::valid_file(const std::string& filename) const
 {
-    ImageSpec tmpspec;
-    bool ok = const_cast<ImageInput*>(this)->open(filename, tmpspec);
-    if (ok)
-        const_cast<ImageInput*>(this)->close();
+    ImageInput* self = const_cast<ImageInput*>(this);
+
+    if (self->supports("ioproxy")) {
+        Filesystem::IOFile io(filename, Filesystem::IOProxy::Read);
+        return valid_file(&io);
+    } else {
+        ImageSpec tmpspec;
+        bool ok = self->open(filename, tmpspec);
+        if (ok)
+            self->close();
+        (void)geterror();  // Clear any errors
+        return ok;
+    }
+}
+
+
+
+bool
+ImageInput::valid_file(Filesystem::IOProxy* io) const
+{
+    ImageInput* self = const_cast<ImageInput*>(this);
+
+    /* Open using the ioproxy if possible. */
+    if (!self->set_ioproxy(io))
+        return false;
+
+    ImageSpec config, tmpspec;
+    bool ok = self->open("", tmpspec, config);
+    if (ok) {
+        self->close();
+    }
+    self->ioproxy_clear();
+
     (void)geterror();  // Clear any errors
     return ok;
 }

--- a/src/libOpenImageIO/imageinput.cpp
+++ b/src/libOpenImageIO/imageinput.cpp
@@ -111,12 +111,12 @@ ImageInput::valid_file(const std::string& filename) const
 
 
 bool
-ImageInput::valid_file(Filesystem::IOProxy* io) const
+ImageInput::valid_file(Filesystem::IOProxy* ioproxy) const
 {
     ImageInput* self = const_cast<ImageInput*>(this);
 
     /* Open using the ioproxy if possible. */
-    if (!self->set_ioproxy(io))
+    if (!self->set_ioproxy(ioproxy))
         return false;
 
     ImageSpec config, tmpspec;

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -368,6 +368,15 @@ OpenEXRInput::open(const std::string& name, ImageSpec& newspec,
         errorf("Could not open file \"%s\"", name);
         return false;
     }
+
+    // If we weren't given an IOProxy, create one now that just reads from
+    // the file.
+    if (!m_io) {
+        m_io = new Filesystem::IOFile(name, Filesystem::IOProxy::Read);
+        m_local_io.reset(m_io);
+    }
+    OIIO_ASSERT(m_io);
+
     if (!valid_file(m_io)) {
         errorf("\"%s\" is not an OpenEXR file", name);
         return false;
@@ -403,14 +412,8 @@ OpenEXRInput::open(const std::string& name, ImageSpec& newspec,
     // Clear the spec with default constructor
     m_spec = ImageSpec();
 
-    // Establish an input stream. If we weren't given an IOProxy, create one
-    // now that just reads from the file.
+    // Establish an input stream.
     try {
-        if (!m_io) {
-            m_io = new Filesystem::IOFile(name, Filesystem::IOProxy::Read);
-            m_local_io.reset(m_io);
-        }
-        OIIO_ASSERT(m_io);
         if (m_io->mode() != Filesystem::IOProxy::Read) {
             // If the proxy couldn't be opened in write mode, try to
             // return an error.

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -133,7 +133,7 @@ public:
                 || feature == "iptc"  // Because of arbitrary_metadata
                 || feature == "ioproxy");
     }
-    bool valid_file(Filesystem::IOProxy* io) const override;
+    bool valid_file(Filesystem::IOProxy* ioproxy) const override;
     bool open(const std::string& name, ImageSpec& newspec,
               const ImageSpec& config) override;
     bool open(const std::string& name, ImageSpec& newspec) override
@@ -336,13 +336,13 @@ OpenEXRInput::OpenEXRInput() { init(); }
 
 
 bool
-OpenEXRInput::valid_file(Filesystem::IOProxy* io) const
+OpenEXRInput::valid_file(Filesystem::IOProxy* ioproxy) const
 {
-    if (!io || io->mode() != Filesystem::IOProxy::Mode::Read)
+    if (!ioproxy || ioproxy->mode() != Filesystem::IOProxy::Mode::Read)
         return false;
 
     try {
-        OpenEXRInputStream IStream("", io);
+        OpenEXRInputStream IStream("", ioproxy);
         return Imf::isOpenExrFile(IStream);
     } catch (const std::exception& e) {
         return false;

--- a/src/png.imageio/pnginput.cpp
+++ b/src/png.imageio/pnginput.cpp
@@ -20,7 +20,7 @@ public:
     {
         return (feature == "ioproxy" || feature == "exif");
     }
-    bool valid_file(Filesystem::IOProxy* io) const override;
+    bool valid_file(Filesystem::IOProxy* ioproxy) const override;
     bool open(const std::string& name, ImageSpec& newspec) override;
     bool open(const std::string& name, ImageSpec& newspec,
               const ImageSpec& config) override;
@@ -110,13 +110,13 @@ OIIO_PLUGIN_EXPORTS_END
 
 
 bool
-PNGInput::valid_file(Filesystem::IOProxy* io) const
+PNGInput::valid_file(Filesystem::IOProxy* ioproxy) const
 {
-    if (!io || io->mode() != Filesystem::IOProxy::Mode::Read)
+    if (!ioproxy || ioproxy->mode() != Filesystem::IOProxy::Mode::Read)
         return false;
 
     unsigned char sig[8] {};
-    const size_t numRead = io->pread(sig, sizeof(sig), 0);
+    const size_t numRead = ioproxy->pread(sig, sizeof(sig), 0);
     return numRead == sizeof(sig) && png_sig_cmp(sig, 0, 8) == 0;
 }
 

--- a/src/png.imageio/pnginput.cpp
+++ b/src/png.imageio/pnginput.cpp
@@ -20,7 +20,7 @@ public:
     {
         return (feature == "ioproxy" || feature == "exif");
     }
-    bool valid_file(const std::string& filename) const override;
+    bool valid_file(Filesystem::IOProxy* io) const override;
     bool open(const std::string& name, ImageSpec& newspec) override;
     bool open(const std::string& name, ImageSpec& newspec,
               const ImageSpec& config) override;
@@ -110,16 +110,14 @@ OIIO_PLUGIN_EXPORTS_END
 
 
 bool
-PNGInput::valid_file(const std::string& filename) const
+PNGInput::valid_file(Filesystem::IOProxy* io) const
 {
-    FILE* fd = Filesystem::fopen(filename, "rb");
-    if (!fd)
+    if (!io || io->mode() != Filesystem::IOProxy::Mode::Read)
         return false;
-    unsigned char sig[8];
-    bool ok = (fread(sig, 1, sizeof(sig), fd) == sizeof(sig)
-               && png_sig_cmp(sig, 0, 7) == 0);
-    fclose(fd);
-    return ok;
+
+    unsigned char sig[8] {};
+    const size_t numRead = io->pread(sig, sizeof(sig), 0);
+    return numRead == sizeof(sig) && png_sig_cmp(sig, 0, 8) == 0;
 }
 
 
@@ -136,7 +134,7 @@ PNGInput::open(const std::string& name, ImageSpec& newspec)
 
     unsigned char sig[8];
     if (ioproxy()->pread(sig, sizeof(sig), 0) != sizeof(sig)
-        || png_sig_cmp(sig, 0, 7)) {
+        || png_sig_cmp(sig, 0, 8)) {
         if (!has_error())
             errorf("Not a PNG file");
         return false;  // Read failed

--- a/src/sgi.imageio/sgiinput.cpp
+++ b/src/sgi.imageio/sgiinput.cpp
@@ -18,7 +18,7 @@ public:
     {
         return feature == "ioproxy";
     }
-    bool valid_file(const std::string& filename) const override;
+    bool valid_file(Filesystem::IOProxy* io) const override;
     bool open(const std::string& name, ImageSpec& spec) override;
     bool open(const std::string& name, ImageSpec& newspec,
               const ImageSpec& config) override;
@@ -82,16 +82,14 @@ OIIO_PLUGIN_EXPORTS_END
 
 
 bool
-SgiInput::valid_file(const std::string& filename) const
+SgiInput::valid_file(Filesystem::IOProxy* io) const
 {
-    FILE* fd = Filesystem::fopen(filename, "rb");
-    if (!fd)
+    if (!io || io->mode() != Filesystem::IOProxy::Read)
         return false;
-    int16_t magic;
-    bool ok = (::fread(&magic, sizeof(magic), 1, fd) == 1)
-              && (magic == sgi_pvt::SGI_MAGIC);
-    fclose(fd);
-    return ok;
+
+    int16_t magic {};
+    const size_t numRead = io->pread(&magic, sizeof(magic), 0);
+    return numRead == sizeof(magic) && magic == sgi_pvt::SGI_MAGIC;
 }
 
 

--- a/src/sgi.imageio/sgiinput.cpp
+++ b/src/sgi.imageio/sgiinput.cpp
@@ -18,7 +18,7 @@ public:
     {
         return feature == "ioproxy";
     }
-    bool valid_file(Filesystem::IOProxy* io) const override;
+    bool valid_file(Filesystem::IOProxy* ioproxy) const override;
     bool open(const std::string& name, ImageSpec& spec) override;
     bool open(const std::string& name, ImageSpec& newspec,
               const ImageSpec& config) override;
@@ -82,13 +82,13 @@ OIIO_PLUGIN_EXPORTS_END
 
 
 bool
-SgiInput::valid_file(Filesystem::IOProxy* io) const
+SgiInput::valid_file(Filesystem::IOProxy* ioproxy) const
 {
-    if (!io || io->mode() != Filesystem::IOProxy::Read)
+    if (!ioproxy || ioproxy->mode() != Filesystem::IOProxy::Read)
         return false;
 
     int16_t magic {};
-    const size_t numRead = io->pread(&magic, sizeof(magic), 0);
+    const size_t numRead = ioproxy->pread(&magic, sizeof(magic), 0);
     return numRead == sizeof(magic) && magic == sgi_pvt::SGI_MAGIC;
 }
 

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -100,7 +100,7 @@ public:
     TIFFInput();
     ~TIFFInput() override;
     const char* format_name(void) const override { return "tiff"; }
-    bool valid_file(const std::string& filename) const override;
+    bool valid_file(Filesystem::IOProxy* io) const override;
     int supports(string_view feature) const override
     {
         return (feature == "exif" || feature == "iptc" || feature == "ioproxy");
@@ -461,8 +461,6 @@ private:
         return xtile + ytile * nxtiles + ztile * nxtiles * nytiles;
     }
 
-    bool valid_file(const std::string& filename, Filesystem::IOProxy* io) const;
-
 #if OIIO_TIFFLIB_VERSION >= 40500
     std::string m_last_error;
     spin_mutex m_last_error_mutex;
@@ -613,7 +611,10 @@ reader_mapproc(thandle_t, tdata_t*, toff_t*)
     return 0;
 }
 
-static void reader_unmapproc(thandle_t, tdata_t, toff_t) {}
+static void
+reader_unmapproc(thandle_t, tdata_t, toff_t)
+{
+}
 
 
 
@@ -686,19 +687,14 @@ TIFFInput::~TIFFInput()
 
 
 bool
-TIFFInput::valid_file(const std::string& filename,
-                      Filesystem::IOProxy* io) const
+TIFFInput::valid_file(Filesystem::IOProxy* io) const
 {
-    std::unique_ptr<Filesystem::IOProxy> local_io;
-    if (!io) {
-        io = new Filesystem::IOFile(filename, Filesystem::IOProxy::Read);
-        local_io.reset(io);
-    }
-    if (!io || !io->opened())
-        return false;  // needs to be able to open
-    uint16_t magic[2] = { 0, 0 };
-    size_t numRead    = io->pread(magic, 2 * sizeof(uint16_t), 0);
-    if (numRead != 2 * sizeof(uint16_t))  // read failed
+    if (!io || io->mode() != Filesystem::IOProxy::Mode::Read)
+        return false;
+
+    uint16_t magic[2] {};
+    const size_t numRead = io->pread(magic, sizeof(magic), 0);
+    if (numRead != sizeof(magic))  // read failed
         return false;
     if (magic[0] != TIFF_LITTLEENDIAN && magic[0] != TIFF_BIGENDIAN)
         return false;  // not the right byte order
@@ -707,14 +703,6 @@ TIFFInput::valid_file(const std::string& filename,
     return (magic[1] == 42 /* Classic TIFF */ || magic[1] == 43 /* Big TIFF */);
     // local_io, if used, will automatically close and free. A passed in
     // proxy will remain in its prior state.
-}
-
-
-
-bool
-TIFFInput::valid_file(const std::string& filename) const
-{
-    return valid_file(filename, nullptr);
 }
 
 
@@ -1975,7 +1963,7 @@ TIFFInput::read_native_scanlines(int subimage, int miplevel, int ybegin,
             char* cbuf        = compressed_scratch.get() + stripidx * cbound;
             tstrip_t stripnum = (y - m_spec.y) / m_rowsperstrip;
             tsize_t csize     = TIFFReadRawStrip(m_tif, stripnum, cbuf,
-                                             tmsize_t(cbound));
+                                                 tmsize_t(cbound));
             if (csize < 0) {
                 std::string err = oiio_tiff_last_error();
                 errorfmt("TIFFRead{}Strip failed reading line y={},z={}: {}",

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -100,7 +100,7 @@ public:
     TIFFInput();
     ~TIFFInput() override;
     const char* format_name(void) const override { return "tiff"; }
-    bool valid_file(Filesystem::IOProxy* io) const override;
+    bool valid_file(Filesystem::IOProxy* ioproxy) const override;
     int supports(string_view feature) const override
     {
         return (feature == "exif" || feature == "iptc" || feature == "ioproxy");
@@ -684,13 +684,13 @@ TIFFInput::~TIFFInput()
 
 
 bool
-TIFFInput::valid_file(Filesystem::IOProxy* io) const
+TIFFInput::valid_file(Filesystem::IOProxy* ioproxy) const
 {
-    if (!io || io->mode() != Filesystem::IOProxy::Mode::Read)
+    if (!ioproxy || ioproxy->mode() != Filesystem::IOProxy::Mode::Read)
         return false;
 
     uint16_t magic[2] {};
-    const size_t numRead = io->pread(magic, sizeof(magic), 0);
+    const size_t numRead = ioproxy->pread(magic, sizeof(magic), 0);
     if (numRead != sizeof(magic))  // read failed
         return false;
     if (magic[0] != TIFF_LITTLEENDIAN && magic[0] != TIFF_BIGENDIAN)

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -611,10 +611,7 @@ reader_mapproc(thandle_t, tdata_t*, toff_t*)
     return 0;
 }
 
-static void
-reader_unmapproc(thandle_t, tdata_t, toff_t)
-{
-}
+static void reader_unmapproc(thandle_t, tdata_t, toff_t) {}
 
 
 
@@ -1963,7 +1960,7 @@ TIFFInput::read_native_scanlines(int subimage, int miplevel, int ybegin,
             char* cbuf        = compressed_scratch.get() + stripidx * cbound;
             tstrip_t stripnum = (y - m_spec.y) / m_rowsperstrip;
             tsize_t csize     = TIFFReadRawStrip(m_tif, stripnum, cbuf,
-                                                 tmsize_t(cbound));
+                                             tmsize_t(cbound));
             if (csize < 0) {
                 std::string err = oiio_tiff_last_error();
                 errorfmt("TIFFRead{}Strip failed reading line y={},z={}: {}",


### PR DESCRIPTION
## Description
Every format that has an existing `valid_file(std::string)` implementation, and which supports an
ioproxy, now also has a `valid_file(IOProxy)` implementation for completeness.

The existing std::string overloads have been implemented in terms of the IOProxy overload where
possible to cut down on the boilerplate. This is done at the base of the hierarchy in ImageInput.

The remaining formats that support ioproxy, but do not currently have a `valid_file` method, will be
submitted in a follow-up PR as the additional logic required for those will require closer review.

## Tests
I haven't had much time/luck to sort out running the tests locally on Windows, or setting up a parallel WSL
environment, so I admit this is coming in with no test coverage beyond it working locally for me in a
test app. The app invokes both `valid_file` methods on a directory filled with various files for the formats in question.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-CORPORATE)).
- [x] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

