### PR TITLE
fix(psd): Prevent simultaneous psd thumbnail reads from clashing

### DIFF
--- a/src/psd.imageio/psdinput.cpp
+++ b/src/psd.imageio/psdinput.cpp
@@ -1344,9 +1344,27 @@ PSDInput::load_resource_thumbnail(uint32_t length, bool isBGR)
     if (!ioread(&jpeg_data[0], jpeg_length))
         return false;
 
+    // Create an IOMemReader that references the thumbnail JPEG blob and read
+    // it with an ImageInput, into the memory owned by an ImageBuf.
     Filesystem::IOMemReader thumbblob(jpeg_data.data(), jpeg_length);
-    m_thumbnail = ImageBuf("thumbnail.jpg", 0, 0, nullptr, nullptr, &thumbblob);
-    m_thumbnail.read(0, 0, true);
+    m_thumbnail.clear();
+    auto imgin = ImageInput::open("thumbnail.jpg", nullptr, &thumbblob);
+    if (imgin) {
+        ImageSpec spec = imgin->spec(0);
+        m_thumbnail.reset(spec, InitializePixels::No);
+        ok = imgin->read_image(0, 0, 0, m_thumbnail.spec().nchannels,
+                               m_thumbnail.spec().format,
+                               m_thumbnail.localpixels());
+        imgin.reset();
+    } else {
+        errorfmt("Failed to open thumbnail");
+        return false;
+    }
+    if (!ok) {
+        errorfmt("Failed to read thumbnail: {}", m_thumbnail.geterror());
+        m_thumbnail.clear();
+        return false;
+    }
 
     // Set these attributes for the merged composite only (subimage 0)
     composite_attribute("thumbnail_width", (int)m_thumbnail.spec().width);


### PR DESCRIPTION
When reading a PSD file, if it contains a thumbnail, we read it from the in-memory blob with a combination of an IOMemReader and an ImageBuf.  But... we always named it "thumbnail.jpg" without considering that multiple simultaneous PSD files reading identically named images (but which are in fact different) could cause a weird kind of clashing in any underlying use of ImageCache!

The simple fix is to use ordinary ImageInput approach to reading the thumbnail from the IOMemReader, but just store it in the ImageBuf.

Fixes #3824
