### PR TITLE
If OpenEXR is found by cmake config file, OpenEXR_VERSION is set instead of OPENEXR_VERSION

### DIFF
--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -108,7 +108,7 @@ include_directories(BEFORE ${IMATH_INCLUDES} ${OPENEXR_INCLUDES})
 if (MSVC AND NOT LINKSTATIC)
     add_definitions (-DOPENEXR_DLL) # Is this needed for new versions?
 endif ()
-if (OPENEXR_VERSION VERSION_GREATER_EQUAL 3.0)
+if (OpenEXR_VERSION VERSION_GREATER_EQUAL 3.0)
     set (OIIO_USING_IMATH 3)
 else ()
     set (OIIO_USING_IMATH 2)


### PR DESCRIPTION
## Description

I use CMake with [`CMAKE_FIND_PACKAGE_PREFER_CONFIG`](https://cmake.org/cmake/help/latest/variable/CMAKE_FIND_PACKAGE_PREFER_CONFIG.html). OpenEXR installs its own config files which set `OpenEXR_VERSION` instead of `OPENEXR_VERSION`.

## Tests

It would be usefull to add a test pipline where CMake is called with `CMAKE_FIND_PACKAGE_PREFER_CONFIG`. However this is out of scope to this PR and should be done by a separate patch. Unfortunately, I don't currently have the time to familiarize myself enough to do this myself.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [ ] (not applicable) If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-CORPORATE)).
- [ ] (not applicable) I have updated the documentation, if applicable.
- [ ] (not applicable) I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

