### PR TITLE
build(deps): fmt 10.0 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,7 +257,7 @@ jobs:
             cc_compiler: gcc-12
             cxx_compiler: g++-12
             cxx_std: 20
-            fmt_ver: 9.1.0
+            fmt_ver: 10.0.0
             openexr_ver: main
             pybind11_ver: master
             python_ver: "3.10"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -25,7 +25,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
  * libjpeg >= 8, or libjpeg-turbo >= 1.1 (tested through jpeg9d and jpeg-turbo
    2.1)
  * Boost >= 1.53 (recommended: at least 1.66; tested through 1.81)
- * [fmtlib](https://github.com/fmtlib/fmt) >= 6.1.2 (tested through 9.1). If
+ * [fmtlib](https://github.com/fmtlib/fmt) >= 6.1.2 (tested through 10.0). If
    not found at build time, this will be automatically downloaded unless the
    build sets `-DBUILD_MISSING_FMT=OFF`.
 

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -319,7 +319,7 @@ endmacro()
 option (BUILD_FMT_FORCE "Force local download/build of fmt even if installed" OFF)
 option (BUILD_MISSING_FMT "Local download/build of fmt if not installed" ON)
 option (INTERNALIZE_FMT "Copy fmt headers into <install>/include/OpenImageIO/detail/fmt" ON)
-set (BUILD_FMT_VERSION "9.1.0" CACHE STRING "Preferred fmtlib/fmt version, when downloading/building our own")
+set (BUILD_FMT_VERSION "9.0.0" CACHE STRING "Preferred fmtlib/fmt version, when downloading/building our own")
 
 macro (find_or_download_fmt)
     # If we weren't told to force our own download/build of fmt, look
@@ -356,3 +356,8 @@ macro (find_or_download_fmt)
 endmacro()
 
 find_or_download_fmt()
+
+if (FMT_VERSION VERSION_EQUAL 90100
+        AND GCC_VERSION VERSION_GREATER 0.0 AND NOT GCC_VERSION VERSION_GREATER 12.2)
+    message (WARNING "${ColorRed}fmt 9.1 is known to not work with gcc <= 7.2${ColorReset}")
+endif ()

--- a/src/include/CMakeLists.txt
+++ b/src/include/CMakeLists.txt
@@ -71,6 +71,9 @@ if (INTERNALIZE_FMT OR OIIO_USING_FMT_LOCAL)
          ${FMT_INCLUDES}/fmt/format.h
          ${FMT_INCLUDES}/fmt/ostream.h
          ${FMT_INCLUDES}/fmt/printf.h )
+    if (fmt_VERSION VERSION_GREATER_EQUAL 90000)
+        list (APPEND fmt_headers ${FMT_INCLUDES}/fmt/std.h)
+    endif ()
     file (COPY ${fmt_headers}
           DESTINATION ${CMAKE_BINARY_DIR}/include/OpenImageIO/detail/fmt)
 else ()
@@ -82,6 +85,11 @@ else ()
         file (WRITE "${CMAKE_BINARY_DIR}/include/OpenImageIO/detail/fmt/${f}"
                     "#include <fmt/${f}>")
     endforeach ()
+    if (fmt_VERSION VERSION_GREATER_EQUAL 90000)
+        list (APPEND fmt_headers ${CMAKE_BINARY_DIR}/include/OpenImageIO/detail/fmt/std.h)
+        file (WRITE "${CMAKE_BINARY_DIR}/include/OpenImageIO/detail/fmt/std.h"
+                    "#include <fmt/std.h>")
+    endif ()
 endif ()
 install (FILES ${fmt_headers}
          DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/detail/fmt

--- a/src/include/OpenImageIO/Imath.h.in
+++ b/src/include/OpenImageIO/Imath.h.in
@@ -6,8 +6,9 @@
 
 #pragma once
 
-#include <OpenImageIO/half.h>
 #include <OpenImageIO/detail/fmt.h>
+
+#include <OpenImageIO/half.h>
 
 #ifndef OIIO_IMATH_H_INCLUDED
 #define OIIO_IMATH_H_INCLUDED 1
@@ -30,7 +31,7 @@
 
 /// Custom fmtlib formatters for Imath types.
 
-namespace fmt {
+FMT_BEGIN_NAMESPACE
 template<> struct formatter<Imath::V2f>
     : OIIO::pvt::array_formatter<Imath::V2f, float, 2> {};
 template<> struct formatter<Imath::V3f>
@@ -45,6 +46,6 @@ template<> struct formatter<Imath::M33f>
     : OIIO::pvt::array_formatter<Imath::M33f, float, 9> {};
 template<> struct formatter<Imath::M44f>
     : OIIO::pvt::array_formatter<Imath::M44f, float, 16> {};
-} // namespace fmt
+FMT_END_NAMESPACE
 
 #endif // !defined(OIIO_IMATH_H_INCLUDED)

--- a/src/include/OpenImageIO/detail/fmt.h
+++ b/src/include/OpenImageIO/detail/fmt.h
@@ -26,6 +26,7 @@
 
 // fmt 8.1 stopped automatically enabling formatting of anything that supports
 // ostream output. This breaks a lot! Re-enable this old behavior.
+// NOTE: fmt 10.0 removed this support entirely.
 #ifndef FMT_DEPRECATED_OSTREAM
 #    define FMT_DEPRECATED_OSTREAM 1
 #endif

--- a/src/include/OpenImageIO/half.h.in
+++ b/src/include/OpenImageIO/half.h.in
@@ -15,3 +15,13 @@
 #else
 #    include <OpenEXR/half.h>
 #endif
+
+
+#if defined(FMT_VERSION) && !defined(OIIO_HALF_FORMATTER)
+#if FMT_VERSION >= 100000
+#define OIIO_HALF_FORMATTER
+FMT_BEGIN_NAMESPACE
+template<> struct formatter<half> : ostream_formatter {};
+FMT_END_NAMESPACE
+#endif
+#endif

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -3271,3 +3271,10 @@ void debug (const char* fmt, const T1& v1, const Args&... args)
 OIIO_API void _ImageIO_force_link ();
 
 OIIO_NAMESPACE_END
+
+
+#if FMT_VERSION >= 100000
+FMT_BEGIN_NAMESPACE
+template<> struct formatter<OIIO::ROI> : ostream_formatter {};
+FMT_END_NAMESPACE
+#endif

--- a/src/include/OpenImageIO/string_view.h
+++ b/src/include/OpenImageIO/string_view.h
@@ -486,6 +486,18 @@ basic_string_view<char>::c_str() const {
 OIIO_NAMESPACE_END
 
 
+#if FMT_VERSION >= 100000
+FMT_BEGIN_NAMESPACE
+template <> struct formatter<OIIO::string_view> : formatter<string_view>
+{
+    auto format(OIIO::string_view c, format_context& ctx) const {
+        return formatter<string_view>::format(string_view(c), ctx);
+    }
+};
+FMT_END_NAMESPACE
+#endif
+
+
 
 // Declare std::size and std::ssize for our string_view.
 namespace std {

--- a/src/include/OpenImageIO/strutil.h
+++ b/src/include/OpenImageIO/strutil.h
@@ -600,9 +600,7 @@ std::string join (const Sequence& seq, string_view sep /*= ""*/, size_t len)
 }
 
 /// Concatenate two strings, returning a std::string, implemented carefully
-/// to not perform any redundant copies or allocations. This is
-/// semantically equivalent to `Strutil::sprintf("%s%s", s, t)`, but is
-/// more efficient.
+/// to not perform any redundant copies or allocations.
 std::string OIIO_UTIL_API concat(string_view s, string_view t);
 
 /// Repeat a string formed by concatenating str n times.

--- a/src/include/OpenImageIO/typedesc.h
+++ b/src/include/OpenImageIO/typedesc.h
@@ -590,6 +590,11 @@ OIIO_NAMESPACE_END
 
 
 // Supply a fmtlib compatible custom formatter for TypeDesc.
+#if FMT_VERSION >= 100000
+FMT_BEGIN_NAMESPACE
+template<> struct formatter<OIIO::TypeDesc> : ostream_formatter {};
+FMT_END_NAMESPACE
+#else
 FMT_BEGIN_NAMESPACE
 template <>
 struct formatter<OIIO::TypeDesc> {
@@ -615,3 +620,4 @@ struct formatter<OIIO::TypeDesc> {
     }
 };
 FMT_END_NAMESPACE
+#endif

--- a/src/include/OpenImageIO/ustring.h
+++ b/src/include/OpenImageIO/ustring.h
@@ -687,9 +687,7 @@ public:
     }
 
     /// Concatenate two strings, returning a ustring, implemented carefully
-    /// to not perform any redundant copies or allocations. This is
-    /// semantically equivalent to `ustring::sprintf("%s%s", s, t)`, but is
-    /// more efficient.
+    /// to not perform any redundant copies or allocations.
     static ustring concat(string_view s, string_view t);
 
     /// Generic stream output of a ustring.

--- a/src/iv/imageviewer.cpp
+++ b/src/iv/imageviewer.cpp
@@ -877,7 +877,7 @@ ImageViewer::updateTitle()
         return;
     }
     std::string message;
-    message = Strutil::sprintf("%s - iv Image Viewer", img->name());
+    message = Strutil::fmt::format("{} - iv Image Viewer", img->name());
     setWindowTitle(QString::fromLocal8Bit(message.c_str()));
 }
 

