### PR TITLE
Improve make_texture for very large images

### DIFF
--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -5533,6 +5533,9 @@ prep_texture_config(ImageSpec& configspec, ParamValueList& fileoptions)
                          fileoptions.get_float("uvslopes_scale", 0.0f));
     if (fileoptions.contains("handed"))
         configspec.attribute("handed", fileoptions.get_string("handed"));
+    if (fileoptions.contains("forcefloat"))
+        configspec.attribute("maketx:forcefloat",
+                             fileoptions.get_int("forcefloat"));
 
     // The default values here should match the initialized values
     // in src/maketx/maketx.cpp
@@ -5818,8 +5821,11 @@ output_file(int /*argc*/, const char* argv[])
             mode = ImageBufAlgo::MakeTxBumpWithSlopes;
         // if (lightprobemode)
         //     mode = ImageBufAlgo::MakeTxEnvLatlFromLightProbe;
-        ok = ImageBufAlgo::make_texture(mode, (*ir)(0, 0), filename,
-                                        configspec);
+        if (ot.verbose || ot.debug)
+            configspec.attribute("maketx:verbose", 1);
+        ok = ImageBufAlgo::make_texture(mode, (*ir)(0, 0), filename, configspec,
+                                        ot.verbose || ot.debug ? &std::cout
+                                                               : nullptr);
         if (!ok) {
             ot.errorfmt(command, "Could not make texture: {}",
                         OIIO::geterror());


### PR DESCRIPTION
`make_texture()` already took a configuration option "maketx:forcefloat" (defaults to 1), which if set to 0 disables the conversion to a float buffer for intermediate computation.

For `oiiotool -otex`, there was no way to specify this. This patch allows it to be disabled with the new optional modifier `-otex:forcefloat=0`.

Also, in make_texture, this option only controlled the initial conversion of the whole buffer to float, but the downsized levels all were float either way. This patch now uses the forcefloat config option to also control the buffers used for downsizing.

Disabling forcefloat like this has a speed penalty (the downsizing math on float buffers is faster than going in and out of float for every indvidual value) and loses some precision in the process of repeatedly downsizing to generate the MIP levels.  But it can sure save a lot of memory if you have a ginormous uint8 image and want to avod the 4x balooning of memory.  I don't recommend disabling forcefloat except for images that can't fit into memory for the texture creation without it. But when this is the right hammer to use, it can be the difference between being able to create the texture, or not.

Some other improvements:

* `oiiotool -otex` wasn't outputting ANY status output during texture output as maketx does, and for that matter, -v and -debug were not being influencing the behavior of make_texture at all despite it having such support. So fix to pass down the right flags. Now there are proper verbose status and debug messages when requested.

* Eliminate useless call to is_monochrome by calling it only when the previously-computed pixel stats indicate that the average value of all the channels is the same (if they don't have the same average, there's no way the pixel-by-pixel values will be the same in all channels for all pixels). This saves an extra traversal of all the pixel memory during texture creation.

* Use synchronized/flushed status messages so users can see them as they are issued for very long maketx tasks. This also included some conversion from old iostream stuff to fmt-based print.

* For verbose/debug, more fine-grained timing for make_texture, in particular, print the time spent downsizing and writing each MIP level.

