### PR TITLE
feat(OpenCV): Improve OpenCV support -- errors, version, half

### DIFF
--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -2354,22 +2354,22 @@ bool OIIO_API make_texture (MakeTextureMode mode,
 /// @}
 
 
-/// Convert an OpenCV cv::Mat into an ImageBuf, copying the pixels
-/// (optionally converting to the pixel data type specified by `convert`, if
-/// not UNKNOWN, which means to preserve the original data type if
-/// possible).  Return true if ok, false if it couldn't figure out how to
-/// make the conversion from Mat to ImageBuf. If OpenImageIO was compiled
-/// without OpenCV support, this function will return an empty image with
-/// error message set.
+/// Convert an OpenCV cv::Mat into an ImageBuf, copying the pixels (optionally
+/// converting to the pixel data type specified by `convert`, if not UNKNOWN,
+/// which means to preserve the original data type if possible).  Return true
+/// if ok, false if it was not able to make the conversion from Mat to
+/// ImageBuf. Any error messages can be retrieved by calling `geterror()` on
+/// the returned ImageBuf. If OpenImageIO was compiled without OpenCV support,
+/// this function will return false.
 OIIO_API ImageBuf
 from_OpenCV (const cv::Mat& mat, TypeDesc convert = TypeUnknown,
              ROI roi={}, int nthreads=0);
 
 /// Construct an OpenCV cv::Mat containing the contents of ImageBuf src, and
-/// return true. If it is not possible, or if OpenImageIO was compiled
-/// without OpenCV support, then return false. Note that OpenCV only
-/// supports up to 4 channels, so >4 channel images will be truncated in the
-/// conversion.
+/// return true. If it is not possible, or if OpenImageIO was compiled without
+/// OpenCV support, then return false. Any error messages can be retrieved by
+/// calling OIIO::geterror(). Note that OpenCV only supports up to 4 channels,
+/// so >4 channel images will be truncated in the conversion.
 OIIO_API bool to_OpenCV (cv::Mat& dst, const ImageBuf& src,
                          ROI roi={}, int nthreads=0);
 

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -2984,6 +2984,12 @@ inline bool attribute (string_view name, string_view val) {
 ///   OpenImageiO, or "0.0.0" if no OpenColorIO support has been enabled.
 ///   (Added in OpenImageIO 2.4.6)
 ///
+/// - `int opencv_version`
+///
+///   Returns the encoded version (such as 40701 for 4.7.1) of the OpenCV that
+///   is used by OpenImageIO, or 0 if no OpenCV support has been enabled.
+///   (Added in OpenImageIO 2.5.2)
+///
 /// - `string hw:simd`
 /// - `string oiio:simd` (read-only)
 ///

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -516,6 +516,10 @@ getattribute(string_view name, TypeDesc type, void* val)
                                             (v >> 16) & 0xff, (v >> 8) & 0xff);
         return true;
     }
+    if (name == "opencv_version" && type == TypeInt) {
+        *(int*)val = OIIO::pvt::opencv_version;
+        return true;
+    }
     return false;
 }
 

--- a/src/libOpenImageIO/imageio_pvt.h.in
+++ b/src/libOpenImageIO/imageio_pvt.h.in
@@ -43,6 +43,7 @@ extern int oiio_log_times;
 extern int openexr_core;
 extern int limit_channels;
 extern int limit_imagesize_MB;
+extern int opencv_version;
 extern OIIO_UTIL_API int oiio_use_tbb; // This lives in libOpenImageIO_Util
 OIIO_API const std::vector<std::string>& font_dirs();
 OIIO_API const std::vector<std::string>& font_file_list();


### PR DESCRIPTION
Various improvements to OpenCV support:

* IBA::from_OpenCV and to_OpenCV now set error messages for every type of failure they encounter, instead of returning false with no explanation. For from_OpenCV, the error message can be retrieved from the ImageBuf returned; for to_OpenCV, the error message can be retrieved from the global OIIO::geterror(). Several assertions were removed, instead relying on error return codes and messages.

* Add global OIIO attribute "opencv_version" which allows you to find out what version of OpenCV OIIO was built against, which was previously impossible to know without seeing the build-time status messages. This can be retrieved via

      OIIO::get_int_attribute("opencv_version")

  and also you can find out from the command line with

      oiiotool --echo "{getattribute(opencv_version)}"

  The return value is an integer encoded as `10000*major + 100*minor + patch`, and it will return 0 if no OpenCV support was enabled when OpenImageIO was built.

* For OpenCV >= 4.0, to_OpenCV can now correctly construct a 'half' matrix. For OpenCV 3.x, we turn it into a float matrix as before, since CV_16F was only supported starting in 4.0.

