### PR TITLE
build: Fix fmt vs gcc warning that had version typo

### DIFF
--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -358,6 +358,6 @@ endmacro()
 find_or_download_fmt()
 
 if (FMT_VERSION VERSION_EQUAL 90100
-        AND GCC_VERSION VERSION_GREATER 0.0 AND NOT GCC_VERSION VERSION_GREATER 12.2)
+        AND GCC_VERSION VERSION_GREATER 0.0 AND NOT GCC_VERSION VERSION_GREATER 7.2)
     message (WARNING "${ColorRed}fmt 9.1 is known to not work with gcc <= 7.2${ColorReset}")
 endif ()


### PR DESCRIPTION
The comment was right, but the test seems to have had a typo we didn't catch in review.

