### PR TITLE
ci: Get icc tests working again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,20 +94,22 @@ jobs:
             simd: "avx2,f16c"
             fmt_ver: 8.1.1
             pybind11_ver: v2.8.1
-          - desc: icc/C++17 py3.9 boost1.76 exr3.1 ocio2.1 qt5.15
-            nametag: linux-vfx2022-icc
-            os: ubuntu-latest
-            vfxyear: 2022
-            cxx_std: 17
-            python_ver: 3.9
-            # simd: "avx2,f16c"
-            fmt_ver: 7.1.3
-            # icc MUST use this older FMT version
-            pybind11_ver: v2.9.0
-            setenvs: export USE_ICC=1 USE_OPENVDB=0
-                            OIIO_EXTRA_CPP_ARGS="-fp-model=precise"
-            # For icc, use fp-model precise to eliminate needless LSB errors
-            # that make test results differ from other platforms.
+          # FIXME: Disable this test because we can't seem to find a freely
+          # installable icc that will run on these machine images.
+          # - desc: icc/C++17 py3.9 boost1.76 exr3.1 ocio2.1 qt5.15
+          #   nametag: linux-vfx2022-icc
+          #   os: ubuntu-latest
+          #   vfxyear: 2022
+          #   cxx_std: 17
+          #   python_ver: 3.9
+          #   # simd: "avx2,f16c"
+          #   fmt_ver: 7.1.3
+          #   # icc MUST use this older FMT version
+          #   pybind11_ver: v2.9.0
+          #   setenvs: export USE_ICC=1 USE_OPENVDB=0
+          #                   OIIO_EXTRA_CPP_ARGS="-fp-model=precise"
+          #   # For icc, use fp-model precise to eliminate needless LSB errors
+          #   # that make test results differ from other platforms.
           - desc: icx/C++17 py3.9 boost1.76 exr3.1 ocio2.1 qt5.15
             nametag: linux-vfx2022-icx
             os: ubuntu-latest
@@ -313,6 +315,20 @@ jobs:
             openexr_ver: v2.5.8
             pybind11_ver: v2.5.0
             simd: avx
+          - desc: icc/C++17 py3.10 boost1.74 exr3.1 ocio1.1 qt5.15
+            nametag: linux-icc
+            os: ubuntu-22.04
+            cxx_std: 17
+            # simd: avx2,f16c
+            # fmt_ver: 7.1.3
+            # icc MUST use this older FMT version
+            openexr_ver: v3.1.7
+            pybind11_ver: v2.10.0
+            python_ver: "3.10"
+            setenvs: export USE_ICC=1 USE_OPENVDB=0
+                            OIIO_EXTRA_CPP_ARGS="-fp-model=precise"
+            # For icc, use fp-model precise to eliminate needless LSB errors
+            # that make test results differ from other platforms.
           - desc: static libs gcc7 C++14 exr2.4
             nametag: linux-static
             os: ubuntu-20.04

--- a/testsuite/tiff-misc/ref/out-libtiff430b.txt
+++ b/testsuite/tiff-misc/ref/out-libtiff430b.txt
@@ -1,0 +1,29 @@
+Reading src/separate.tif
+src/separate.tif     :  128 x  128, 3 channel, uint8 tiff
+    SHA-1: 486088DECAE711C444FDCAB009C378F7783AD9C5
+    channel list: R, G, B
+    compression: "zip"
+    DateTime: "2020:10:25 15:32:04"
+    Orientation: 1 (normal)
+    planarconfig: "separate"
+    Software: "OpenImageIO 2.3.0dev : oiiotool --pattern fill:topleft=0,0,0:topright=1,0,0:bottomleft=0,1,0:bottomright=1,1,1 128x128 3 --planarconfig separate -scanline -attrib tiff:rowsperstrip 17 -d uint8 -o separate.tif"
+    oiio:BitsPerSample: 8
+    tiff:Compression: 8
+    tiff:PhotometricInterpretation: 2
+    tiff:PlanarConfiguration: 2
+    tiff:RowsPerStrip: 7
+Comparing "src/separate.tif" and "separate.tif"
+PASS
+oiiotool ERROR: read : No support for data format of "src/corrupt1.tif"
+Full command line was:
+> oiiotool --oiioattrib try_all_readers 0 --info -v src/corrupt1.tif
+oiiotool ERROR: read : File does not exist: "src/crash-1633.tif"
+Full command line was:
+> oiiotool --oiioattrib try_all_readers 0 --info -v src/crash-1633.tif
+oiiotool ERROR: read : File does not exist: "src/crash-1643.tif"
+Full command line was:
+> oiiotool --oiioattrib try_all_readers 0 --info src/crash-1643.tif -o out.exr
+iconvert ERROR copying "src/crash-1709.tif" to "crash-1709.exr" :
+	Decoding error at scanline 0
+Comparing "check1.tif" and "ref/check1.tif"
+PASS


### PR DESCRIPTION
For a couple years, we installed the
intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic package from Intel's yum repo https://yum.repos.intel.com/oneapi to get a copy of icc and icx to test against.

This broke in January 2023 when Intel bumped the version of the package and the new package's icc (but curiously not icx) wouldn't run on the CentOS images and complained about

    /opt/intel/oneapi/compiler/2023.1.0/linux/bin/intel64/icpc: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.21' not found (required by /opt/intel/oneapi/compiler/2023.1.0/linux/bin/intel64/icpc)

In https://github.com/OpenImageIO/oiio/pull/3744, we tried to combat this by locking down to a specific version of icc 2022.1 that was known to work and that we used to use until the default version was bumped.

But in April 2023, the 2022.1.0-3768 package seemed to disappear from the repository entirely, so we're back to being unable to install icc and test against it from any of the ASWF VFX Platform compliant containers. So in this patch, we disable that part of the CI testing.

However, with some tinkering, I was able to use that icc package from the plain Ubuntu 22.04 environment (just not from the VFX Platform compliant container). So set that up so we're still testing icc somehow.

icx has been fine all along, this doesn't change anything about how we test icx, which is still done in the VFX Platform 2022 container.
