### PR TITLE
build: Disable new warning for fmt headers in gcc13

### DIFF
--- a/site/spi/Makefile-bits
+++ b/site/spi/Makefile-bits
@@ -222,6 +222,10 @@ else ifeq (${platform}, macosx)
         MY_CMAKE_FLAGS += \
            -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11
         USE_LIBCPLUSPLUS := 0
+    else ifeq (${COMPILER}, gcc13)
+        MY_CMAKE_FLAGS += \
+           -DCMAKE_C_COMPILER=gcc-13 -DCMAKE_CXX_COMPILER=g++-13
+        USE_LIBCPLUSPLUS := 0
     else ifeq (${COMPILER},clang13)
         MY_CMAKE_FLAGS += -DCMAKE_C_COMPILER=/usr/local/opt/llvm@13/bin/clang \
         				  -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm@13/bin/clang++

--- a/src/include/OpenImageIO/detail/fmt.h
+++ b/src/include/OpenImageIO/detail/fmt.h
@@ -41,6 +41,9 @@ OIIO_PRAGMA_WARNING_PUSH
 #if OIIO_GNUC_VERSION >= 70000
 #    pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
+#if OIIO_GNUC_VERSION >= 130000
+#    pragma GCC diagnostic ignored "-Wdangling-reference"
+#endif
 #if OIIO_INTEL_LLVM_COMPILER
 #    pragma GCC diagnostic ignored "-Wtautological-constant-compare"
 #endif


### PR DESCRIPTION
Working toward clean build with the new gcc 13.1. This isn't the whole story, but it is one thing necessary.

