### PR TITLE
fix(oiiotool): don't propagate unsupported channels

### DIFF
--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -995,6 +995,7 @@ DateTime_to_time_t(string_view datetime, time_t& timet)
 
 
 
+#if 0
 // For a comma-separated list of channel names (e.g., "B,G,R,A"), compute
 // the vector of integer indices for those channels as found in the spec
 // (e.g., {2,1,0,3}), using -1 for any channels whose names were not found
@@ -1031,6 +1032,20 @@ parse_channels(const ImageSpec& spec, string_view chanlist,
             break;
     }
     return ok;
+}
+#endif
+
+
+static std::string
+first_n_channels(const ImageSpec& spec, int n)
+{
+    std::string s;
+    for (int i = 0; i < n; ++i) {
+        if (i)
+            s += ",";
+        s += spec.channel_name(i);
+    }
+    return s;
 }
 
 
@@ -2955,6 +2970,8 @@ public:
         auto newchannelnames   = Strutil::splits(channelarg, ",");
         ImageSpec& spec        = img[0]->specmod();
         spec.channelnames.resize(spec.nchannels);
+        spec.alpha_channel = -1;
+        spec.z_channel     = -1;
         for (int c = 0; c < spec.nchannels; ++c) {
             if (c < (int)newchannelnames.size() && newchannelnames[c].size()) {
                 std::string name = newchannelnames[c];
@@ -5657,21 +5674,32 @@ output_file(int /*argc*/, const char* argv[])
 
     timer.stop();  // resume after all these auto-transforms
 
-    // Automatically drop channels we can't support in output
-    if ((ir->spec()->nchannels > 4 && !out->supports("nchannels"))
-        || (ir->spec()->nchannels > 3 && !out->supports("alpha"))) {
-        bool alpha = (ir->spec()->nchannels > 3 && out->supports("alpha"));
-        const char* chanlist = alpha ? "R,G,B,A" : "R,G,B";
-        std::vector<int> channels;
-        bool found = parse_channels(*ir->spec(), chanlist, channels);
-        if (!found)
-            chanlist = alpha ? "0,1,2,3" : "0,1,2";
-        const char* argv[] = { "channels:allsubimages=1", chanlist };
-        int action_channels(int argc, const char* argv[]);  // forward decl
-        action_channels(2, argv);
-        ot.warningfmt(command, "Can't save {} channels to {}... saving only {}",
-                      ir->spec()->nchannels, out->format_name(), chanlist);
-        ir = ot.curimg;
+    // Automatically drop channels we can't support in output.
+    int nchans = ir->spec()->nchannels;
+    if (nchans > 3) {
+        int trimchans = nchans;
+        bool chan3_is_alpha
+            = (nchans > 3
+               && (ir->spec()->alpha_channel == 3
+                   || Strutil::iequals(ir->spec()->channel_name(3), "A")
+                   || Strutil::iequals(ir->spec()->channel_name(3), "Alpha")));
+        if (nchans > 4 && !out->supports("nchannels"))
+            trimchans = 4;
+        if ((chan3_is_alpha && !out->supports("alpha"))
+            || (!chan3_is_alpha && !out->supports("nchannels")))
+            trimchans = 3;
+        if (trimchans < nchans) {
+            std::string chanlist = first_n_channels(*ir->spec(), trimchans);
+            ot.warningfmt(
+                command,
+                "Can't save {} channels to {}... saving only channels {}",
+                ir->spec()->nchannels, out->format_name(), chanlist);
+            const char* argv[] = { "channels:allsubimages=1",
+                                   chanlist.c_str() };
+            int action_channels(int argc, const char* argv[]);  // forward decl
+            action_channels(2, argv);
+            ir = ot.curimg;
+        }
     }
 
     // Handle --autotrim

--- a/testsuite/oiiotool-copy/ref/out.txt
+++ b/testsuite/oiiotool-copy/ref/out.txt
@@ -28,6 +28,7 @@ combining images result:
 tmp.tif              :  128 x  128, 3 channel, uint8 tiff
     tile size: 16 x 16
 
+oiiotool WARNING: -o : Can't save 4 channels to png... saving only channels R,G,B
 Reading green.exr
 green.exr            :   64 x   64, 3 channel, half openexr
     SHA-1: 8B61993247469F3C208CA894D71856727B11606A

--- a/testsuite/oiiotool-copy/run.py
+++ b/testsuite/oiiotool-copy/run.py
@@ -47,6 +47,10 @@ command += oiiotool ("uint8.tif copy_uint16.tif -siappend -o tmp.tif " +
 command += oiiotool ("-pattern checker 128x128 3 uint8.tif -add -o tmp.tif " +
                      "-echo \"combining images result: \" -metamatch \"width|tile\" -i:info=2 tmp.tif -echo \"\"")
 
+# Try to copy extra channels to a file that doesn't support it -- we should get
+# a warning message about only saving the first 3 channels.
+command += oiiotool ("--pattern constant:color=0.1,0.2,0.3,0.4 64x64 4 --chnames R,G,B,X -d uint8 -o rgbx.png")
+
 # test --crop
 command += oiiotool ("../common/grid.tif --crop 100x400+50+200 -o crop.tif")
 


### PR DESCRIPTION
Fixes #3837

oiiotool already attempted to trim extra channels when outputting to a format that can't support it. It correctly handled the two common cases:

* More than 4 channels for formats that don't have `supports("nchannels")` will drop after the first 4 channels.
* More than 3 channels for formats that don't have `supports("alpha")` will drop after the first 3 channels.

But this omits an interesting (but rare) corner case: a 4 channel file where the last channel is NOT alpha, and the output file supports an alpha channel but not arbitrary channels. A concrete example might be an input file that is exr with channels R, G, B, Z, writing to a PNG file (which can support RGB or RGBA). We wouldn't want to write what appears to be an RGBA file if that last channel isn't really alpha.

Also, noticed that oiiotool --chnames didn't properly clear the alpha_channel and z_channel flags, which is important if the new channel lists drop one of those channels.