--- a/src/iv/ivimage.cpp
+++ b/src/iv/ivimage.cpp
@@ -90,13 +90,14 @@ std::string
 IvImage::shortinfo() const
 {
     if (m_shortinfo.empty()) {
-        m_shortinfo = Strutil::sprintf("%d x %d", spec().width, spec().height);
+        m_shortinfo = Strutil::fmt::format("{} x {}", spec().width,
+                                           spec().height);
         if (spec().depth > 1)
-            m_shortinfo += Strutil::sprintf(" x %d", spec().depth);
-        m_shortinfo += Strutil::sprintf(" x %d channel %s (%.2f MB)",
-                                        spec().nchannels, m_file_dataformat,
-                                        (float)spec().image_bytes()
-                                            / (1024.0 * 1024.0));
+            m_shortinfo += Strutil::fmt::format(" x {}", spec().depth);
+        m_shortinfo += Strutil::fmt::format(" x {} channel {} ({:.2f} MB)",
+                                            spec().nchannels, m_file_dataformat,
+                                            (float)spec().image_bytes()
+                                                / (1024.0 * 1024.0));
     }
     return m_shortinfo;
 }

--- a/src/iv/ivinfowin.cpp
+++ b/src/iv/ivinfowin.cpp
@@ -56,7 +56,7 @@ IvInfoWindow::update(IvImage* img)
 {
     std::string newtitle;
     if (img) {
-        newtitle = Strutil::sprintf("%s - iv Info", img->name());
+        newtitle = Strutil::fmt::format("{} - iv Info", img->name());
         infoLabel->setText(img->longinfo().c_str());
     } else {
         newtitle = "iv Info";

--- a/src/libOpenImageIO/imageinout_test.cpp
+++ b/src/libOpenImageIO/imageinout_test.cpp
@@ -238,7 +238,7 @@ test_read_proxy(string_view formatname, string_view extension,
 
     // Read the in-memory file using an ioproxy, with ImageInput
     Filesystem::IOMemReader inproxy(readbuf);
-    std::string memname = Strutil::sprintf("mem.%s", extension);
+    std::string memname = Strutil::concat("mem.", extension);
     auto in             = ImageInput::open(memname, nullptr, &inproxy);
     OIIO_CHECK_ASSERT(in && "Failed to open input with proxy");
     if (in) {
@@ -286,7 +286,7 @@ test_write_unwritable(string_view extension, const ImageBuf& buf)
 {
     bool ok = true;
     Sysutil::Term term(stdout);
-    std::string bad_filename = Strutil::sprintf("bad/bad.%s", extension);
+    std::string bad_filename = Strutil::concat("bad/bad.", extension);
     std::cout << "    Writing bad to " << bad_filename << " ... ";
     auto badout = ImageOutput::create(bad_filename);
     if (badout) {
@@ -331,8 +331,8 @@ test_all_formats()
         //
         // Try writing the file
         //
-        std::string filename = Strutil::sprintf("imageinout_test-%s.%s",
-                                                formatname, extensions[0]);
+        std::string filename = Strutil::fmt::format("imageinout_test-{}.{}",
+                                                    formatname, extensions[0]);
         auto out             = ImageOutput::create(filename);
         if (!out) {
             std::cout << "  [skipping " << formatname << " -- no writer]\n";

--- a/src/libOpenImageIO/imageinput.cpp
+++ b/src/libOpenImageIO/imageinput.cpp
@@ -262,8 +262,8 @@ ImageInput::read_scanline(int y, int z, TypeDesc format, void* data,
     }
 
     if (!ok)
-        errorf("ImageInput::read_scanline : no support for format %s",
-               m_spec.format);
+        errorfmt("ImageInput::read_scanline : no support for format {}",
+                 m_spec.format);
     return ok;
 }
 
@@ -404,8 +404,8 @@ ImageInput::read_scanlines(int subimage, int miplevel, int ybegin, int yend,
             }
         }
         if (!ok)
-            errorf("ImageInput::read_scanlines : no support for format %s",
-                   spec.format);
+            errorfmt("ImageInput::read_scanlines : no support for format {}",
+                     spec.format);
         data = (char*)data + ystride * nscanlines;
     }
     return ok;
@@ -553,8 +553,8 @@ ImageInput::read_tile(int x, int y, int z, TypeDesc format, void* data,
     }
 
     if (!ok)
-        errorf("ImageInput::read_tile : no support for format %s",
-               m_spec.format);
+        errorfmt("ImageInput::read_tile : no support for format {}",
+                 m_spec.format);
     return ok;
 }
 

--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -958,7 +958,7 @@ stripdir_cmd_line(string_view cmdline)
         // Add the maybe-stripped string to the output, surrounding by
         // double quotes if it contains any spaces.
         if (stripped.find(' ') != std::string::npos)
-            out += Strutil::sprintf("\"%s\"", stripped);
+            out += Strutil::fmt::format("\"{}\"", stripped);
         else
             out += stripped;
         firstarg  = false;
@@ -1150,7 +1150,7 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
         }
     }
     stat_readtime += alltime.lap();
-    STATUS(Strutil::sprintf("read \"%s\"", src->name()), stat_readtime);
+    STATUS(Strutil::fmt::format("read \"{}\"", src->name()), stat_readtime);
 
     if (mode == ImageBufAlgo::MakeTxEnvLatlFromLightProbe) {
         ImageSpec newspec = src->spec();
@@ -1833,8 +1833,8 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
         if (out->supports("arbitrary_metadata")) {
             dstspec.attribute("oiio:ConstantColor", colstr);
         } else {
-            desc += Strutil::sprintf("%soiio:ConstantColor=%s",
-                                     desc.length() ? " " : "", colstr);
+            desc += Strutil::fmt::format("{}oiio:ConstantColor={}",
+                                         desc.length() ? " " : "", colstr);
             updatedDesc = true;
         }
         if (verbose)
@@ -1849,8 +1849,8 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
         } else {
             // if arbitrary metadata is not supported, cram it into the
             // ImageDescription.
-            desc += Strutil::sprintf("%soiio:AverageColor=%s",
-                                     desc.length() ? " " : "", avgstr);
+            desc += Strutil::fmt::format("{}oiio:AverageColor={}",
+                                         desc.length() ? " " : "", avgstr);
             updatedDesc = true;
         }
         if (verbose)

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -1904,8 +1904,8 @@ ImageCacheImpl::getstats(int level) const
         if (stats.unique_files) {
             print(out, "  Images : {} unique\n", stats.unique_files);
             print(out, "    ImageInputs : {} created, {} current, {} peak\n",
-                  m_stat_open_files_created, m_stat_open_files_current,
-                  m_stat_open_files_peak);
+                  int(m_stat_open_files_created),
+                  int(m_stat_open_files_current), int(m_stat_open_files_peak));
             print(out,
                   "    Total pixel data size of all images referenced : {}\n",
                   Strutil::memformat(stats.files_totalsize));
@@ -1945,8 +1945,8 @@ ImageCacheImpl::getstats(int level) const
                   Strutil::timeintervalformat(total_input_mutex_wait_time));
         if (m_stat_tiles_created > 0 || level > 2) {
             print(out, "  Tiles: {} created, {} current, {} peak\n",
-                  m_stat_tiles_created, m_stat_tiles_current,
-                  m_stat_tiles_peak);
+                  int(m_stat_tiles_created), int(m_stat_tiles_current),
+                  int(m_stat_tiles_peak));
             print(out, "    total tile requests : {}\n", stats.find_tile_calls);
             if (stats.find_tile_microcache_misses)
                 print(out, "    micro-cache misses : {} ({:.1f}%)\n",

--- a/src/libutil/argparse.cpp
+++ b/src/libutil/argparse.cpp
@@ -1063,8 +1063,8 @@ ArgParse::print_help() const
                     std::cout << "\n    " << std::string(maxlen + 2, ' ');
                 std::string h = opt->help();
                 if (m_impl->m_print_defaults && cparams().contains(opt->dest()))
-                    h += Strutil::sprintf(" (default: %s)",
-                                          cparams()[opt->dest()].get());
+                    h += Strutil::fmt::format(" (default: {})",
+                                              cparams()[opt->dest()].get());
                 std::cout << Strutil::wordwrap(h, columns - 2,
                                                (int)maxlen + 2 + 4 + 2);
                 std::cout << '\n';

--- a/src/libutil/fmath_test.cpp
+++ b/src/libutil/fmath_test.cpp
@@ -350,14 +350,14 @@ benchmark_convert_type()
     const S testval(1.0);
     std::vector<S> svec(size, testval);
     std::vector<D> dvec(size);
-    Strutil::printf("Benchmark conversion of %6s -> %6s : ",
-                    TypeDesc(BaseTypeFromC<S>::value),
-                    TypeDesc(BaseTypeFromC<D>::value));
+    Strutil::print("Benchmark conversion of {:6} -> {:6} : ",
+                   TypeDesc(BaseTypeFromC<S>::value).c_str(),
+                   TypeDesc(BaseTypeFromC<D>::value).c_str());
     float time = time_trial(bind(do_convert_type<S, D>, std::cref(svec),
                                  std::ref(dvec)),
                             ntrials, repeats)
                  / repeats;
-    Strutil::printf("%7.1f Mvals/sec\n", (size / 1.0e6) / time);
+    Strutil::print("{:7.1f} Mvals/sec\n", (size / 1.0e6) / time);
     D r = convert_type<S, D>(testval);
     OIIO_CHECK_EQUAL(dvec[size - 1], r);
 }
