### PR TITLE
jpeg output: fix density calculation

### DIFF
--- a/src/jpeg.imageio/jpegoutput.cpp
+++ b/src/jpeg.imageio/jpegoutput.cpp
@@ -397,7 +397,7 @@ JpgOutput::resmeta_to_density()
             // resolutions were not set
             if (aspect >= 1.0f) {
                 XRes = 72.0f;
-                YRes = XRes * aspect;
+                YRes = XRes / aspect;
             } else {
                 YRes = 72.0f;
                 XRes = YRes * aspect;


### PR DESCRIPTION
## Description

In `jpegoutput.cpp` when computing the density fields the relationship between `XRes`, `YRes` and `aspect` is `aspect = XRes / YRes`.

However this relationship was not respected in one specific case, when `aspect >= 1.0` and `XRes` and `YRes` are not set.

This PR solves this problem by enforcing the correct relationship.

Related to: https://github.com/OpenImageIO/oiio/issues/2822