### PR TITLE
Implement valid_file(IOProxy) overloads for DDS, PSD, and WEBP

### DIFF
--- a/src/dds.imageio/ddsinput.cpp
+++ b/src/dds.imageio/ddsinput.cpp
@@ -37,6 +37,8 @@ public:
     {
         return feature == "ioproxy";
     }
+    bool valid_file(Filesystem::IOProxy* ioproxy) const override;
+
     bool open(const std::string& name, ImageSpec& newspec) override;
     bool open(const std::string& name, ImageSpec& spec,
               const ImageSpec& config) override;
@@ -80,6 +82,12 @@ private:
         m_buf.clear();
         ioproxy_clear();
     }
+
+    /// Helper funtion: load header and handle endianness (advances the ioproxy)
+    bool read_header(dds_header& header, Filesystem::IOProxy* ioproxy) const;
+
+    /// Helper funtion: validate (simple header checks)
+    bool validate_header(const dds_header& header) const;
 
     /// Helper function: read the image as scanlines (all but cubemaps).
     ///
@@ -317,6 +325,25 @@ OIIO_PLUGIN_EXPORTS_END
 
 
 bool
+DDSInput::valid_file(Filesystem::IOProxy* ioproxy) const
+{
+    if (!ioproxy || ioproxy->mode() != Filesystem::IOProxy::Mode::Read)
+        return false;
+
+    dds_header header;
+    const bool read_ok = read_header(header, ioproxy);
+    const bool all_ok  = read_ok && validate_header(header);
+
+    // Reset and clear any errors
+    ioproxy->seek(0);
+    (void)geterror();
+
+    return all_ok;
+}
+
+
+
+bool
 DDSInput::open(const std::string& name, ImageSpec& newspec,
                const ImageSpec& config)
 {
@@ -335,74 +362,11 @@ DDSInput::open(const std::string& name, ImageSpec& newspec)
         return false;
 
     static_assert(sizeof(dds_header) == 128, "dds header size does not match");
-    if (!ioread(&m_dds, sizeof(m_dds), 1))
+    if (!read_header(m_dds, ioproxy()))
         return false;
 
-    if (bigendian()) {
-        // DDS files are little-endian
-        // only swap values which are not flags or bitmasks
-        swap_endian(&m_dds.size);
-        swap_endian(&m_dds.height);
-        swap_endian(&m_dds.width);
-        swap_endian(&m_dds.pitch);
-        swap_endian(&m_dds.depth);
-        swap_endian(&m_dds.mipmaps);
-
-        swap_endian(&m_dds.fmt.size);
-        swap_endian(&m_dds.fmt.bpp);
-    }
-
-    /*std::cerr << "[dds] fourCC: " << ((char *)&m_dds.fourCC)[0]
-                                  << ((char *)&m_dds.fourCC)[1]
-                                  << ((char *)&m_dds.fourCC)[2]
-                                  << ((char *)&m_dds.fourCC)[3]
-                                  << " (" << m_dds.fourCC << ")\n";
-    std::cerr << "[dds] size: " << m_dds.size << "\n";
-    std::cerr << "[dds] flags: " << m_dds.flags << "\n";
-    std::cerr << "[dds] pitch: " << m_dds.pitch << "\n";
-    std::cerr << "[dds] width: " << m_dds.width << "\n";
-    std::cerr << "[dds] height: " << m_dds.height << "\n";
-    std::cerr << "[dds] depth: " << m_dds.depth << "\n";
-    std::cerr << "[dds] mipmaps: " << m_dds.mipmaps << "\n";
-    std::cerr << "[dds] fmt.size: " << m_dds.fmt.size << "\n";
-    std::cerr << "[dds] fmt.flags: " << m_dds.fmt.flags << "\n";
-    
-    std::cerr << "[dds] fmt.fourCC: " << ((char *)&m_dds.fmt.fourCC)[0]
-                                      << ((char *)&m_dds.fmt.fourCC)[1]
-                                      << ((char *)&m_dds.fmt.fourCC)[2]
-                                      << ((char *)&m_dds.fmt.fourCC)[3]
-                                      << " (" << m_dds.fmt.fourCC << ")\n";
-    std::cerr << "[dds] fmt.bpp: " << m_dds.fmt.bpp << "\n";
-    std::cerr << "[dds] caps.flags1: " << m_dds.caps.flags1 << "\n";
-    std::cerr << "[dds] caps.flags2: " << m_dds.caps.flags2 << "\n";*/
-
-    // sanity checks - valid 4CC, correct struct sizes and flags which should
-    // be always present, regardless of the image type, size etc., also check
-    // for impossible flag combinations
-    if (m_dds.fourCC != DDS_MAKE4CC('D', 'D', 'S', ' ') || m_dds.size != 124
-        || m_dds.fmt.size != 32 || !(m_dds.caps.flags1 & DDS_CAPS1_TEXTURE)
-        || !(m_dds.flags & DDS_CAPS) || !(m_dds.flags & DDS_PIXELFORMAT)
-        || (m_dds.caps.flags2 & DDS_CAPS2_VOLUME
-            && !(m_dds.caps.flags1 & DDS_CAPS1_COMPLEX
-                 && m_dds.flags & DDS_DEPTH))
-        || (m_dds.caps.flags2 & DDS_CAPS2_CUBEMAP
-            && !(m_dds.caps.flags1 & DDS_CAPS1_COMPLEX))) {
-        errorf("Invalid DDS header, possibly corrupt file");
+    if (!validate_header(m_dds))
         return false;
-    }
-
-    // make sure all dimensions are > 0 and that we have at least one channel
-    // (for uncompressed images)
-    if (!(m_dds.flags & DDS_WIDTH) || !m_dds.width
-        || !(m_dds.flags & DDS_HEIGHT) || !m_dds.height
-        || ((m_dds.flags & DDS_DEPTH) && !m_dds.depth)
-        || (!(m_dds.fmt.flags & DDS_PF_FOURCC)
-            && !(m_dds.fmt.flags
-                 & (DDS_PF_RGB | DDS_PF_LUMINANCE | DDS_PF_ALPHA
-                    | DDS_PF_ALPHAONLY)))) {
-        errorf("Image with no data");
-        return false;
-    }
 
     // read optional DX10 header
     if (m_dds.fmt.fourCC == DDS_4CC_DX10) {
@@ -812,6 +776,93 @@ DDSInput::internal_readimg(unsigned char* dst, int w, int h, int d)
             }
         }
     }
