### PR TITLE
fix(strutil.h): ensure proper constexpr of string hashing

### DIFF
--- a/src/include/OpenImageIO/string_view.h
+++ b/src/include/OpenImageIO/string_view.h
@@ -106,9 +106,8 @@ public:
         : m_chars(chars), m_len(len) { }
 
     /// Construct from char*, use strlen to determine length.
-    OIIO_CONSTEXPR17 basic_string_view(const CharT* chars) noexcept
-        : m_chars(chars), m_len(chars ? Traits::length(chars) : 0) { }
-    // N.B. char_traits::length() is constexpr starting with C++17.
+    constexpr basic_string_view(const CharT* chars) noexcept
+        : m_chars(chars), m_len(chars ? cestrlen(chars) : 0) { }
 
     /// Construct from std::string. Remember that a string_view doesn't have
     /// its own copy of the characters, so don't use the `string_view` after
@@ -429,6 +428,20 @@ private:
             if (!traits::find(s.data(), s.length(), *first))
                 return first;
         return last;
+    }
+
+    // Guaranteed constexpr length of a C string
+    static constexpr size_t cestrlen(const charT* chars) {
+#if OIIO_CPLUSPLUS_VERSION >= 17
+        return Traits::length(chars);
+#else
+        if (chars == nullptr)
+            return 0;
+        size_t len = 0;
+        while (chars[len] != 0)
+            len++;
+        return len;
+#endif
     }
 
     class traits_eq {

--- a/src/libutil/strutil_test.cpp
+++ b/src/libutil/strutil_test.cpp
@@ -350,6 +350,9 @@ test_hash()
     OIIO_CHECK_EQUAL(strhash(std::string("foo")), 6150913649986995171);
     OIIO_CHECK_EQUAL(strhash(string_view("foo")), 6150913649986995171);
     OIIO_CHECK_EQUAL(strhash(""), 0);  // empty string hashes to 0
+    // Check longer hash and ensure that it's really constexpr
+    constexpr size_t hash = Strutil::strhash("much longer string");
+    OIIO_CHECK_EQUAL(hash, 16257490369375554819ULL);
 }
 
 


### PR DESCRIPTION
The underlying farmhash algorithm (which is the basis for Strutil::strhash, and thus ustring's hash representation) turned out to not be properly constexpr under certain circumstances and needed to be expressed a different way to be fully constexpr on all platforms and for all strings.

New implementation suggested by Alex Wells.

Also, make sure string_view ctr from char* can be constexpr, even for
C++14. This is related for the sake of the strhash calls that, when
taking string literals, actually choose the variety that accepts a
string_view.
