### PR TITLE
Fix WebP linking if CMAKE_FIND_PACKAGE_PREFER_CONFIG is ON

### DIFF
--- a/src/cmake/modules/FindWebP.cmake
+++ b/src/cmake/modules/FindWebP.cmake
@@ -44,18 +44,18 @@ if (WebP_FOUND)
     set (WEBP_INCLUDES "${WEBP_INCLUDE_DIR}")
     set (WEBP_LIBRARIES ${WEBP_LIBRARY} ${WEBPDEMUX_LIBRARY})
 
-    if (NOT TARGET WebP::WebP)
-        add_library(WebP::WebP UNKNOWN IMPORTED)
-        set_target_properties(WebP::WebP PROPERTIES
+    if (NOT TARGET WebP::webp)
+        add_library(WebP::webp UNKNOWN IMPORTED)
+        set_target_properties(WebP::webp PROPERTIES
             INTERFACE_INCLUDE_DIRECTORIES ${WEBP_INCLUDES})
-        set_property(TARGET WebP::WebP APPEND PROPERTY
+        set_property(TARGET WebP::webp APPEND PROPERTY
             IMPORTED_LOCATION ${WEBP_LIBRARY})
     endif ()
-    if (NOT TARGET WebP::WebPDemux)
-        add_library(WebP::WebPDemux UNKNOWN IMPORTED)
-        set_target_properties(WebP::WebPDemux PROPERTIES
+    if (NOT TARGET WebP::webpdemux)
+        add_library(WebP::webpdemux UNKNOWN IMPORTED)
+        set_target_properties(WebP::webpdemux PROPERTIES
             INTERFACE_INCLUDE_DIRECTORIES ${WEBP_INCLUDES})
-        set_property(TARGET WebP::WebPDemux APPEND PROPERTY
+        set_property(TARGET WebP::webpdemux APPEND PROPERTY
             IMPORTED_LOCATION ${WEBPDEMUX_LIBRARY})
     endif ()
 endif ()

--- a/src/webp.imageio/CMakeLists.txt
+++ b/src/webp.imageio/CMakeLists.txt
@@ -4,11 +4,8 @@
 
 if (WebP_FOUND)
     add_oiio_plugin (webpinput.cpp webpoutput.cpp
-                     INCLUDE_DIRS ${WEBP_INCLUDES}
-                     LINK_LIBRARIES ${WEBP_LIBRARIES}
+                     LINK_LIBRARIES WebP::webp WebP::webpdemux
                      DEFINITIONS "-DUSE_WEBP=1")
 else ()
     message (STATUS "WebP plugin will not be built")
 endif()
-
-


### PR DESCRIPTION
## Description

I use CMake with [`CMAKE_FIND_PACKAGE_PREFER_CONFIG`](https://cmake.org/cmake/help/latest/variable/CMAKE_FIND_PACKAGE_PREFER_CONFIG.html). WebP installs its own config files which but doesn't respect `CMAKE_DEBUG_POSTFIX` in `WEBP_LIBRARIES`. Linking to the target resolves that issue.

## Tests

It would be usefull to add a test pipline where CMake is called with `CMAKE_FIND_PACKAGE_PREFER_CONFIG`. However this is out of scope to this PR and should be done by a separate patch. Unfortunately, I don't currently have the time to familiarize myself enough to do this myself.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [ ] (not applicable) If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-CORPORATE)).
- [ ] (not applicable) I have updated the documentation, if applicable.
- [ ] (not applicable) I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

