### PR TITLE
fix(exr): correction to dwa vs zip logic when outputting OpenEXR

### DIFF
--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -742,9 +742,10 @@ OpenEXROutput::spec_to_header(ImageSpec& spec, int subimage,
     // on deep files (but allow "none" as well)
     if (spec.deep && comp != "none")
         comp = "zips";
-    // For single channel images, dwaa/b compression only seems to work reliably
-    // when size > 16 and size is a power of two
-    if (spec.nchannels == 1 && Strutil::istarts_with(comp, "dwa")
+    // For single channel tiled images, dwaa/b compression only seems to work
+    // reliably when tile size > 16 and size is a power of two.
+    if (spec.nchannels == 1 && spec.tile_width > 0
+        && Strutil::istarts_with(comp, "dwa")
         && ((spec.tile_width < 16 && spec.tile_height < 16)
             || !ispow2(spec.tile_width) || !ispow2(spec.tile_height))) {
         comp = "zip";


### PR DESCRIPTION
PR #2147, addressing issue #1844, is related to an apparent OpenEXR bug wherein single channel tiled images where the tile dimensions were not a power of 2 and >= 16 would not work properly with dwa compression. We work around the problem by automatically substituting zip compression in those cases. But it was implemented with a subtle bug, forgetting that tile_size == 0 for untiled images, and thus we were silently switching from dwa to zip compression for all *untiled* single channel images of any size (which presumably were never problematic). This patch fixes the test so we are not changing the compression for the untiled files.