### PR TITLE
docs: Add repology badge to README and package versions to INSTALL

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -123,6 +123,9 @@ build options), maybe one of these packages managers will do it for you:
 
 If these work for you and it's all you need, bingo! You are done.
 
+You may find this guide to versions carried by distributions helpful:
+
+[![OpenImageIO packaging status](https://repology.org/badge/vertical-allrepos/openimageio.svg?exclude_unsupported=1&columns=3&exclude_sources=modules,site&header=OpenImageIO%20packaging%20status)](https://repology.org/project/openimageio/versions)
 
 
 Building from source

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ README for OpenImageIO
 [![License](https://img.shields.io/badge/license-BSD%203--Clause-blue.svg?style=flat-square)](https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md)
 [![CI](https://github.com/OpenImageIO/oiio/actions/workflows/ci.yml/badge.svg)](https://github.com/OpenImageIO/oiio/actions/workflows/ci.yml)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/2694/badge)](https://bestpractices.coreinfrastructure.org/projects/2694)
+[![latest packaged version(s)](https://repology.org/badge/latest-versions/openimageio.svg)](https://repology.org/project/openimageio/versions)
 
 
 Introduction


### PR DESCRIPTION
repology has a handy tool that will show all the package distros
and which version of openimageio they supply.
