### PR TITLE
ci: Fix broken heif dependency and test

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -59,7 +59,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
      * giflib >= 4.1 (tested through 5.2; 5.0+ is strongly recommended for
        stability and thread safety)
  * If you want support for HEIF/HEIC or AVIF images:
-     * libheif >= 1.3 (1.7 required for AVIF support, tested through 1.15)
+     * libheif >= 1.3 (1.7 required for AVIF support, tested through 1.16)
      * libheif must be built with an AV1 encoder/decoder for AVIF support.
      * Avoid libheif 1.10 on Mac, it is very broken. Libheif 1.11+ is fine.
  * If you want support for DICOM medical image files:

--- a/src/build-scripts/gh-installdeps.bash
+++ b/src/build-scripts/gh-installdeps.bash
@@ -97,7 +97,9 @@ else
     if [[ "$USE_LIBHEIF" != "0" ]] ; then
        sudo add-apt-repository ppa:strukturag/libde265 || true
        sudo add-apt-repository ppa:strukturag/libheif || true
-       time sudo apt-get -q install -y libheif-dev || true
+       time sudo apt-get -q install -y libheif-plugin-aomdec \
+            libheif-plugin-aomenc libheif-plugin-libde265 \
+            libheif-plugin-x265 libheif-dev || true
     fi
 
     export CMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu:$CMAKE_PREFIX_PATH

--- a/src/heif.imageio/heifinput.cpp
+++ b/src/heif.imageio/heifinput.cpp
@@ -59,6 +59,17 @@ private:
 
 
 
+void
+oiio_heif_init()
+{
+#if LIBHEIF_HAVE_VERSION(1, 6, 0)
+    static std::once_flag flag;
+    std::call_once(flag, []() { heif_init(nullptr); });
+#endif
+}
+
+
+
 // Export version number and create function symbols
 OIIO_PLUGIN_EXPORTS_BEGIN
 
@@ -73,6 +84,7 @@ heif_imageio_library_version()
 OIIO_EXPORT ImageInput*
 heif_input_imageio_create()
 {
+    oiio_heif_init();
     return new HeifInput;
 }
 

--- a/src/heif.imageio/heifoutput.cpp
+++ b/src/heif.imageio/heifoutput.cpp
@@ -70,11 +70,14 @@ private:
 }  // namespace
 
 
+
 OIIO_PLUGIN_EXPORTS_BEGIN
 
 OIIO_EXPORT ImageOutput*
 heif_output_imageio_create()
 {
+    extern void oiio_heif_init();
+    oiio_heif_init();
     return new HeifOutput;
 }
 


### PR DESCRIPTION
The strukturag repo for libheif recently upgraded the version it was serving from 1.14 to 1.16, and that caused our tests to fail because (a) some of the codec support has been moved to plugins that are loaded at runtime and those are now distributed in packages we need to install separately; (b) you must call heif_init() or it won't know about the optional plugins.