+    return true;
+}
+
+
+
+bool
+DDSInput::read_header(dds_header& header, Filesystem::IOProxy* ioproxy) const
+{
+    const size_t numRead = ioproxy->read(&header, sizeof(header));
+    if (numRead != sizeof(header)) {
+        return false;
+    }
+
+    if (bigendian()) {
+        // DDS files are little-endian
+        // only swap values which are not flags or bitmasks
+        swap_endian(&header.size);
+        swap_endian(&header.height);
+        swap_endian(&header.width);
+        swap_endian(&header.pitch);
+        swap_endian(&header.depth);
+        swap_endian(&header.mipmaps);
+
+        swap_endian(&header.fmt.size);
+        swap_endian(&header.fmt.bpp);
+    }
+
+    return true;
+}
+
+
+
+bool
+DDSInput::validate_header(const dds_header& header) const
+{
+    /*std::cerr << "[dds] fourCC: " << ((char *)&header.fourCC)[0]
+                                  << ((char *)&header.fourCC)[1]
+                                  << ((char *)&header.fourCC)[2]
+                                  << ((char *)&header.fourCC)[3]
+                                  << " (" << header.fourCC << ")\n";
+    std::cerr << "[dds] size: " << header.size << "\n";
+    std::cerr << "[dds] flags: " << header.flags << "\n";
+    std::cerr << "[dds] pitch: " << header.pitch << "\n";
+    std::cerr << "[dds] width: " << header.width << "\n";
+    std::cerr << "[dds] height: " << header.height << "\n";
+    std::cerr << "[dds] depth: " << header.depth << "\n";
+    std::cerr << "[dds] mipmaps: " << header.mipmaps << "\n";
+    std::cerr << "[dds] fmt.size: " << header.fmt.size << "\n";
+    std::cerr << "[dds] fmt.flags: " << header.fmt.flags << "\n";
+    
+    std::cerr << "[dds] fmt.fourCC: " << ((char *)&header.fmt.fourCC)[0]
+                                      << ((char *)&header.fmt.fourCC)[1]
+                                      << ((char *)&header.fmt.fourCC)[2]
+                                      << ((char *)&header.fmt.fourCC)[3]
+                                      << " (" << header.fmt.fourCC << ")\n";
+    std::cerr << "[dds] fmt.bpp: " << header.fmt.bpp << "\n";
+    std::cerr << "[dds] caps.flags1: " << header.caps.flags1 << "\n";
+    std::cerr << "[dds] caps.flags2: " << header.caps.flags2 << "\n";*/
+
+    // sanity checks - valid 4CC, correct struct sizes and flags which should
+    // be always present, regardless of the image type, size etc., also check
+    // for impossible flag combinations
+    if (header.fourCC != DDS_MAKE4CC('D', 'D', 'S', ' ') || header.size != 124
+        || header.fmt.size != 32 || !(header.caps.flags1 & DDS_CAPS1_TEXTURE)
+        || !(header.flags & DDS_CAPS) || !(header.flags & DDS_PIXELFORMAT)
+        || (header.caps.flags2 & DDS_CAPS2_VOLUME
+            && !(header.caps.flags1 & DDS_CAPS1_COMPLEX
+                 && header.flags & DDS_DEPTH))
+        || (header.caps.flags2 & DDS_CAPS2_CUBEMAP
+            && !(header.caps.flags1 & DDS_CAPS1_COMPLEX))) {
+        errorf("Invalid DDS header, possibly corrupt file");
+        return false;
+    }
+
+    // make sure all dimensions are > 0 and that we have at least one channel
+    // (for uncompressed images)
+    if (!(header.flags & DDS_WIDTH) || !header.width
+        || !(header.flags & DDS_HEIGHT) || !header.height
+        || ((header.flags & DDS_DEPTH) && !header.depth)
+        || (!(header.fmt.flags & DDS_PF_FOURCC)
+            && !(header.fmt.flags
+                 & (DDS_PF_RGB | DDS_PF_LUMINANCE | DDS_PF_ALPHA
+                    | DDS_PF_ALPHAONLY)))) {
+        errorf("Image with no data");
+        return false;
+    }
+
     return true;
 }
 

