### PR TITLE
fix(simd.h): Fix sense of hiding deprecated type names

### DIFF
--- a/src/include/OpenImageIO/oiioversion.h.in
+++ b/src/include/OpenImageIO/oiioversion.h.in
@@ -95,11 +95,19 @@
 //     #define OIIO_DISABLE_DEPRECATED OIIO_MAKE_VERSION(2,2,0)
 //
 // before including any OpenImageIO header, then we will do our best to make
-// it a compile-time error if they try to use anything we consider deprecated
-// in version 2.2.0 or later. This is viewed as equivalent to the downstream
+// it a compile-time error if they try to use anything that was deprecated
+// in or before version 2.2.0. This is viewed as equivalent to the downstream
 // package considering their minimum OIIO to be 2.2 and they want to be sure
 // they aren't using any features that are slated for deprecation. The
 // default, 0, will not try to hide any deprecated features.
+//
+// To clarify, if version 2.2 is the first to deprecate a certain definition,
+// then it is considered good practice to guard it like this:
+//
+//     #if OIIO_DISABLE_DEPRECATED < OIIO_MAKE_VERSION(2,2,0)
+//        ... deprecated definition here ...
+//     #endif
+//
 #ifndef OIIO_DISABLE_DEPRECATED
 #    define OIIO_DISABLE_DEPRECATED 0
 #endif

--- a/src/include/OpenImageIO/simd.h
+++ b/src/include/OpenImageIO/simd.h
@@ -290,7 +290,7 @@ class vbool16;
 class vint16;
 class vfloat16;
 
-#if OIIO_DISABLE_DEPRECATED >= OIIO_MAKE_VERSION(1,9,0) && !defined(OIIO_INTERNAL)
+#if OIIO_DISABLE_DEPRECATED < OIIO_MAKE_VERSION(1,9,0) && !defined(OIIO_INTERNAL)
 // Deprecated names -- remove these in 1.9
 // These are removed from visibility for the OIIO codebase itself, or for any
 // downstream project that defines OIIO_DISABLE_DEPRECATED to exclude


### PR DESCRIPTION
I got the test backwards, and it was incorrectly hiding the definition for the default case of OIIO_DISABLE_DEPRECATED == 0.