@@ -533,8 +533,8 @@ test_half_convert_accuracy()
              || bitcast<uint16_t, half>(h) != i)
             && Imath::finitef(H[i])) {
             ++nwrong;
-            Strutil::printf("wrong %d 0b%s  h=%g, f=%g %s\n", i, bin16(i), H[i],
-                            F[i], isnan(f) ? "(nan)" : "");
+            Strutil::print("wrong {} 0b{}  h={}, f={} {}\n", i, bin16(i), H[i],
+                           F[i], isnan(f) ? "(nan)" : "");
         }
     }
 

--- a/src/libutil/paramlist.cpp
+++ b/src/libutil/paramlist.cpp
@@ -303,11 +303,29 @@ formatType(const ParamValue& p, int beginindex, int endindex,
         for (int c = 0; c < (int)element.aggregate; ++c, ++f) {
             if (c)
                 out += " ";
-            out += Strutil::sprintf(formatString, f[0]);
+            out += Strutil::fmt::format(formatString, f[0]);
         }
     }
 }
 
+
+template<>
+void
+formatType<half>(const ParamValue& p, int beginindex, int endindex,
+                 const char* formatString, std::string& out)
+{
+    TypeDesc element = p.type().elementtype();
+    const half* f    = (const half*)p.data() + beginindex * element.aggregate;
+    for (int i = beginindex; i < endindex; ++i) {
+        if (i > beginindex)
+            out += ", ";
+        for (int c = 0; c < (int)element.aggregate; ++c, ++f) {
+            if (c)
+                out += " ";
+            out += Strutil::fmt::format(formatString, float(f[0]));
+        }
+    }
+}
 }  // namespace
 
 
