### PR TITLE
ImageInput and ImageOutput docs updated to Python 3.

### DIFF
--- a/src/doc/imageinput.rst
+++ b/src/doc/imageinput.rst
@@ -38,14 +38,13 @@ memory, even if that's not the way they're stored in the file):
         import numpy as np
 
         inp = ImageInput.open(filename)
-        if inp is None :
-            return
-        spec = inp.spec()
-        xres = spec.width
-        yres = spec.height
-        channels = spec.nchannels
-        pixels = inp.read_image("uint8")
-        inp.close()
+        if inp :
+            spec = inp.spec()
+            xres = spec.width
+            yres = spec.height
+            channels = spec.nchannels
+            pixels = inp.read_image("uint8")
+            inp.close()
 
 Here is a breakdown of what work this code is doing:
 

--- a/src/doc/imageoutput.rst
+++ b/src/doc/imageoutput.rst
@@ -44,12 +44,11 @@ to a file:
        pixels = np.zeros((yres, xres, channels), dtype=np.uint8)
 
        out = oiio.ImageOutput.create (filename)
-       if out is None:
-           return
-       spec = ImageSpec(xres, yres, channels, 'uint8')
-       out.open (filename, spec)
-       out.write_image (pixels)
-       out.close ()
+       if out:
+           spec = oiio.ImageSpec(xres, yres, channels, 'uint8')
+           out.open (filename, spec)
+           out.write_image (pixels)
+           out.close ()
 
 This little bit of code does a surprising amount of useful work:
 


### PR DESCRIPTION
## Description

Fixes #3846 by updating Python examples.

Current code examples for [ImageInput](https://openimageio.readthedocs.io/en/latest/imageinput.html) and [ImageOutput](https://openimageio.readthedocs.io/en/latest/imageoutput.html) raise a SyntaxError in Python 3:
```python
File "<cwd>\main.py", line 13
    return
    ^^^^^^
SyntaxError: 'return' outside function
```

It seems these code examples might be for Python 2.7. Perhaps it would be worth creating an extra tab instead of replacing the old code?

## Tests

Tested on Python 3.11, no issues.

## Checklist:

- [x] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-CORPORATE)).
- [x] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.