### PR TITLE
cleanup: root out deprecated simd type names; `OIIO_DISABLE_DEPRECATED`

### DIFF
--- a/src/include/OpenImageIO/oiioversion.h.in
+++ b/src/include/OpenImageIO/oiioversion.h.in
@@ -88,6 +88,21 @@
                              OIIO_VERSION_MINOR, OIIO_VERSION_PATCH, \
                              OIIO_VERSION_TWEAK, "")
 
+// OIIO_DISABLE_DEPRECATED encodes the version for which any declarations that
+// were deprecated as of that version may be hidden from view of software
+// including the OIIO headers.  For example, if a downstream project says
+//
+//     #define OIIO_DISABLE_DEPRECATED OIIO_MAKE_VERSION(2,2,0)
+//
+// before including any OpenImageIO header, then we will do our best to make
+// it a compile-time error if they try to use anything we consider deprecated
+// in version 2.2.0 or later. This is viewed as equivalent to the downstream
+// package considering their minimum OIIO to be 2.2 and they want to be sure
+// they aren't using any features that are slated for deprecation. The
+// default, 0, will not try to hide any deprecated features.
+#ifndef OIIO_DISABLE_DEPRECATED
+#    define OIIO_DISABLE_DEPRECATED 0
+#endif
 
 // Establish the name spaces
 namespace @PROJ_NAMESPACE_V@ { }

--- a/src/include/OpenImageIO/simd.h
+++ b/src/include/OpenImageIO/simd.h
@@ -289,7 +289,11 @@ class vbool16;
 class vint16;
 class vfloat16;
 
+#if OIIO_DISABLE_DEPRECATED >= OIIO_MAKE_VERSION(1,9,0) && !defined(OIIO_INTERNAL)
 // Deprecated names -- remove these in 1.9
+// These are removed from visibility for the OIIO codebase itself, or for any
+// downstream project that defines OIIO_DISABLE_DEPRECATED to exclude
+// declarations deprecated as of version 1.9 or later.
 typedef vbool4 mask4;    // old name
 typedef vbool4 bool4;
 typedef vbool8 bool8;
@@ -298,6 +302,7 @@ typedef vint8 int8;
 typedef vfloat3 float3;
 typedef vfloat4 float4;
 typedef vfloat8 float8;
+#endif
 
 } // namespace simd
 

--- a/src/libutil/timer_test.cpp
+++ b/src/libutil/timer_test.cpp
@@ -137,7 +137,7 @@ main(int argc, char** argv)
 
     float val = 0.5;
     clobber(val);
-    simd::float4 val4 = val;
+    simd::vfloat4 val4 = val;
     clobber(val4);
 
     bench("add", [&]() { DoNotOptimize(val + 1.5); });


### PR DESCRIPTION
We have some OIIO 1.x era type aliases float4, int4, etc., for the
simd types that have long since been renamed vfloat4, vint4, etc.
Hide those aliases when buiding OIIO itself, to be sure we aren't
inadvertently using them. And indeed, in one spot, we were! (Fix it.)

Introuce a new preprocessor symbol, `OIIO_DISABLE_DEPRECATED`, which
if set to an encoded version number (such as 20100 for version 2.1) by
a downstream package, indicates that we are permitted to hide
declarations that were considered deprecated from that version
on. This is an aid to downstream projects who wish to enforce that
they are not inadvertently using any deprecated OIIO calls which may
disappear in a future release.

So back to the deprecated simd names: Also hide them if
`OIIO_DISABLE_DEPRECATED` is defined to exclude things that were
deprecated as of OIIO 1.9+, which apparently is when we changed this
definition.