@@ -345,47 +363,47 @@ ParamValue::get_string_indexed(int index) const
     if (element.basetype == TypeDesc::STRING) {
         return get<ustring>(index).string();
     } else if (element.basetype == TypeDesc::FLOAT) {
-        formatType<float>(*this, index, index + 1, "%g", out);
+        formatType<float>(*this, index, index + 1, "{}", out);
     } else if (element.basetype == TypeDesc::DOUBLE) {
-        formatType<double>(*this, index, index + 1, "%g", out);
+        formatType<double>(*this, index, index + 1, "{}", out);
     } else if (element.basetype == TypeDesc::HALF) {
-        formatType<half>(*this, index, index + 1, "%g", out);
+        formatType<half>(*this, index, index + 1, "{}", out);
     } else if (element.basetype == TypeDesc::INT) {
         if (element == TypeRational) {
             const int* val = (const int*)data() + 2 * index;
-            out            = Strutil::sprintf("%d/%d", val[0], val[1]);
+            out            = Strutil::fmt::format("{}/{}", val[0], val[1]);
         } else {
-            formatType<int>(*this, index, index + 1, "%d", out);
+            formatType<int>(*this, index, index + 1, "{}", out);
         }
     } else if (element.basetype == TypeDesc::UINT) {
         if (element.vecsemantics == TypeDesc::RATIONAL
             && element.aggregate == TypeDesc::VEC2) {
             const int* val = (const int*)data() + 2 * index;
-            out            = Strutil::sprintf("%d/%d", val[0], val[1]);
+            out            = Strutil::fmt::format("{}/{}}", val[0], val[1]);
         } else if (type() == TypeTimeCode) {
             out += tostring(TypeTimeCode, data());
         } else {
-            formatType<unsigned int>(*this, index, index + 1, "%u", out);
+            formatType<unsigned int>(*this, index, index + 1, "{}", out);
         }
     } else if (element.basetype == TypeDesc::UINT16) {
-        formatType<unsigned short>(*this, index, index + 1, "%u", out);
+        formatType<unsigned short>(*this, index, index + 1, "{}", out);
     } else if (element.basetype == TypeDesc::INT16) {
-        formatType<short>(*this, index, index + 1, "%d", out);
+        formatType<short>(*this, index, index + 1, "{}", out);
     } else if (element.basetype == TypeDesc::UINT64) {
-        formatType<unsigned long long>(*this, index, index + 1, "%u", out);
+        formatType<unsigned long long>(*this, index, index + 1, "{}", out);
     } else if (element.basetype == TypeDesc::INT64) {
-        formatType<long long>(*this, index, index + 1, "%d", out);
+        formatType<long long>(*this, index, index + 1, "{}", out);
     } else if (element.basetype == TypeDesc::UINT8) {
-        formatType<unsigned char>(*this, index, index + 1, "%d", out);
+        formatType<unsigned char>(*this, index, index + 1, "{}", out);
     } else if (element.basetype == TypeDesc::INT8) {
-        formatType<char>(*this, index, index + 1, "%d", out);
+        formatType<char>(*this, index, index + 1, "{}", out);
     } else if (element.basetype == TypeDesc::PTR) {
         out += "ptr ";
-        formatType<void*>(*this, index, index + 1, "%p", out);
+        formatType<void*>(*this, index, index + 1, "{:p}", out);
     } else {
-        out += Strutil::sprintf("<unknown data type> (base %d, agg %d vec %d)",
-                                type().basetype, type().aggregate,
-                                type().vecsemantics);
+        out += Strutil::fmt::format(
+            "<unknown data type> (base {:d}, agg {:d} vec {:d})",
+            type().basetype, type().aggregate, type().vecsemantics);
     }
     return out;
 }

