### PR TITLE
Fix: Wait for terminated threads to join in thread_pool::Impl::resize

### DIFF
--- a/src/libutil/thread.cpp
+++ b/src/libutil/thread.cpp
@@ -161,8 +161,7 @@ public:
                 std::vector<std::unique_ptr<std::thread>> terminating_threads;
                 for (int i = oldNThreads - 1; i >= nThreads; --i) {
                     *this->flags[i] = true;  // this thread will finish
-                    terminating_threads.push_back(
-                        std::move(this->threads[i]));
+                    terminating_threads.push_back(std::move(this->threads[i]));
                     this->threads.erase(this->threads.begin() + i);
                 }
                 {

--- a/src/libutil/thread.cpp
+++ b/src/libutil/thread.cpp
@@ -158,9 +158,10 @@ public:
                     this->set_thread(i);
                 }
             } else {  // the number of threads is decreased
+                std::vector<std::unique_ptr<std::thread>> terminating_threads;
                 for (int i = oldNThreads - 1; i >= nThreads; --i) {
                     *this->flags[i] = true;  // this thread will finish
-                    this->terminating_threads.push_back(
+                    terminating_threads.push_back(
                         std::move(this->threads[i]));
                     this->threads.erase(this->threads.begin() + i);
                 }
@@ -168,6 +169,11 @@ public:
                     // stop the detached threads that were waiting
                     std::unique_lock<std::mutex> lock(this->mutex);
                     this->cv.notify_all();
+                }
+                // wait for the terminated threads to finish
+                for (auto& thread : terminating_threads) {
+                    if (thread->joinable())
+                        thread->join();
                 }
                 this->threads.resize(
                     nThreads);  // safe to delete because the threads are detached
@@ -245,16 +251,10 @@ public:
             if (thread->joinable())
                 thread->join();
         }
-        // wait for the terminated threads to finish
-        for (auto& thread : this->terminating_threads) {
-            if (thread->joinable())
-                thread->join();
-        }
         // if there were no threads in the pool but some functors in the queue, the functors are not deleted by the threads
         // therefore delete them here
         this->clear_queue();
         this->threads.clear();
-        this->terminating_threads.clear();
         this->flags.clear();
     }
 
@@ -356,7 +356,6 @@ private:
     }
 
     std::vector<std::unique_ptr<std::thread>> threads;
-    std::vector<std::unique_ptr<std::thread>> terminating_threads;
     std::vector<std::shared_ptr<std::atomic<bool>>> flags;
     mutable pvt::ThreadsafeQueue<std::function<void(int id)>*> q;
     std::atomic<bool> isDone;


### PR DESCRIPTION
## Description

Part of solving #3851.

When decreasing the number of threads in `thread_pool::Impl::resize` it was possible for the threads marked for termination to still be fully alive at process exit time if the call to `resize` and the exit of the main function were close enough to each other.

This change makes `resize` wait for the threads to actually join guaranteeing the threads have been shut down in a orderly manner when the `resize` function exits.

## Tests

N/A

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-CORPORATE)). - small change no CLA required.
- [ ] I have updated the documentation, if applicable. - N/A
- [ ] I have ensured that the change is tested somewhere in the testsuite N/A
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project. - Just moved code around should have no style issues
