### PR TITLE
build(cmake): Fix incorrect variable name to control symbol visibility

### DIFF
--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -121,11 +121,11 @@ endif ()
 # give more fine-grained control for hiding symbols, because sometimes
 # dependent libraries may not be well behaved and need extra hiding.
 #
-set (CXX_VISIBILITY_PRESET "hidden" CACHE STRING "Symbol visibility (hidden or default")
+set (CMAKE_CXX_VISIBILITY_PRESET "hidden" CACHE STRING "Symbol visibility (hidden or default")
 option (VISIBILITY_INLINES_HIDDEN "Hide symbol visibility of inline functions" ON)
 set (VISIBILITY_MAP_FILE "${PROJECT_SOURCE_DIR}/src/build-scripts/hidesymbols.map" CACHE FILEPATH "Visibility map file")
-set (C_VISIBILITY_PRESET ${CXX_VISIBILITY_PRESET})
-if (${CXX_VISIBILITY_PRESET} STREQUAL "hidden" AND VISIBILITY_MAP_FILE AND
+set (CMAKE_C_VISIBILITY_PRESET ${CMAKE_CXX_VISIBILITY_PRESET})
+if (${CMAKE_CXX_VISIBILITY_PRESET} STREQUAL "hidden" AND VISIBILITY_MAP_FILE AND
     (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG) AND
     (CMAKE_SYSTEM_NAME MATCHES "Linux|kFreeBSD" OR CMAKE_SYSTEM_NAME STREQUAL "GNU"))
     # Linux/FreeBSD/Hurd: also hide all the symbols of dependent libraries

--- a/src/include/OpenImageIO/texture.h
+++ b/src/include/OpenImageIO/texture.h
@@ -1852,6 +1852,9 @@ public:
 
     virtual ~TextureSystem () { }
 
+    // For testing -- do not use
+    static void unit_test_hash();
+
 protected:
     // User code should never directly construct or destruct a TextureSystem.
     // Always use TextureSystem::create() and TextureSystem::destroy().

--- a/src/testtex/testtex.cpp
+++ b/src/testtex/testtex.cpp
@@ -26,8 +26,6 @@
 #include <OpenImageIO/timer.h>
 #include <OpenImageIO/ustring.h>
 
-#include "../libtexture/imagecache_pvt.h"
-
 using namespace OIIO;
 
 using OIIO::_1;
@@ -1390,119 +1388,6 @@ test_getimagespec_gettexels(ustring filename)
 
 
 
-#ifndef OIIO_CODE_COVERAGE
-static void
-test_hash()
-{
-    std::vector<size_t> fourbits(1 << 4, 0);
-    std::vector<size_t> eightbits(1 << 8, 0);
-    std::vector<size_t> sixteenbits(1 << 16, 0);
-    std::vector<size_t> highereightbits(1 << 8, 0);
-
-    const size_t iters = 1000000;
-    const int res      = 4 * 1024;  // Simulate tiles from a 4k image
-    const int tilesize = 64;
-    const int nfiles   = iters / ((res / tilesize) * (res / tilesize));
-    Strutil::print("Testing hashing with {} files of {}x{} with {}x{} tiles:",
-                   nfiles, res, res, tilesize, tilesize);
-
-    ImageCache* imagecache = ImageCache::create();
-
-    // Set up the ImageCacheFiles outside of the timing loop
-    using OIIO::pvt::ImageCacheFile;
-    using OIIO::pvt::ImageCacheFileRef;
-    using OIIO::pvt::ImageCacheImpl;
-    std::vector<ImageCacheFileRef> icf;
-    for (int f = 0; f < nfiles; ++f) {
-        ustring filename = ustring::fmtformat("{:06}.tif", f);
-        icf.push_back(
-            new ImageCacheFile(*(ImageCacheImpl*)imagecache, NULL, filename));
-    }
-
-    // First, just try to do raw timings of the hash
-    Timer timer;
-    size_t i = 0, hh = 0;
-    for (int f = 0; f < nfiles; ++f) {
-        for (int y = 0; y < res; y += tilesize) {
-            for (int x = 0; x < res; x += tilesize, ++i) {
-                OIIO::pvt::TileID id(*icf[f], 0, 0, x, y, 0, 0, 1);
-                size_t h = id.hash();
-                hh += h;
-            }
-        }
-    }
-    Strutil::print("hh = {}\n", hh);
-    double time = timer();
-    double rate = (i / 1.0e6) / time;
-    Strutil::print("Hashing rate:` {:3.2f} Mhashes/sec\n", rate);
-
-    // Now, check the quality of the hash by looking at the low 4, 8, and
-    // 16 bits and making sure that they divide into hash buckets fairly
-    // evenly.
-    i = 0;
-    for (int f = 0; f < nfiles; ++f) {
-        for (int y = 0; y < res; y += tilesize) {
-            for (int x = 0; x < res; x += tilesize, ++i) {
-                OIIO::pvt::TileID id(*icf[f], 0, 0, x, y, 0, 0, 1);
-                size_t h = id.hash();
-                ++fourbits[h & 0xf];
-                ++eightbits[h & 0xff];
-                ++highereightbits[(h >> 24) & 0xff];
-                ++sixteenbits[h & 0xffff];
-                // if (i < 16) Strutil::print({:x}\n", h);
-            }
-        }
-    }
-
-    size_t min, max;
-    min = std::numeric_limits<size_t>::max();
-    max = 0;
-    for (int i = 0; i < 16; ++i) {
-        if (fourbits[i] < min)
-            min = fourbits[i];
-        if (fourbits[i] > max)
-            max = fourbits[i];
-    }
-    Strutil::print("4-bit hash buckets range from {} to {}\n", min, max);
-
-    min = std::numeric_limits<size_t>::max();
-    max = 0;
-    for (int i = 0; i < 256; ++i) {
-        if (eightbits[i] < min)
-            min = eightbits[i];
-        if (eightbits[i] > max)
-            max = eightbits[i];
-    }
-    Strutil::print("8-bit hash buckets range from {} to {}\n", min, max);
-
-    min = std::numeric_limits<size_t>::max();
-    max = 0;
-    for (int i = 0; i < 256; ++i) {
-        if (highereightbits[i] < min)
-            min = highereightbits[i];
-        if (highereightbits[i] > max)
-            max = highereightbits[i];
-    }
-    Strutil::print("higher 8-bit hash buckets range from {} to {}\n", min, max);
-
-    min = std::numeric_limits<size_t>::max();
-    max = 0;
-    for (int i = 0; i < (1 << 16); ++i) {
-        if (sixteenbits[i] < min)
-            min = sixteenbits[i];
-        if (sixteenbits[i] > max)
-            max = sixteenbits[i];
-    }
-    Strutil::print("16-bit hash buckets range from {} to {}\n", min, max);
-
-    Strutil::print("\n");
-
-    ImageCache::destroy(imagecache);
-}
-#endif
-
-
-
 static const char* workload_names[] = {
     /*0*/ "None",
     /*1*/ "Everybody accesses the same spot in one file (handles)",
@@ -1986,11 +1871,9 @@ main(int argc, const char* argv[])
         iters = 0;
     }
 
-#ifndef OIIO_CODE_COVERAGE
     if (testhash) {
-        test_hash();
+        TextureSystem::unit_test_hash();
     }
-#endif
 
     Imath::M33f scale;
     scale.scale(Imath::V2f(0.3, 0.3));


### PR DESCRIPTION
As Fabrice Macagno points out on the mail list, we weren't setting the correct variable name CMAKE_CXX_VISIBILITY_PRESET.

Fixing this -- and finally hiding all the symbols correctly -- uncovered an instance where testtex was relying on some classes that should have been hidden in libOpenImageIO. For symbol visibility reasons, move the functionality of testtex's test_hash() function to be in TextureSystem itself. This is a much cleaner separation.