--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -415,7 +415,7 @@ Strutil::wordwrap(string_view src, int columns, int prefix, string_view sep,
         return src;  // give up, no way to make it wrap
     std::ostringstream out;
     columns -= prefix;  // now columns is the real width we have to work with
-    std::string allsep = Strutil::sprintf("%s%s", sep, presep);
+    std::string allsep = Strutil::concat(sep, presep);
     while ((int)src.length() > columns) {
         // Find the last `sep` break before the column limit.
         size_t breakpoint = src.find_last_of(allsep, columns);

--- a/src/libutil/strutil_test.cpp
+++ b/src/libutil/strutil_test.cpp
@@ -307,7 +307,7 @@ test_get_rest_arguments()
 void
 test_escape(string_view raw, string_view escaped)
 {
-    Strutil::printf ("escape '%s' <-> '%s'\n", raw, escaped);
+    Strutil::print("escape '{}' <-> '{}'\n", raw, escaped);
     OIIO_CHECK_EQUAL(Strutil::escape_chars(raw), escaped);
     OIIO_CHECK_EQUAL(Strutil::unescape_chars(escaped), raw);
 }

--- a/src/libutil/typedesc.cpp
+++ b/src/libutil/typedesc.cpp
@@ -7,6 +7,8 @@
 #include <cstdlib>
 #include <string>
 
+#include <OpenImageIO/detail/fmt.h>
+
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/half.h>
 #include <OpenImageIO/strutil.h>
@@ -372,7 +374,7 @@ tostring_formatting::tostring_formatting(
 
 
 
-template<class T>
+template<class T, class Cast = T>
 static std::string
 sprint_type(TypeDesc type, const char* format, const tostring_formatting& fmt,
             const T* v)
@@ -385,7 +387,7 @@ sprint_type(TypeDesc type, const char* format, const tostring_formatting& fmt,
         if (type.aggregate > 1)
             val += fmt.aggregate_begin;
         for (int j = 0; j < (int)type.aggregate; ++j, ++v) {
-            val += Strutil::sprintf(format, *v);
+            val += Strutil::sprintf(format, static_cast<Cast>(*v));
             if (type.aggregate > 1 && j < type.aggregate - 1)
                 val += fmt.aggregate_sep;
         }
@@ -601,7 +603,8 @@ tostring(TypeDesc type, const void* data, const tostring_formatting& fmt)
                    : format_type(type, fmt.int_fmt, fmt, (const int64_t*)data);
     case TypeDesc::HALF:
         return fmt.use_sprintf
-                   ? sprint_type(type, fmt.float_fmt, fmt, (const half*)data)
+                   ? sprint_type<half, float>(type, fmt.float_fmt, fmt,
+                                              (const half*)data)
                    : format_type(type, fmt.float_fmt, fmt, (const half*)data);
     case TypeDesc::FLOAT:
         return fmt.use_sprintf

--- a/src/libutil/ustring_test.cpp
+++ b/src/libutil/ustring_test.cpp
@@ -17,6 +17,10 @@
 #include <OpenImageIO/unittest.h>
 #include <OpenImageIO/ustring.h>
 
+#if FMT_VERSION >= 90000
+#    include <OpenImageIO/detail/fmt/std.h>
+#endif
+
 
 using namespace OIIO;
 

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -7336,7 +7336,7 @@ main(int argc, char* argv[])
             Strutil::print(stderr,
                            "Bad half conversion, code {} {} -> {} "
                            "(suspect badly set DENORMS_ZERO_MODE)\n",
-                           bad[0], h[0], vf[0]);
+                           bad[0], float(h[0]), vf[0]);
     }
 
     // Helpful for debugging to make sure that any crashes dump a stack

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -869,10 +869,10 @@ public:
         cleanup();
 
         if (ot.debug) {
-            Strutil::printf("    %s took %s  (total time %s, mem %s)\n",
-                            opname(), Strutil::timeintervalformat(timer(), 2),
-                            Strutil::timeintervalformat(ot.total_runtime(), 2),
-                            Strutil::memformat(Sysutil::memory_used()));
+            Strutil::print("    {} took {}  (total time {}, mem {})\n",
+                           opname(), Strutil::timeintervalformat(timer(), 2),
+                           Strutil::timeintervalformat(ot.total_runtime(), 2),
+                           Strutil::memformat(Sysutil::memory_used()));
         }
         return 0;
     }

--- a/src/oiiotool/printinfo.cpp
+++ b/src/oiiotool/printinfo.cpp
@@ -15,6 +15,9 @@
 #    include <io.h>
 #endif
 
+#include <OpenImageIO/detail/fmt.h>
+#include <OpenImageIO/half.h>
+
 #include "oiiotool.h"
 
 #include <OpenImageIO/Imath.h>
@@ -31,6 +34,17 @@ using namespace OIIO::pvt;
 using namespace OiioTool;
 using namespace ImageBufAlgo;
 
+
+// clang-format off
+#if defined(FMT_VERSION) && !defined(OIIO_HALF_FORMATTER)
+#if FMT_VERSION >= 100000
+#define OIIO_HALF_FORMATTER
+FMT_BEGIN_NAMESPACE
+template<> struct formatter<half> : ostream_formatter { };
+FMT_END_NAMESPACE
+#endif
+#endif
+// clang-format on
 
 
 template<typename T>

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -996,8 +996,8 @@ OpenEXRInput::PartInfo::query_channels(OpenEXRInput* in,
             spec.z_channel = c;
         if (cnh[c].xSampling != 1 || cnh[c].ySampling != 1) {
             ok = false;
-            in->errorf(
-                "Subsampled channels are not supported (channel \"%s\" has sampling %d,%d).",
+            in->errorfmt(
+                "Subsampled channels are not supported (channel \"{}\" has sampling {},{}).",
                 cnh[c].fullname, cnh[c].xSampling, cnh[c].ySampling);
             // FIXME: Some day, we should handle channel subsampling.
         }

--- a/src/openexr.imageio/exrinput_c.cpp
+++ b/src/openexr.imageio/exrinput_c.cpp
@@ -956,8 +956,8 @@ OpenEXRCoreInput::PartInfo::query_channels(OpenEXRCoreInput* in,
             spec.z_channel = c;
         if (cnh[c].xSampling != 1 || cnh[c].ySampling != 1) {
             ok = false;
-            in->errorf(
-                "Subsampled channels are not supported (channel \"%s\" has sampling %d,%d).",
+            in->errorfmt(
+                "Subsampled channels are not supported (channel \"{}\" has sampling {},{}).",
                 cnh[c].fullname, cnh[c].xSampling, cnh[c].ySampling);
             // FIXME: Some day, we should handle channel subsampling.
         }

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -1034,8 +1034,8 @@ OpenEXROutput::put_parameter(const std::string& name, TypeDesc type,
     // Now if we still don't match a specific type OpenEXR is looking for,
     // skip it.
     if (exrtype != TypeDesc() && !exrtype.equivalent(type)) {
-        OIIO::debugf(
-            "OpenEXR output metadata \"%s\" type mismatch: expected %s, got %s\n",
+        OIIO::debugfmt(
+            "OpenEXR output metadata \"{}\" type mismatch: expected {}, got {}\n",
             name, exrtype, type);
         return false;
     }
@@ -1303,12 +1303,12 @@ OpenEXROutput::put_parameter(const std::string& name, TypeDesc type,
 #endif
         }
     } catch (const std::exception& e) {
-        OIIO::debugf("Caught OpenEXR exception: %s\n", e.what());
+        OIIO::debugfmt("Caught OpenEXR exception: {}\n", e.what());
     } catch (...) {  // catch-all for edge cases or compiler bugs
         OIIO::debug("Caught unknown OpenEXR exception\n");
     }
 
-    OIIO::debugf("Don't know what to do with %s %s\n", type, xname);
+    OIIO::debugfmt("Don't know what to do with {} {}\n", type, xname);
     return false;
 }
 

--- a/src/testtex/testtex.cpp
+++ b/src/testtex/testtex.cpp
@@ -1247,8 +1247,8 @@ env_region_batch(ImageBuf& image, ustring filename, MappingEnvWide mapping,
 static void
 test_environment(ustring filename, MappingEnv mapping)
 {
-    Strutil::print("Testing environment {}, output = {}\n", filename,
-                   output_filename);
+    Strutil::sync::print("Testing environment {}, output = {}\n", filename,
+                         output_filename);
     int nchannels = nchannels_override ? nchannels_override : 4;
     ImageSpec outspec(output_xres, output_yres, nchannels, TypeDesc::FLOAT);
     ImageBuf image(outspec);
@@ -1297,8 +1297,8 @@ test_environment(ustring filename, MappingEnv mapping)
 static void
 test_environment_batch(ustring filename, MappingEnvWide mapping)
 {
-    Strutil::print("Testing BATCHED environment {}, output = {}\n", filename,
-                   output_filename);
+    Strutil::sync::print("Testing BATCHED environment {}, output = {}\n",
+                         filename, output_filename);
     int nchannels = nchannels_override ? nchannels_override : 4;
     ImageSpec outspec(output_xres, output_yres, nchannels, TypeDesc::FLOAT);
     ImageBuf image(outspec);
@@ -1904,7 +1904,7 @@ main(int argc, const char* argv[])
     OIIO::attribute("threads", nthreads);
 
     texsys = TextureSystem::create();
-    Strutil::print("Created texture system\n");
+    Strutil::sync::print("Created texture system\n");
     if (texoptions.size())
         texsys->attribute("options", texoptions);
     texsys->attribute("autotile", autotile);


### PR DESCRIPTION
fmt 10.0 was recently released, and it breaks a lot for us because they have fully removed legacy support for automatically being able to format anything that has an iostream `<<` operator. This facility was deprecatd in 8.1 but could be re-enabled with FMT_DEPRECATED_OSTREAM, but even that was removed in 10.0.

So this means that we had to write several explicit format handlers for some types for use with format() and print().

Also, they are even more strict with sprintf/printf which don't honor the custom formatters as far as I can tell, so in several cases I also switched those to the std::format/print style.

Fixes #3835 
