### PR TITLE
refactor(oiiotool): Get rid of the global Oiiotool singleton.

### DIFF
--- a/src/oiiotool/imagerec.cpp
+++ b/src/oiiotool/imagerec.cpp
@@ -262,6 +262,7 @@ ImageRec::read(ReadPolicy readpolicy, string_view channel_set)
     }
     m_subimages.resize(subimages);
     bool allok = true;
+    ErrorHandler eh;
     for (int s = 0; s < subimages; ++s) {
         int miplevels = 0;
         m_imagecache->get_image_info(uname, s, 0, u_miplevels, TypeInt,
@@ -296,7 +297,7 @@ ImageRec::read(ReadPolicy readpolicy, string_view channel_set)
             if (channel_set.size()) {
                 decode_channel_set(ib->nativespec(), channel_set,
                                    newchannelnames, channel_set_channels,
-                                   channel_set_values);
+                                   channel_set_values, eh);
                 for (size_t c = 0, e = channel_set_channels.size(); c < e;
                      ++c) {
                     if (channel_set_channels[c] < 0)

--- a/testsuite/oiiotool-copy/ref/out.txt
+++ b/testsuite/oiiotool-copy/ref/out.txt
@@ -1,7 +1,7 @@
-oiiotool WARNING: --ch : Unknown channel name "Z", filling with 0 (actual channels: "R,G,B")
-oiiotool WARNING: --ch : Unknown channel name "R", filling with 0 (actual channels: "Z")
-oiiotool WARNING: --ch : Unknown channel name "G", filling with 0 (actual channels: "Z")
-oiiotool WARNING: --ch : Unknown channel name "B", filling with 0 (actual channels: "Z")
+WARNING: --ch: Unknown channel name "Z", filling with 0 (actual channels: "R,G,B")
+WARNING: --ch: Unknown channel name "R", filling with 0 (actual channels: "Z")
+WARNING: --ch: Unknown channel name "G", filling with 0 (actual channels: "Z")
+WARNING: --ch: Unknown channel name "B", filling with 0 (actual channels: "Z")
 explicit -d uint save result: 
 uint8.tif            :  128 x  128, 3 channel, uint8 tiff
     tile size: 16 x 16


### PR DESCRIPTION
Make all oiiotool actions take ot as a parameter.

This is a necessary first step to being able to parallelize over frame ranges.

Also finally convert the last of the `int argc, const char**argv` idioms to `cspan<const char*>`.
