### PR TITLE
Fix: Build error with MSVC

### DIFF
--- a/src/python/py_oiio.cpp
+++ b/src/python/py_oiio.cpp
@@ -153,7 +153,7 @@ oiio_bufinfo::oiio_bufinfo(const py::buffer_info& pybuf, int nchans, int width,
             format = TypeUnknown;  // No idea what's going on -- error
             error  = Strutil::fmt::format(
                 "Python array shape is [{:,}] but expecting h={}, w={}, ch={}",
-                cspan<ssize_t>(pybuf.shape), height, width, nchans);
+                cspan<py::ssize_t>(pybuf.shape), height, width, nchans);
         }
     } else if (pixeldims == 1) {
         // Reading a 1D scanline span


### PR DESCRIPTION
## Description

`ssize_t` is a posix type, msvc seemingly doesn't know about leading to a build error with MSVC 2019

usage elsewhere in this files used the `py::ssize_t` type, which seems to fix this

## Checklist:

- [x] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [x] If this is a small change, no CLA should be required 
- [x] I have updated the documentation, if applicable. -> NA
- [x] I have ensured that the change is tested somewhere in the testsuite (N/A) 
- [x] My code follows the prevailing code style of this project.

