### PR TITLE
ci: Simplify build_llvm.bash script

### DIFF
--- a/src/build-scripts/build_llvm.bash
+++ b/src/build-scripts/build_llvm.bash
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 
 # Utility script to download and build LLVM & clang
+#
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: BSD-3-Clause
+# https://github.com/OpenImageIO/oiio
 
 # Exit the whole script if any command fails.
 set -ex
@@ -10,30 +14,12 @@ uname
 
 
 if [[ `uname` == "Linux" ]] ; then
-    LLVM_VERSION=${LLVM_VERSION:=13.0.0}
-    LLVM_INSTALL_DIR=${LLVM_INSTALL_DIR:=${PWD}/llvm-install}
-    if [[ "$GITHUB_WORKFLOW" != "" ]] ; then
-        LLVM_DISTRO_NAME=${LLVM_DISTRO_NAME:=ubuntu-18.04}
-    elif [[ "$TRAVIS_DIST" == "trusty" ]] ; then
-        LLVM_DISTRO_NAME=${LLVM_DISTRO_NAME:=ubuntu-14.04}
-    elif [[ "$TRAVIS_DIST" == "xenial" ]] ; then
-        LLVM_DISTRO_NAME=${LLVM_DISTRO_NAME:=ubuntu-16.04}
-    elif [[ "$TRAVIS_DIST" == "bionic" ]] ; then
-        LLVM_DISTRO_NAME=${LLVM_DISTRO_NAME:=ubuntu-18.04}
-    else
-        LLVM_DISTRO_NAME=${LLVM_DISTRO_NAME:=error}
-    fi
+    : ${LLVM_VERSION:=13.0.0}
+    : ${LLVM_INSTALL_DIR:=${PWD}/llvm-install}
+    : ${LLVM_DISTRO_NAME:=ubuntu-18.04}
     LLVMTAR=clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-${LLVM_DISTRO_NAME}.tar.xz
     echo LLVMTAR = $LLVMTAR
-    if [[ "$LLVM_VERSION" == "10.0.0" ]] || [[ "$LLVM_VERSION" == "11.0.0" ]] \
-      || [[ "$LLVM_VERSION" == "11.1.0" ]] || [[ "$LLVM_VERSION" == "12.0.0" ]] \
-      || [[ "$LLVM_VERSION" == "13.0.0" ]]  || [[ "$LLVM_VERSION" == "14.0.0" ]] ;
-    then
-        # new
-        curl --location https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/${LLVMTAR} -o $LLVMTAR
-    else
-        curl --location http://releases.llvm.org/${LLVM_VERSION}/${LLVMTAR} -o $LLVMTAR
-    fi
+    curl --location https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/${LLVMTAR} -o $LLVMTAR
     ls -l $LLVMTAR
     tar xf $LLVMTAR
     rm -f $LLVMTAR


### PR DESCRIPTION
* Remove leftover logic from when we used TravisCI.
* Pick a default for LLVM_DISTRO_NAME so it works when the script is run standalone when not on GitHub Actions CI. (But it's still really only meant to run on x86 Ubuntu, and not designed for anything useful outside of our CI.)
* Eliminate all the complexity with old LLVM versions -- in practice, our CI only uses this to download fairly modern clang versions.

Fixes #3891
