### PR TITLE
fix(int): prevent possible deadlock when reaading files with wrong extensions

### DIFF
--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -36,7 +36,7 @@ threads_default()
 
 // Global private data
 namespace pvt {
-mutex imageio_mutex;
+std::recursive_mutex imageio_mutex;
 atomic_int oiio_threads(threads_default());
 atomic_int oiio_exr_threads(threads_default());
 atomic_int oiio_read_chunk(256);

--- a/src/libOpenImageIO/imageio_pvt.h.in
+++ b/src/libOpenImageIO/imageio_pvt.h.in
@@ -26,7 +26,7 @@ struct PixelStats;
 namespace pvt {
 
 // Mutex allowing thread safety of the ImageIO internals below
-extern mutex imageio_mutex;
+extern std::recursive_mutex imageio_mutex;
 
 extern atomic_int oiio_threads;
 extern atomic_int oiio_read_chunk;


### PR DESCRIPTION
Make pvt::imageio_mutex be a recursive_mutex

Fixes #3842
