### PR TITLE
Remove redundant instructions from tile hash

### DIFF
--- a/src/include/OpenImageIO/hash.h
+++ b/src/include/OpenImageIO/hash.h
@@ -80,7 +80,12 @@ inline uint64_t fasthash64(const void *buf, size_t len, uint64_t seed=1771)
 	uint64_t v;
 
 	while (pos != end) {
+		// This appears to be a false positive which only affects GCC.
+		// https://godbolt.org/z/5q7Y7ndfb
+		OIIO_PRAGMA_WARNING_PUSH
+		OIIO_GCC_ONLY_PRAGMA(GCC diagnostic ignored "-Wmaybe-uninitialized")
 		v  = *pos++;
+		OIIO_PRAGMA_WARNING_PUSH
 		h ^= mix(v);
 		h *= m;
 	}

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -570,12 +570,7 @@ struct TileID {
         static_assert(
             sizeof(*this) % sizeof(uint64_t) == 0,
             "FastHash uses the fewest instructions when data size is a multiple of 8 bytes.");
-        // This appears to be a false positive which only affects GCC.
-        // https://godbolt.org/z/5q7Y7ndfb
-        OIIO_PRAGMA_WARNING_PUSH
-        OIIO_GCC_ONLY_PRAGMA(GCC diagnostic ignored "-Wuninitialized")
         return fasthash::fasthash64(this, sizeof(*this));
-        OIIO_PRAGMA_WARNING_POP
     }
 
     /// Functor that hashes a TileID

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -570,7 +570,12 @@ struct TileID {
         static_assert(
             sizeof(*this) % sizeof(uint64_t) == 0,
             "FastHash uses the fewest instructions when data size is a multiple of 8 bytes.");
+        // This appears to be a false positive which only affects GCC.
+        // https://godbolt.org/z/5q7Y7ndfb
+        OIIO_PRAGMA_WARNING_PUSH
+        OIIO_GCC_ONLY_PRAGMA(GCC diagnostic ignored "-Wuninitialized")
         return fasthash::fasthash64(this, sizeof(*this));
+        OIIO_PRAGMA_WARNING_POP
     }
 
     /// Functor that hashes a TileID

--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -3181,13 +3181,8 @@ TextureSystem::unit_test_hash()
     for (int f = 0; f < nfiles; ++f) {
         for (int y = 0; y < res; y += tilesize) {
             for (int x = 0; x < res; x += tilesize, ++i) {
-                // This appears to be a false positive which only affects GCC.
-                // https://godbolt.org/z/5q7Y7ndfb
-                OIIO_PRAGMA_WARNING_PUSH
-                OIIO_GCC_ONLY_PRAGMA(GCC diagnostic ignored "-Wuninitialized")
                 OIIO::pvt::TileID id(*icf[f], 0, 0, x, y, 0, 0, 1);
                 size_t h = id.hash();
-                OIIO_PRAGMA_WARNING_POP
                 hh += h;
             }
         }
@@ -3204,13 +3199,8 @@ TextureSystem::unit_test_hash()
     for (int f = 0; f < nfiles; ++f) {
         for (int y = 0; y < res; y += tilesize) {
             for (int x = 0; x < res; x += tilesize, ++i) {
-                // This appears to be a false positive which only affects GCC.
-                // https://godbolt.org/z/5q7Y7ndfb
-                OIIO_PRAGMA_WARNING_PUSH
-                OIIO_GCC_ONLY_PRAGMA(GCC diagnostic ignored "-Wuninitialized")
                 OIIO::pvt::TileID id(*icf[f], 0, 0, x, y, 0, 0, 1);
                 size_t h = id.hash();
-                OIIO_PRAGMA_WARNING_POP
                 ++fourbits[h & 0xf];
                 ++eightbits[h & 0xff];
                 ++highereightbits[(h >> 24) & 0xff];

--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -3181,8 +3181,13 @@ TextureSystem::unit_test_hash()
     for (int f = 0; f < nfiles; ++f) {
         for (int y = 0; y < res; y += tilesize) {
             for (int x = 0; x < res; x += tilesize, ++i) {
+                // This appears to be a false positive which only affects GCC.
+                // https://godbolt.org/z/5q7Y7ndfb
+                OIIO_PRAGMA_WARNING_PUSH
+                OIIO_GCC_ONLY_PRAGMA(GCC diagnostic ignored "-Wuninitialized")
                 OIIO::pvt::TileID id(*icf[f], 0, 0, x, y, 0, 0, 1);
                 size_t h = id.hash();
+                OIIO_PRAGMA_WARNING_POP
                 hh += h;
             }
         }
@@ -3199,8 +3204,13 @@ TextureSystem::unit_test_hash()
     for (int f = 0; f < nfiles; ++f) {
         for (int y = 0; y < res; y += tilesize) {
             for (int x = 0; x < res; x += tilesize, ++i) {
+                // This appears to be a false positive which only affects GCC.
+                // https://godbolt.org/z/5q7Y7ndfb
+                OIIO_PRAGMA_WARNING_PUSH
+                OIIO_GCC_ONLY_PRAGMA(GCC diagnostic ignored "-Wuninitialized")
                 OIIO::pvt::TileID id(*icf[f], 0, 0, x, y, 0, 0, 1);
                 size_t h = id.hash();
+                OIIO_PRAGMA_WARNING_POP
                 ++fourbits[h & 0xf];
                 ++eightbits[h & 0xff];
                 ++highereightbits[(h >> 24) & 0xff];


### PR DESCRIPTION
## Description

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

Optimises the code in the tile hash function. During a render this function is called billions of times so this small improvement adds up, in some test scenes it reduces total render time by an average of about 2%.

See https://godbolt.org/z/jMzz4PTce for the exact details. A summary would be:

- Reduced instruction count from 75 to 61, this is due to the redundant add and shift operations that can be implicitely handled by taking advantage of the member layout in the class.
- Halves the number of memory fetch instructions because all accesses are now 64-bit.
- Removes branching instructions and extra memory indirection inside `ustring::hash()`.

There is a slight change in behaviour, which is that the hash is now computed from the `m_file` pointer rather than from `m_file->filename().hash()`, so runtime reproducibility is lost. However the performance gain seems worth it.



## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [x] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-CORPORATE)).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