--- a/src/dpx.imageio/dpxinput.cpp
+++ b/src/dpx.imageio/dpxinput.cpp
@@ -12,6 +12,7 @@
 // But that seems not to be actively maintained.
 #include "libdpx/DPX.h"
 #include "libdpx/DPXColorConverter.h"
+#include "libdpx/DPXHeader.h"
 
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/strutil.h>
@@ -112,13 +113,9 @@ DPXInput::valid_file(Filesystem::IOProxy* ioproxy) const
     if (!ioproxy || ioproxy->mode() != Filesystem::IOProxy::Mode::Read)
         return false;
 
-    std::unique_ptr<InStream> stream_uptr(new InStream(ioproxy));
-    if (!stream_uptr)
-        return false;
-
-    dpx::Reader dpx;
-    dpx.SetInStream(stream_uptr.get());
-    return dpx.ReadHeader();
+    dpx::U32 magic {};
+    const size_t numRead = ioproxy->pread(&magic, sizeof(magic), 0);
+    return numRead == sizeof(magic) && dpx::Header::ValidMagicCookie(magic);
 }
 
 

--- a/src/hdr.imageio/hdrinput.cpp
+++ b/src/hdr.imageio/hdrinput.cpp
@@ -41,6 +41,7 @@ public:
     {
         return feature == "ioproxy";
     }
+    bool valid_file(Filesystem::IOProxy* ioproxy) const override;
     bool open(const std::string& name, ImageSpec& spec) override;
     bool open(const std::string& name, ImageSpec& newspec,
               const ImageSpec& config) override;
@@ -198,6 +199,19 @@ rgbe2float(float& red, float& green, float& blue, unsigned char rgbe[4])
     } else {
         red = green = blue = 0.0f;
     }
+}
+
+
+
+bool
+HdrInput::valid_file(Filesystem::IOProxy* ioproxy) const
+{
+    if (!ioproxy || ioproxy->mode() != Filesystem::IOProxy::Mode::Read)
+        return false;
+
+    char magic[2] {};
+    const size_t numRead = ioproxy->pread(magic, sizeof(magic), 0);
+    return numRead == sizeof(magic) && memcmp(magic, "#?", sizeof(magic)) == 0;
 }
 
 

--- a/src/psd.imageio/psdinput.cpp
+++ b/src/psd.imageio/psdinput.cpp
@@ -539,6 +539,7 @@ PSDInput::valid_file(Filesystem::IOProxy* ioproxy) const
     const bool all_ok  = read_ok && self->validate_header(header);
 
     // Reset and clear any errors
+    ioproxy->seek(0);
     self->ioproxy_clear();
     (void)geterror();
 

