### PR TITLE
ci: Fix package name for icc

### DIFF
--- a/src/build-scripts/gh-installdeps.bash
+++ b/src/build-scripts/gh-installdeps.bash
@@ -44,7 +44,7 @@ if [[ "$ASWF_ORG" != ""  ]] ; then
         # we run CI on. So we lock down to a specific version of icc 2022.1
         # that is known to work.
         sudo cp src/build-scripts/oneAPI.repo /etc/yum.repos.d
-        sudo /usr/bin/yum install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-2022.1.0-3768
+        sudo /usr/bin/yum install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-2022.1.0.x86_64
         # Because multiple (possibly newer) versions of oneAPI may be installed,
         # use a config file to specify compiler and tbb versions
         # NOTE: oneAPI components have independent version numbering.

--- a/src/include/OpenImageIO/strutil.h
+++ b/src/include/OpenImageIO/strutil.h
@@ -217,7 +217,7 @@ inline void print (FILE *file, const Str& fmt, Args&&... args)
 template<typename Str, typename... Args>
 inline void print (const Str& fmt, Args&&... args)
 {
-    print(stdout, fmt, std::forward<Args>(args)...);
+    sync_output(stdout, ::fmt::vformat(fmt, ::fmt::make_format_args(args...)));
 }
 
 template<typename Str, typename... Args>


### PR DESCRIPTION
The Intel yum repo renamed this package a couple weeks ago, and it broke our CI. Update to the new name.

Adjust fmt use to solve icc warning.
