### PR TITLE
build(Mac): Fixes for latest xcode on MacOS 13.3 Ventura

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -402,6 +402,13 @@ jobs:
             python_ver: "3.10"
             aclang: 13
             setenvs: export CTEST_TEST_TIMEOUT=600
+          - desc: MacOS-13
+            os: macos-13
+            nametag: macos13-py311
+            cxx_std: 20
+            python_ver: "3.11"
+            aclang: 14
+            setenvs: export CTEST_TEST_TIMEOUT=600
     runs-on: ${{ matrix.os }}
     env:
       CC: clang

--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -2340,7 +2340,8 @@ TextureSystemImpl::sample_bilinear(
         else
             tile_st %= tilewh;
         OIIO_PRAGMA_WARNING_PUSH
-#if OIIO_CLANG_VERSION >= 140000 || OIIO_INTEL_CLANG_VERSION >= 140000
+#if OIIO_CLANG_VERSION >= 140000 || OIIO_INTEL_CLANG_VERSION >= 140000 \
+    || OIIO_APPLE_CLANG_VERSION >= 140000
         OIIO_CLANG_PRAGMA(GCC diagnostic ignored "-Wbitwise-instead-of-logical")
 #endif
         bool s_onetile = (tile_st[S0] != tilewhmask[S0])


### PR DESCRIPTION
I found that this was needed after weekend OS update of my laptop.

Also added MacOS-13 CI test.