--- a/src/webp.imageio/webpinput.cpp
+++ b/src/webp.imageio/webpinput.cpp
@@ -24,7 +24,6 @@ public:
     {
         return feature == "exif" || feature == "ioproxy";
     }
-    bool valid_file(Filesystem::IOProxy* ioproxy) const override;
     bool open(const std::string& name, ImageSpec& spec) override;
     bool open(const std::string& name, ImageSpec& newspec,
               const ImageSpec& config) override;
@@ -80,19 +79,6 @@ private:
 
 
 bool
-WebpInput::valid_file(Filesystem::IOProxy* ioproxy) const
-{
-    if (!ioproxy || ioproxy->mode() != Filesystem::IOProxy::Mode::Read)
-        return false;
-
-    uint8_t header[64] {};
-    const size_t numRead = ioproxy->pread(header, sizeof(header), 0);
-    return WebPGetInfo(header, numRead, nullptr, nullptr);
-}
-
-
-
-bool
 WebpInput::open(const std::string& name, ImageSpec& newspec)
 {
     return open(name, newspec, ImageSpec());
@@ -113,13 +99,30 @@ WebpInput::open(const std::string& name, ImageSpec& spec,
 
     // Get file size and check we've got enough data to decode WebP.
     m_image_size = io->size();
-    if (m_image_size == size_t(-1)) {
+    if (m_image_size == uint64_t(-1)) {
         errorfmt("Failed to get size for \"{}\"", m_filename);
+        return false;
+    }
+    if (m_image_size < 12) {
+        errorfmt("File size is less than WebP header for file \"{}\"",
+                 m_filename);
+        return false;
+    }
+    if (m_image_size > std::numeric_limits<size_t>::max()) {
+        errorfmt("Image size ({}) is too big to read", m_image_size);
         return false;
     }
 
     // Read header and verify we've got WebP image.
-    if (!valid_file(io)) {
+    std::vector<uint8_t> image_header;
+    image_header.resize(std::min(m_image_size, (uint64_t)64), 0);
+    if (!io->pread(image_header.data(), image_header.size(), 0)) {
+        close();
+        return false;
+    }
+
+    int width = 0, height = 0;
+    if (!WebPGetInfo(&image_header[0], image_header.size(), &width, &height)) {
         errorfmt("{} is not a WebP image file", m_filename);
         close();
         return false;

--- a/src/webp.imageio/webpinput.cpp
+++ b/src/webp.imageio/webpinput.cpp
@@ -24,6 +24,7 @@ public:
     {
         return feature == "exif" || feature == "ioproxy";
     }
+    bool valid_file(Filesystem::IOProxy* ioproxy) const override;
     bool open(const std::string& name, ImageSpec& spec) override;
     bool open(const std::string& name, ImageSpec& newspec,
               const ImageSpec& config) override;
@@ -79,6 +80,19 @@ private:
 
 
 bool
+WebpInput::valid_file(Filesystem::IOProxy* ioproxy) const
+{
+    if (!ioproxy || ioproxy->mode() != Filesystem::IOProxy::Mode::Read)
+        return false;
+
+    uint8_t header[64] {};
+    const size_t numRead = ioproxy->pread(header, sizeof(header), 0);
+    return WebPGetInfo(header, numRead, nullptr, nullptr);
+}
+
+
+
+bool
 WebpInput::open(const std::string& name, ImageSpec& newspec)
 {
     return open(name, newspec, ImageSpec());
@@ -99,30 +113,13 @@ WebpInput::open(const std::string& name, ImageSpec& spec,
 
     // Get file size and check we've got enough data to decode WebP.
     m_image_size = io->size();
-    if (m_image_size == uint64_t(-1)) {
+    if (m_image_size == size_t(-1)) {
         errorfmt("Failed to get size for \"{}\"", m_filename);
-        return false;
-    }
-    if (m_image_size < 12) {
-        errorfmt("File size is less than WebP header for file \"{}\"",
-                 m_filename);
-        return false;
-    }
-    if (m_image_size > std::numeric_limits<size_t>::max()) {
-        errorfmt("Image size ({}) is too big to read", m_image_size);
         return false;
     }
 
     // Read header and verify we've got WebP image.
-    std::vector<uint8_t> image_header;
-    image_header.resize(std::min(m_image_size, (uint64_t)64), 0);
-    if (!io->pread(image_header.data(), image_header.size(), 0)) {
-        close();
-        return false;
-    }
-
-    int width = 0, height = 0;
-    if (!WebPGetInfo(&image_header[0], image_header.size(), &width, &height)) {
+    if (!valid_file(io)) {
         errorfmt("{} is not a WebP image file", m_filename);
         close();
         return false;

--- a/testsuite/dds/ref/out.txt
+++ b/testsuite/dds/ref/out.txt
@@ -184,7 +184,7 @@ Reading ../oiio-images/dds/broken/dds_bc3_just_header.dds
     channel list: R, G, B, A
     compression: "DXT5"
     textureformat: "Plain Texture"
-oiiotool ERROR: read : OpenImageIO could not find a format reader for "../oiio-images/dds/broken/dds_bc3_no_full_header.dds". Is it a file format that OpenImageIO doesn't know about?
+oiiotool ERROR: read : "../oiio-images/dds/broken/dds_bc3_no_full_header.dds": Read error: hit end of file
 Full command line was:
 > oiiotool --info -v -a --hash ../oiio-images/dds/broken/dds_bc3_no_full_header.dds
 Reading ../oiio-images/dds/broken/dds_bc7_just_header.dds

--- a/testsuite/dds/ref/out.txt
+++ b/testsuite/dds/ref/out.txt
@@ -184,7 +184,7 @@ Reading ../oiio-images/dds/broken/dds_bc3_just_header.dds
     channel list: R, G, B, A
     compression: "DXT5"
     textureformat: "Plain Texture"
-oiiotool ERROR: read : "../oiio-images/dds/broken/dds_bc3_no_full_header.dds": Read error: hit end of file
+oiiotool ERROR: read : OpenImageIO could not find a format reader for "../oiio-images/dds/broken/dds_bc3_no_full_header.dds". Is it a file format that OpenImageIO doesn't know about?
 Full command line was:
 > oiiotool --info -v -a --hash ../oiio-images/dds/broken/dds_bc3_no_full_header.dds
 Reading ../oiio-images/dds/broken/dds_bc7_just_header.dds

--- a/testsuite/psd/ref/out.txt
+++ b/testsuite/psd/ref/out.txt
@@ -24,10 +24,10 @@ Reading ../oiio-images/psd_123.psd
     IPTC:ModifyDate: "2011-08-22T22:14:43-04:00"
     IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
     oiio:ColorSpace: "sRGB"
-    photoshop:ColorMode: 3, 3
+    photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
-    photoshop:LayerName: 1, 2, 3, 1, 2, 3
-    photoshop:LayerText: 1, 2, 3, 1, 2, 3
+    photoshop:LayerName: 1, 2, 3
+    photoshop:LayerText: 1, 2, 3
     rdf:parseType: "Resource"
     stEvt:action: "created"
     stEvt:instanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
@@ -74,10 +74,10 @@ Reading ../oiio-images/psd_123.psd
     IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
     oiio:ColorSpace: "sRGB"
     oiio:subimagename: "1"
-    photoshop:ColorMode: 3, 3
+    photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
-    photoshop:LayerName: 1, 2, 3, 1, 2, 3
-    photoshop:LayerText: 1, 2, 3, 1, 2, 3
+    photoshop:LayerName: 1, 2, 3
+    photoshop:LayerText: 1, 2, 3
     rdf:parseType: "Resource"
     stEvt:action: "created"
     stEvt:instanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
@@ -124,10 +124,10 @@ Reading ../oiio-images/psd_123.psd
     IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
     oiio:ColorSpace: "sRGB"
     oiio:subimagename: "2"
-    photoshop:ColorMode: 3, 3
+    photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
-    photoshop:LayerName: 1, 2, 3, 1, 2, 3
-    photoshop:LayerText: 1, 2, 3, 1, 2, 3
+    photoshop:LayerName: 1, 2, 3
+    photoshop:LayerText: 1, 2, 3
     rdf:parseType: "Resource"
     stEvt:action: "created"
     stEvt:instanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
@@ -174,10 +174,10 @@ Reading ../oiio-images/psd_123.psd
     IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
     oiio:ColorSpace: "sRGB"
     oiio:subimagename: "3"
-    photoshop:ColorMode: 3, 3
+    photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
-    photoshop:LayerName: 1, 2, 3, 1, 2, 3
-    photoshop:LayerText: 1, 2, 3, 1, 2, 3
+    photoshop:LayerName: 1, 2, 3
+    photoshop:LayerText: 1, 2, 3
     rdf:parseType: "Resource"
     stEvt:action: "created"
     stEvt:instanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
@@ -209,10 +209,10 @@ Reading ../oiio-images/psd_123_nomaxcompat.psd
     IPTC:ModifyDate: "2011-08-29T12:10:28-04:00"
     IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
     oiio:ColorSpace: "sRGB"
-    photoshop:ColorMode: 3, 3
+    photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
-    photoshop:LayerName: 1, 2, 3, 1, 2, 3
-    photoshop:LayerText: 1, 2, 3, 1, 2, 3
+    photoshop:LayerName: 1, 2, 3
+    photoshop:LayerText: 1, 2, 3
     rdf:parseType: "Resource"
     stEvt:action: "created; saved"
     stEvt:changed: "/"
@@ -260,10 +260,10 @@ Reading ../oiio-images/psd_123_nomaxcompat.psd
     IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
     oiio:ColorSpace: "sRGB"
     oiio:subimagename: "1"
-    photoshop:ColorMode: 3, 3
+    photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
-    photoshop:LayerName: 1, 2, 3, 1, 2, 3
-    photoshop:LayerText: 1, 2, 3, 1, 2, 3
+    photoshop:LayerName: 1, 2, 3
+    photoshop:LayerText: 1, 2, 3
     rdf:parseType: "Resource"
     stEvt:action: "created; saved"
     stEvt:changed: "/"
@@ -311,10 +311,10 @@ Reading ../oiio-images/psd_123_nomaxcompat.psd
     IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
     oiio:ColorSpace: "sRGB"
     oiio:subimagename: "2"
-    photoshop:ColorMode: 3, 3
+    photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
-    photoshop:LayerName: 1, 2, 3, 1, 2, 3
-    photoshop:LayerText: 1, 2, 3, 1, 2, 3
+    photoshop:LayerName: 1, 2, 3
+    photoshop:LayerText: 1, 2, 3
     rdf:parseType: "Resource"
     stEvt:action: "created; saved"
     stEvt:changed: "/"
@@ -362,10 +362,10 @@ Reading ../oiio-images/psd_123_nomaxcompat.psd
     IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
     oiio:ColorSpace: "sRGB"
     oiio:subimagename: "3"
-    photoshop:ColorMode: 3, 3
+    photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
-    photoshop:LayerName: 1, 2, 3, 1, 2, 3
-    photoshop:LayerText: 1, 2, 3, 1, 2, 3
+    photoshop:LayerName: 1, 2, 3
+    photoshop:LayerText: 1, 2, 3
     rdf:parseType: "Resource"
     stEvt:action: "created; saved"
     stEvt:changed: "/"
@@ -429,7 +429,7 @@ Reading ../oiio-images/psd_bitmap.psd
     IPTC:MetadataDate: "2011-08-25T17:40:47-04:00"
     IPTC:ModifyDate: "2011-08-25T17:40:47-04:00"
     IPTC:OriginalDocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
-    photoshop:ColorMode: 0, 0
+    photoshop:ColorMode: 0
     rdf:parseType: "Resource"
     stEvt:action: "saved; converted; derived"
     stEvt:changed: "/"
@@ -499,7 +499,7 @@ Reading ../oiio-images/psd_indexed_trans.psd
     IPTC:ModifyDate: "2011-08-29T11:54:09-04:00"
     IPTC:OriginalDocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
     oiio:ColorSpace: "sRGB"
-    photoshop:ColorMode: 2, 2
+    photoshop:ColorMode: 2
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
     stEvt:action: "saved; converted; derived"
@@ -570,7 +570,7 @@ Reading ../oiio-images/psd_rgb_8.psd
     IPTC:ModifyDate: "2011-08-25T17:40-04:00"
     IPTC:OriginalDocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
     oiio:ColorSpace: "sRGB"
-    photoshop:ColorMode: 3, 3
+    photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
     stEvt:action: "saved; converted; derived"
@@ -641,7 +641,7 @@ Reading ../oiio-images/psd_rgb_16.psd
     IPTC:ModifyDate: "2011-08-25T17:39:49-04:00"
     IPTC:OriginalDocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
     oiio:ColorSpace: "sRGB"
-    photoshop:ColorMode: 3, 3
+    photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
     stEvt:action: "saved; converted; derived"
@@ -711,7 +711,7 @@ Reading ../oiio-images/psd_rgb_32.psd
     IPTC:MetadataDate: "2011-08-25T17:39:38-04:00"
     IPTC:ModifyDate: "2011-08-25T17:39:38-04:00"
     IPTC:OriginalDocumentID: "E146B3E37A92795EE3EA6577040DE6D5"
-    photoshop:ColorMode: 3, 3
+    photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1 (Linear RGB Profile)"
     rdf:parseType: "Resource"
     stEvt:action: "saved; converted; derived"
@@ -749,7 +749,7 @@ Reading ../oiio-images/psd_rgba_8.psd
     IPTC:ModifyDate: "2011-08-25T17:39:28-04:00"
     IPTC:OriginalDocumentID: "xmp.did:037A91A22BCDE011A998CBE7B5CCEB92"
     oiio:ColorSpace: "sRGB"
-    photoshop:ColorMode: 3, 3
+    photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
     stEvt:action: "created; saved"
@@ -797,7 +797,7 @@ Reading ../oiio-images/psd_rgba_8.psd
     IPTC:OriginalDocumentID: "xmp.did:037A91A22BCDE011A998CBE7B5CCEB92"
     oiio:ColorSpace: "sRGB"
     oiio:subimagename: "Layer 1"
-    photoshop:ColorMode: 3, 3
+    photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
     stEvt:action: "created; saved"
@@ -832,10 +832,10 @@ Reading ../oiio-images/psd_123.psd
     IPTC:OriginalDocumentID: "xmp.did:047A91A22BCDE011A998CBE7B5CCEB92"
     oiio:ColorSpace: "sRGB"
     oiio:UnassociatedAlpha: 1
-    photoshop:ColorMode: 3, 3
+    photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
-    photoshop:LayerName: 1, 2, 3, 1, 2, 3
-    photoshop:LayerText: 1, 2, 3, 1, 2, 3
+    photoshop:LayerName: 1, 2, 3
+    photoshop:LayerText: 1, 2, 3
     rdf:parseType: "Resource"
     stEvt:action: "created"
     stEvt:instanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
@@ -883,10 +883,10 @@ Reading ../oiio-images/psd_123.psd
     oiio:ColorSpace: "sRGB"
     oiio:subimagename: "1"
     oiio:UnassociatedAlpha: 1
-    photoshop:ColorMode: 3, 3
+    photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
-    photoshop:LayerName: 1, 2, 3, 1, 2, 3
-    photoshop:LayerText: 1, 2, 3, 1, 2, 3
+    photoshop:LayerName: 1, 2, 3
+    photoshop:LayerText: 1, 2, 3
     rdf:parseType: "Resource"
     stEvt:action: "created"
     stEvt:instanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
@@ -934,10 +934,10 @@ Reading ../oiio-images/psd_123.psd
     oiio:ColorSpace: "sRGB"
     oiio:subimagename: "2"
     oiio:UnassociatedAlpha: 1
-    photoshop:ColorMode: 3, 3
+    photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
-    photoshop:LayerName: 1, 2, 3, 1, 2, 3
-    photoshop:LayerText: 1, 2, 3, 1, 2, 3
+    photoshop:LayerName: 1, 2, 3
+    photoshop:LayerText: 1, 2, 3
     rdf:parseType: "Resource"
     stEvt:action: "created"
     stEvt:instanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
@@ -985,10 +985,10 @@ Reading ../oiio-images/psd_123.psd
     oiio:ColorSpace: "sRGB"
     oiio:subimagename: "3"
     oiio:UnassociatedAlpha: 1
-    photoshop:ColorMode: 3, 3
+    photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
-    photoshop:LayerName: 1, 2, 3, 1, 2, 3
-    photoshop:LayerText: 1, 2, 3, 1, 2, 3
+    photoshop:LayerName: 1, 2, 3
+    photoshop:LayerText: 1, 2, 3
     rdf:parseType: "Resource"
     stEvt:action: "created"
     stEvt:instanceID: "xmp.iid:047A91A22BCDE011A998CBE7B5CCEB92"
@@ -1017,7 +1017,7 @@ src/different-mask-size.psd :   30 x   90, 3 channel, uint8 psd
     IPTC:ModifyDate: "2017-01-10T17:55:32+09:00"
     IPTC:OriginalDocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
     oiio:ColorSpace: "sRGB"
-    photoshop:ColorMode: 3, 3
+    photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
     stEvt:action: "created; saved"
@@ -1065,7 +1065,7 @@ src/different-mask-size.psd :   30 x   90, 3 channel, uint8 psd
     IPTC:OriginalDocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
     oiio:ColorSpace: "sRGB"
     oiio:subimagename: "Layer 0"
-    photoshop:ColorMode: 3, 3
+    photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
     stEvt:action: "created; saved"
@@ -1114,7 +1114,7 @@ src/different-mask-size.psd :   30 x   90, 3 channel, uint8 psd
     IPTC:OriginalDocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
     oiio:ColorSpace: "sRGB"
     oiio:subimagename: "line1"
-    photoshop:ColorMode: 3, 3
+    photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
     stEvt:action: "created; saved"
@@ -1163,7 +1163,7 @@ src/different-mask-size.psd :   30 x   90, 3 channel, uint8 psd
     IPTC:OriginalDocumentID: "xmp.did:e5390921-47bd-41b6-9237-d4903a41e966"
     oiio:ColorSpace: "sRGB"
     oiio:subimagename: "line2"
-    photoshop:ColorMode: 3, 3
+    photoshop:ColorMode: 3
     photoshop:ICCProfile: "sRGB IEC61966-2.1"
     rdf:parseType: "Resource"
     stEvt:action: "created; saved"
@@ -1192,7 +1192,7 @@ src/layer-mask.psd   :   10 x   10, 4 channel, uint8 psd
     IPTC:MetadataDate: "2017-07-13T11:42:54+09:00"
     IPTC:ModifyDate: "2017-07-13T11:42:54+09:00"
     IPTC:OriginalDocumentID: "xmp.did:a64763c8-be7b-ff48-b857-0f1ee8e5da2b"
-    photoshop:ColorMode: 3, 3
+    photoshop:ColorMode: 3
     rdf:parseType: "Resource"
     stEvt:action: "created; saved"
     stEvt:changed: "/"
@@ -1219,7 +1219,7 @@ src/layer-mask.psd   :   10 x   10, 4 channel, uint8 psd
     IPTC:ModifyDate: "2017-07-13T11:42:54+09:00"
     IPTC:OriginalDocumentID: "xmp.did:a64763c8-be7b-ff48-b857-0f1ee8e5da2b"
     oiio:subimagename: "Vector mask feather"
-    photoshop:ColorMode: 3, 3
+    photoshop:ColorMode: 3
     rdf:parseType: "Resource"
     stEvt:action: "created; saved"
     stEvt:changed: "/"
@@ -1246,7 +1246,7 @@ src/layer-mask.psd   :   10 x   10, 4 channel, uint8 psd
     IPTC:ModifyDate: "2017-07-13T11:42:54+09:00"
     IPTC:OriginalDocumentID: "xmp.did:a64763c8-be7b-ff48-b857-0f1ee8e5da2b"
     oiio:subimagename: "Layer mask"
-    photoshop:ColorMode: 3, 3
+    photoshop:ColorMode: 3
     rdf:parseType: "Resource"
     stEvt:action: "created; saved"
     stEvt:changed: "/"


### PR DESCRIPTION
## Description

Following up #3826, this implements efficient `valid_file` support for DDS, DPX, PSD, HDR, and WEBP.

The quick magic/signature checks were abstracted into small helper functions where necessary to eliminate duplicate code.

For WEBP, some redundant checks were also removed and there's also a fix for a `uint64_t` vs `size_t` check which would have caused issues on 32-bit builds.

## Tests
The PSD changes exposed an issue with array attributes. During a normal ImageInput create+open sequence, an ImageInput may be opened then closed and then opened again.

Array attributes are not cleared as part of close and so their contents will be doubled up next time they are read into the existing `m_spec`. This PR does not fix that general problem but now that PSD has a proper valid_file which doesn't do an open, the array attributes are now correct:

```
This PR
2023-05-06T02:32:05.8774584Z -    photoshop:ColorMode: 3
2023-05-06T02:32:05.8774888Z -    photoshop:ICCProfile: "sRGB IEC61966-2.1"
2023-05-06T02:32:05.8775194Z -    photoshop:LayerName: 1, 2, 3
2023-05-06T02:32:05.8775436Z -    photoshop:LayerText: 1, 2, 3

vs. the current
2023-05-06T02:32:05.8775725Z +    photoshop:ColorMode: 3, 3
2023-05-06T02:32:05.8776023Z +    photoshop:ICCProfile: "sRGB IEC61966-2.1"
2023-05-06T02:32:05.8776494Z +    photoshop:LayerName: 1, 2, 3, 1, 2, 3
2023-05-06T02:32:05.8776746Z +    photoshop:LayerText: 1, 2, 3, 1, 2, 3
```

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-CORPORATE)).
- [x] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

