### PR TITLE
[exif] Convert paramvalue string to integer when needed

### DIFF
--- a/src/libOpenImageIO/exif.cpp
+++ b/src/libOpenImageIO/exif.cpp
@@ -923,6 +923,15 @@ append_tiff_dir_entry_integer(const ParamValue& p,
     case TypeDesc::INT: i = (T) * (int*)p.data(); break;
     case TypeDesc::UINT16: i = (T) * (unsigned short*)p.data(); break;
     case TypeDesc::INT16: i = (T) * (short*)p.data(); break;
+    case TypeDesc::STRING:
+    {
+        if (Strutil::string_is_int(p.get_ustring())) {
+            i = (T) p.get_int();
+            break;
+        } else {
+            return false;
+        }
+    }
     default: return false;
     }
     append_tiff_dir_entry(dirs, data, tag, type, 1, &i, offset_correction, 0,

--- a/src/libOpenImageIO/exif.cpp
+++ b/src/libOpenImageIO/exif.cpp
@@ -923,10 +923,9 @@ append_tiff_dir_entry_integer(const ParamValue& p,
     case TypeDesc::INT: i = (T) * (int*)p.data(); break;
     case TypeDesc::UINT16: i = (T) * (unsigned short*)p.data(); break;
     case TypeDesc::INT16: i = (T) * (short*)p.data(); break;
-    case TypeDesc::STRING:
-    {
+    case TypeDesc::STRING: {
         if (Strutil::string_is_int(p.get_ustring())) {
-            i = (T) p.get_int();
+            i = (T)p.get_int();
             break;
         } else {
             return false;


### PR DESCRIPTION
Make sure we can input exif tags as strings containing numbers when number are required.

E.G. if my input is "Orientation"=>"8", i would like the jpeg output to contains the value 8 for the exif tag orientation.

