### PR TITLE
raw input: fix user_flip usage

### DIFF
--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -436,20 +436,13 @@ RawInput::open_raw(bool unpack, const std::string& name,
     // Store flip before it is potentially overwritten
     // LibRaw's convention for flip values differs from Exif orientation tags
     // so we need to convert it
-    int original_flip                 = 1;
-    int libraw_flip                   = m_processor->imgdata.sizes.flip;
+    int original_flip = 1;
+    int libraw_flip   = m_processor->imgdata.sizes.flip;
     switch (libraw_flip) {
-        case 3:
-            original_flip             = 3;
-            break;
-        case 5:
-            original_flip             = 8;
-            break;
-        case 6:
-            original_flip             = 6;
-            break;
-        default:
-            break;
+    case 3: original_flip = 3; break;
+    case 5: original_flip = 8; break;
+    case 6: original_flip = 6; break;
+    default: break;
     }
     m_processor->adjust_sizes_info_only();
 

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -950,10 +950,10 @@ RawInput::open_raw(bool unpack, const std::string& name,
         m_spec.attribute("raw:Orientation", ori);
     m_spec.attribute("Orientation", 1);
 
-    // If user flip is set to 1, it means we ignore the flip
+    // If user flip is set to 0, it means we ignore the flip
     // Let's set the orientation exif flags to the original flip
     // value so that it is still displayed correctly
-    if (config.get_int_attribute("raw:user_flip", -1) == 1) {
+    if (config.get_int_attribute("raw:user_flip", -1) == 0) {
         m_spec.attribute("Orientation", original_flip);
     }
 

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -438,9 +438,18 @@ RawInput::open_raw(bool unpack, const std::string& name,
     // so we need to convert it
     int original_flip                 = 1;
     int libraw_flip                   = m_processor->imgdata.sizes.flip;
-    static int libraw_to_exif_flip[8] = { 1, 2, 4, 3, 5, 8, 6, 7 };
-    if (libraw_flip >= 1 && libraw_flip <= 8) {
-        original_flip = libraw_to_exif_flip[libraw_flip - 1];
+    switch (libraw_flip) {
+        case 3:
+            original_flip             = 3;
+            break;
+        case 5:
+            original_flip             = 8;
+            break;
+        case 6:
+            original_flip             = 6;
+            break;
+        default:
+            break;
     }
     m_processor->adjust_sizes_info_only();
 


### PR DESCRIPTION
## Description

When reading a raw image, setting the `user_flip` to 1 meant ignoring the `flip` value (to avoid buffer rotation from LibRaw).

However the value 1 for the `user_flip` is **not neutral**: values lie between 0 and 7 (see https://www.libraw.org/docs/API-datastruct-eng.html#libraw_image_sizes_t), and 1 corresponds to a horizontal mirror (in my understanding of the source code).

The proposed fix is to use 0 as `user_flip` value for ignoring the `flip` value.

This modification invalidates the changes made in this PR: https://github.com/OpenImageIO/oiio/pull/3847.
Therefore, flip to orientation conversion has been adapted to match exactly LibRaw's documentation, which handles only rotations (+90, +180, -90 degrees).

## Tests

The previous PR was only tested on images of landscape and human faces, hence the mirroring issue remained unnoticed.
When reading images containing text however the problem is clearly visible.
This PR fixes this mirroring issue on the following 4 orientations: 0, +90, +180 and -90 degrees rotation.
Other orientations could not be tested as they don't seem to ever appear on raw images datasets.