### PR TITLE
fix(jpeg2000): better pixel type promotion logic

### DIFF
--- a/src/jpeg2000.imageio/jpeg2000output.cpp
+++ b/src/jpeg2000.imageio/jpeg2000output.cpp
@@ -156,9 +156,9 @@ Jpeg2000Output::open(const std::string& name, const ImageSpec& spec,
 
     m_filename = name;
 
-    // If not uint8 or uint16, default to uint8
+    // If not uint8 or uint16, default to uint16
     if (m_spec.format != TypeDesc::UINT8 && m_spec.format != TypeDesc::UINT16)
-        m_spec.set_format(TypeDesc::UINT8);
+        m_spec.set_format(TypeDesc::UINT16);
 
     m_dither        = (m_spec.format == TypeDesc::UINT8)
                           ? m_spec.get_int_attribute("oiio:dither", 0)


### PR DESCRIPTION
J2K output was defaulting to UINT8 when asked to output an unsupported type. It should have been UINT16 to try to minimize the amount of precision loss.

Fixes #3876
