### PR TITLE
admin: update licensing

### DIFF
--- a/src/build-scripts/build_Ptex.bash
+++ b/src/build-scripts/build_Ptex.bash
@@ -3,7 +3,7 @@
 # Utility script to download and build Ptex
 #
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 # Exit the whole script if any command fails.

--- a/src/build-scripts/build_cmake.bash
+++ b/src/build-scripts/build_cmake.bash
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 
 # Utility script to download and build cmake
+#
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
 
 # Exit the whole script if any command fails.
 set -ex

--- a/src/build-scripts/build_llvm.bash
+++ b/src/build-scripts/build_llvm.bash
@@ -3,7 +3,7 @@
 # Utility script to download and build LLVM & clang
 #
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 # Exit the whole script if any command fails.

--- a/src/build-scripts/build_ninja.bash
+++ b/src/build-scripts/build_ninja.bash
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 # Exit the whole script if any command fails.
 set -ex
 

--- a/src/build-scripts/ci-build.bash
+++ b/src/build-scripts/ci-build.bash
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 # Important: set -ex causes this whole script to terminate with error if
 # any command in it fails. This is crucial for CI tests.
 set -ex

--- a/src/build-scripts/ci-coverage.bash
+++ b/src/build-scripts/ci-coverage.bash
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 # Run code coverage analysis
 # This assumes that the build occurred with CODECOV=1 and tests have already
 # fully run.

--- a/src/build-scripts/ci-startup.bash
+++ b/src/build-scripts/ci-startup.bash
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 # This script is run when CI system first starts up.
 # Since it sets many env variables needed by the caller, it should be run
 # with 'source', not in a separate shell.

--- a/src/build-scripts/ci-test.bash
+++ b/src/build-scripts/ci-test.bash
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 # Important: set -ex causes this whole script to terminate with error if
 # any command in it fails. This is crucial for CI tests.
 # (Though we let it run all the way through for code coverage workflows.)

--- a/src/build-scripts/gh-win-installdeps.bash
+++ b/src/build-scripts/gh-win-installdeps.bash
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Copyright 2008-present Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 # DEP_DIR="$PWD/ext/dist"

--- a/src/build-scripts/save-env.bash
+++ b/src/build-scripts/save-env.bash
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 # Save the env for use by other stages. Exclude things that we know aren't
 # needed.
 printenv \

--- a/src/cineon.imageio/CMakeLists.txt
+++ b/src/cineon.imageio/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 add_oiio_plugin (cineoninput.cpp

--- a/src/cmake/add_oiio_plugin.cmake
+++ b/src/cmake/add_oiio_plugin.cmake
@@ -1,5 +1,5 @@
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 

--- a/src/cmake/check_is_enabled.cmake
+++ b/src/cmake/check_is_enabled.cmake
@@ -1,5 +1,5 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 # Is the named package "enabled" via our disabling convention? If either

--- a/src/cmake/colors.cmake
+++ b/src/cmake/colors.cmake
@@ -1,5 +1,5 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 

--- a/src/cmake/modules/FindDCMTK.cmake
+++ b/src/cmake/modules/FindDCMTK.cmake
@@ -1,5 +1,9 @@
 # Module to find DCMTK
 #
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+#
 # This module will first look into the directories defined by the variables:
 #   - DCMTK_ROOT, DCMTK_INCLUDE_PATH, DCMTK_LIBRARY_PATH
 #

--- a/src/cmake/modules/FindLibheif.cmake
+++ b/src/cmake/modules/FindLibheif.cmake
@@ -1,5 +1,9 @@
 # Module to find LIBHEIF
 #
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+#
 # This module will first look into the directories defined by the variables:
 #   - Libheif_ROOT, LIBHEIF_INCLUDE_PATH, LIBHEIF_LIBRARY_PATH
 #

--- a/src/cmake/modules/FindRobinmap.cmake
+++ b/src/cmake/modules/FindRobinmap.cmake
@@ -1,5 +1,9 @@
 # Find Robinmap
 #
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+#
 # Sets the usual variables expected for find_package scripts:
 #
 # ROBINMAP_INCLUDES - header location

--- a/src/cmake/modules/FindWebP.cmake
+++ b/src/cmake/modules/FindWebP.cmake
@@ -1,5 +1,9 @@
 # Module to find Webp
 #
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+#
 # This module will first look into the directories defined by the variables:
 #   - Webp_ROOT, WEBP_INCLUDE_PATH, WEBP_LIBRARY_PATH
 #

--- a/src/cmake/modules/Findfmt.cmake
+++ b/src/cmake/modules/Findfmt.cmake
@@ -1,5 +1,9 @@
 # Find fmt library
 #
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+#
 # Sets the usual variables expected for find_package scripts:
 #
 # FMT_INCLUDES - header location

--- a/src/cmake/modules/Findpugixml.cmake
+++ b/src/cmake/modules/Findpugixml.cmake
@@ -1,5 +1,5 @@
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 # Find the pugixml XML parsing library.

--- a/src/cmake/packaging.cmake
+++ b/src/cmake/packaging.cmake
@@ -1,5 +1,5 @@
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio/
 
 #########################################################################

--- a/src/dicom.imageio/CMakeLists.txt
+++ b/src/dicom.imageio/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 if (DCMTK_FOUND)

--- a/src/dicom.imageio/dicominput.cpp
+++ b/src/dicom.imageio/dicominput.cpp
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 #include <OpenImageIO/fmath.h>

--- a/src/doc/copyr.rst
+++ b/src/doc/copyr.rst
@@ -1,5 +1,10 @@
 :orphan:
 
+..
+  Copyright Contributors to the OpenImageIO project.
+  SPDX-License-Identifier: CC-BY-4.0
+
+
 .. only:: not latex
 
     Copyright Notice

--- a/src/doc/glossary.rst
+++ b/src/doc/glossary.rst
@@ -1,5 +1,11 @@
 .. _chap-glossary:
 
+..
+  Copyright Contributors to the OpenImageIO project.
+  SPDX-License-Identifier: CC-BY-4.0
+
+
+
 Glossary
 ########
 

--- a/src/doc/iconvert.rst
+++ b/src/doc/iconvert.rst
@@ -1,3 +1,8 @@
+..
+  Copyright Contributors to the OpenImageIO project.
+  SPDX-License-Identifier: CC-BY-4.0
+
+
 Converting Image Formats With `iconvert`
 ########################################
 

--- a/src/doc/idiff.rst
+++ b/src/doc/idiff.rst
@@ -1,3 +1,8 @@
+..
+  Copyright Contributors to the OpenImageIO project.
+  SPDX-License-Identifier: CC-BY-4.0
+
+
 Comparing Images With `idiff`
 #############################
 

--- a/src/doc/igrep.rst
+++ b/src/doc/igrep.rst
@@ -1,3 +1,8 @@
+..
+  Copyright Contributors to the OpenImageIO project.
+  SPDX-License-Identifier: CC-BY-4.0
+
+
 Searching Image Metadata With `igrep`
 #####################################
 

--- a/src/doc/imagebuf.rst
+++ b/src/doc/imagebuf.rst
@@ -1,3 +1,8 @@
+..
+  Copyright Contributors to the OpenImageIO project.
+  SPDX-License-Identifier: CC-BY-4.0
+
+
 .. _chap-imagebuf:
 
 ImageBuf: Image Buffers

--- a/src/doc/imagebufalgo.rst
+++ b/src/doc/imagebufalgo.rst
@@ -1,3 +1,8 @@
+..
+  Copyright Contributors to the OpenImageIO project.
+  SPDX-License-Identifier: CC-BY-4.0
+
+
 .. _chap-imagebufalgo:
 
 ImageBufAlgo: Image Processing

--- a/src/doc/imagecache.rst
+++ b/src/doc/imagecache.rst
@@ -1,3 +1,8 @@
+..
+  Copyright Contributors to the OpenImageIO project.
+  SPDX-License-Identifier: CC-BY-4.0
+
+
 .. _chap-imagecache:
 
 Cached Images

--- a/src/doc/index.rst
+++ b/src/doc/index.rst
@@ -1,3 +1,8 @@
+..
+  Copyright Contributors to the OpenImageIO project.
+  SPDX-License-Identifier: CC-BY-4.0
+
+
 =====================
 OpenImageIO |version|
 =====================

--- a/src/doc/mainpage.h
+++ b/src/doc/mainpage.h
@@ -1,6 +1,10 @@
 // Comments that don't go anywhere in the source code, but help to
 // generate the "main page" or other docs for doxygen.
 
+// Copyright Contributors to the OpenImageIO project.
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/OpenImageIO/oiio
+
 
 namespace OpenImageIO {
 

--- a/src/doc/makefigures.bash
+++ b/src/doc/makefigures.bash
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 if [ "${OIIOTOOL}" == "" ] ; then
     OIIOTOOL=oiiotool
 fi

--- a/src/doc/stdmetadata.rst
+++ b/src/doc/stdmetadata.rst
@@ -1,3 +1,8 @@
+..
+  Copyright Contributors to the OpenImageIO project.
+  SPDX-License-Identifier: CC-BY-4.0
+
+
 .. _chap-stdmetadata:
 
 Metadata conventions

--- a/src/doc/writingplugins.rst
+++ b/src/doc/writingplugins.rst
@@ -1,3 +1,8 @@
+..
+  Copyright Contributors to the OpenImageIO project.
+  SPDX-License-Identifier: CC-BY-4.0
+
+
 Writing ImageIO Plugins
 #######################
 

--- a/src/dpx.imageio/CMakeLists.txt
+++ b/src/dpx.imageio/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 add_oiio_plugin (dpxinput.cpp dpxoutput.cpp

--- a/src/fits.imageio/CMakeLists.txt
+++ b/src/fits.imageio/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 add_oiio_plugin (fitsinput.cpp fitsoutput.cpp fits_pvt.cpp)

--- a/src/hdr.imageio/CMakeLists.txt
+++ b/src/hdr.imageio/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 add_oiio_plugin (hdrinput.cpp hdroutput.cpp)

--- a/src/heif.imageio/CMakeLists.txt
+++ b/src/heif.imageio/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 if (Libheif_FOUND)

--- a/src/ico.imageio/CMakeLists.txt
+++ b/src/ico.imageio/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 if (TARGET PNG::PNG)

--- a/src/iconvert/CMakeLists.txt
+++ b/src/iconvert/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 fancy_add_executable (LINK_LIBRARIES OpenImageIO)

--- a/src/idiff/CMakeLists.txt
+++ b/src/idiff/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 fancy_add_executable (LINK_LIBRARIES OpenImageIO)

--- a/src/iff.imageio/CMakeLists.txt
+++ b/src/iff.imageio/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 option (ENABLE_RLA_IOPROXY "(Temporarily) turn this off to switch back to the old pre-IOProxy RLA implementation to address a bug." ON)

--- a/src/iff.imageio/noproxy-iff_pvt.cpp
+++ b/src/iff.imageio/noproxy-iff_pvt.cpp
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 #include "noproxy-iff_pvt.h"
 #include <OpenImageIO/dassert.h>

--- a/src/iff.imageio/noproxy-iff_pvt.h
+++ b/src/iff.imageio/noproxy-iff_pvt.h
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 #pragma once

--- a/src/iff.imageio/noproxy-iffinput.cpp
+++ b/src/iff.imageio/noproxy-iffinput.cpp
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 #include "noproxy-iff_pvt.h"
 

--- a/src/iff.imageio/noproxy-iffoutput.cpp
+++ b/src/iff.imageio/noproxy-iffoutput.cpp
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 #include "noproxy-iff_pvt.h"

--- a/src/include/OpenImageIO/Imath.h.in
+++ b/src/include/OpenImageIO/Imath.h.in
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio/
 
 // clang-format off

--- a/src/include/OpenImageIO/array_view.h
+++ b/src/include/OpenImageIO/array_view.h
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/include/OpenImageIO/attrdelegate.h
+++ b/src/include/OpenImageIO/attrdelegate.h
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/include/OpenImageIO/benchmark.h
+++ b/src/include/OpenImageIO/benchmark.h
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 // clang-format off

--- a/src/include/OpenImageIO/deepdata.h
+++ b/src/include/OpenImageIO/deepdata.h
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/include/OpenImageIO/errorhandler.h
+++ b/src/include/OpenImageIO/errorhandler.h
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/include/OpenImageIO/filter.h
+++ b/src/include/OpenImageIO/filter.h
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/include/OpenImageIO/function_view.h
+++ b/src/include/OpenImageIO/function_view.h
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 // Portions of the code in this file is a derived work based on the

--- a/src/include/OpenImageIO/half.h.in
+++ b/src/include/OpenImageIO/half.h.in
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio/
 
 

--- a/src/include/OpenImageIO/image_view.h
+++ b/src/include/OpenImageIO/image_view.h
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/include/OpenImageIO/missing_math.h
+++ b/src/include/OpenImageIO/missing_math.h
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/include/OpenImageIO/optparser.h
+++ b/src/include/OpenImageIO/optparser.h
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/include/OpenImageIO/parallel.h
+++ b/src/include/OpenImageIO/parallel.h
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 #pragma once

--- a/src/include/OpenImageIO/plugin.h
+++ b/src/include/OpenImageIO/plugin.h
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/include/OpenImageIO/span.h
+++ b/src/include/OpenImageIO/span.h
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 // clang-format off

--- a/src/include/OpenImageIO/strongparam.h
+++ b/src/include/OpenImageIO/strongparam.h
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/include/OpenImageIO/tiffutils.h
+++ b/src/include/OpenImageIO/tiffutils.h
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 // clang-format off

--- a/src/include/OpenImageIO/type_traits.h
+++ b/src/include/OpenImageIO/type_traits.h
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 // clang-format off

--- a/src/include/OpenImageIO/unittest.h
+++ b/src/include/OpenImageIO/unittest.h
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 #pragma once

--- a/src/include/OpenImageIO/vecparam.h
+++ b/src/include/OpenImageIO/vecparam.h
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 #pragma once

--- a/src/jpeg2000.imageio/CMakeLists.txt
+++ b/src/jpeg2000.imageio/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 if (OPENJPEG_FOUND)

--- a/src/libOpenImageIO/bluenoise.cpp
+++ b/src/libOpenImageIO/bluenoise.cpp
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/libOpenImageIO/color_test.cpp
+++ b/src/libOpenImageIO/color_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 #include <algorithm>

--- a/src/libOpenImageIO/compute_test.cpp
+++ b/src/libOpenImageIO/compute_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/libOpenImageIO/deepdata.cpp
+++ b/src/libOpenImageIO/deepdata.cpp
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 #include <algorithm>

--- a/src/libOpenImageIO/exif-canon.cpp
+++ b/src/libOpenImageIO/exif-canon.cpp
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 // clang-format off

--- a/src/libOpenImageIO/exif.h
+++ b/src/libOpenImageIO/exif.h
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 // clang-format off

--- a/src/libOpenImageIO/imagebufalgo_addsub.cpp
+++ b/src/libOpenImageIO/imagebufalgo_addsub.cpp
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 /// \file

--- a/src/libOpenImageIO/imagebufalgo_channels.cpp
+++ b/src/libOpenImageIO/imagebufalgo_channels.cpp
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 /// \file

--- a/src/libOpenImageIO/imagebufalgo_compare.cpp
+++ b/src/libOpenImageIO/imagebufalgo_compare.cpp
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 /// \file

--- a/src/libOpenImageIO/imagebufalgo_copy.cpp
+++ b/src/libOpenImageIO/imagebufalgo_copy.cpp
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 #include <cmath>

--- a/src/libOpenImageIO/imagebufalgo_deep.cpp
+++ b/src/libOpenImageIO/imagebufalgo_deep.cpp
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/libOpenImageIO/imagebufalgo_mad.cpp
+++ b/src/libOpenImageIO/imagebufalgo_mad.cpp
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 #include <cmath>

--- a/src/libOpenImageIO/imagebufalgo_minmaxchan.cpp
+++ b/src/libOpenImageIO/imagebufalgo_minmaxchan.cpp
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 #include <cmath>

--- a/src/libOpenImageIO/imagebufalgo_muldiv.cpp
+++ b/src/libOpenImageIO/imagebufalgo_muldiv.cpp
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 /// \file

--- a/src/libOpenImageIO/imagebufalgo_orient.cpp
+++ b/src/libOpenImageIO/imagebufalgo_orient.cpp
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 #include <cmath>

--- a/src/libOpenImageIO/imagebufalgo_yee.cpp
+++ b/src/libOpenImageIO/imagebufalgo_yee.cpp
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/libOpenImageIO/imagecache_test.cpp
+++ b/src/libOpenImageIO/imagecache_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/libOpenImageIO/imagespeed_test.cpp
+++ b/src/libOpenImageIO/imagespeed_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/libOpenImageIO/printinfo.cpp
+++ b/src/libOpenImageIO/printinfo.cpp
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/libOpenImageIO/xmp.cpp
+++ b/src/libOpenImageIO/xmp.cpp
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/libtexture/environment.cpp
+++ b/src/libtexture/environment.cpp
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/libutil/argparse_test.cpp
+++ b/src/libutil/argparse_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 #include <vector>

--- a/src/libutil/benchmark.cpp
+++ b/src/libutil/benchmark.cpp
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 #include <cstdio>

--- a/src/libutil/filter_test.cpp
+++ b/src/libutil/filter_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 #include <vector>

--- a/src/libutil/fmath.cpp
+++ b/src/libutil/fmath.cpp
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 #include <OpenImageIO/half.h>

--- a/src/libutil/optparser_test.cpp
+++ b/src/libutil/optparser_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/libutil/parallel_test.cpp
+++ b/src/libutil/parallel_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/libutil/simd_test.cpp
+++ b/src/libutil/simd_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 // clang-format off

--- a/src/libutil/span_test.cpp
+++ b/src/libutil/span_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 #include <array>

--- a/src/libutil/spin_rw_test.cpp
+++ b/src/libutil/spin_rw_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/libutil/spinlock_test.cpp
+++ b/src/libutil/spinlock_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/libutil/strongparam_test.cpp
+++ b/src/libutil/strongparam_test.cpp
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/libutil/thread_test.cpp
+++ b/src/libutil/thread_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/libutil/timer_test.cpp
+++ b/src/libutil/timer_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/libutil/type_traits_test.cpp
+++ b/src/libutil/type_traits_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/libutil/typedesc_test.cpp
+++ b/src/libutil/typedesc_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/maketx/CMakeLists.txt
+++ b/src/maketx/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 fancy_add_executable (LINK_LIBRARIES OpenImageIO)

--- a/src/null.imageio/CMakeLists.txt
+++ b/src/null.imageio/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 add_oiio_plugin (nullimageio.cpp)

--- a/src/null.imageio/nullimageio.cpp
+++ b/src/null.imageio/nullimageio.cpp
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/openexr.imageio/exr_pvt.h
+++ b/src/openexr.imageio/exr_pvt.h
@@ -1,5 +1,5 @@
 // Copyright 2021-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 #pragma once

--- a/src/png.imageio/CMakeLists.txt
+++ b/src/png.imageio/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 if (TARGET PNG::PNG)

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 # from pythonutils.cmake

--- a/src/python/py_deepdata.cpp
+++ b/src/python/py_deepdata.cpp
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 #include "py_oiio.h"

--- a/src/python/py_roi.cpp
+++ b/src/python/py_roi.cpp
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 #include "py_oiio.h"

--- a/src/softimage.imageio/CMakeLists.txt
+++ b/src/softimage.imageio/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 add_oiio_plugin (softimageinput.cpp softimage_pvt.cpp)

--- a/src/term.imageio/CMakeLists.txt
+++ b/src/term.imageio/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 add_oiio_plugin (termoutput.cpp)

--- a/src/term.imageio/termoutput.cpp
+++ b/src/term.imageio/termoutput.cpp
@@ -1,5 +1,5 @@
 // Copyright 2008-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 #include <cstdio>

--- a/src/testtex/CMakeLists.txt
+++ b/src/testtex/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 # testtex ordinarily gets built for testing but is not "installed". Setting

--- a/src/zfile.imageio/CMakeLists.txt
+++ b/src/zfile.imageio/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2008-present Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 add_oiio_plugin (zfile.cpp

--- a/testsuite/cineon/run.py
+++ b/testsuite/cineon/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 files = [ "checker.cin" ]
 for f in files:
     command += info_command ("../oiio-images/cineon/" + f)

--- a/testsuite/cmake-consumer/CMakeLists.txt
+++ b/testsuite/cmake-consumer/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 cmake_minimum_required (VERSION 3.12)

--- a/testsuite/cmake-consumer/consumer.cpp
+++ b/testsuite/cmake-consumer/consumer.cpp
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/testsuite/cmake-consumer/run.py
+++ b/testsuite/cmake-consumer/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 

--- a/testsuite/diff/run.py
+++ b/testsuite/diff/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 # Make two images that differ by a particular known pixel value
 command += oiiotool("-pattern fill:color=0.1,0.1,0.1 64x64 3 -d float -o img1.exr")
 command += oiiotool("-pattern fill:color=0.1,0.1,0.1 64x64 3 -d float -box:fill=1:color=0.1,0.6,0.1 5,17,15,27 -o img2.exr")

--- a/testsuite/dither/run.py
+++ b/testsuite/dither/run.py
@@ -1,4 +1,9 @@
-#!/usr/bin/env python 
+#!/usr/bin/env python
+
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 
 # Basic test -- save with dither
 command += oiiotool ("-pattern fill:left=0,0,0:right=0.0625,0.0625,0.0625 256x256 3 -d uint8 -dither -o ramp.tif")

--- a/testsuite/dup-channels/run.py
+++ b/testsuite/dup-channels/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 # Test that appending channels fixes duplicate channel names
 
 

--- a/testsuite/hdr/run.py
+++ b/testsuite/hdr/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 # Make an .hdr image out of an openexr image -- tests write
 command += oiiotool (OIIO_TESTSUITE_IMAGEDIR+"/ScanLines/MtTamWest.exr -o MtTamWest.hdr")
 # read and print stats, that tests the read

--- a/testsuite/igrep/run.py
+++ b/testsuite/igrep/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 redirect = ' >> out.txt 2>&1 '
 
 command += run_app (oiio_app("igrep") + " -i -E wg ../oiio-images/tahoe-gps.jpg")

--- a/testsuite/iinfo/run.py
+++ b/testsuite/iinfo/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 command += info_command ("-s --stats ../common/textures/grid.tx", info_program="iinfo")
 
 # command += oiiotool ("-pattern constant:color=0.25,0.5,0.75 4x4 3 --origin +2+2 --fullsize 20x20+1+1 -o tiny-az.exr")

--- a/testsuite/jpeg-corrupt/run.py
+++ b/testsuite/jpeg-corrupt/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 failureok = 1
 redirect = ' >> out.txt 2>&1 '
 

--- a/testsuite/jpeg2000-j2kp4files/run.py
+++ b/testsuite/jpeg2000-j2kp4files/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 # Allow some LSB slop -- necessary because of the alpha disassociation
 # combined with implied sRGB conversion.
 failthresh = 0.02

--- a/testsuite/misnamed-file/run.py
+++ b/testsuite/misnamed-file/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 from __future__ import absolute_import
 import shutil
 

--- a/testsuite/missingcolor/run.py
+++ b/testsuite/missingcolor/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 # Test "missingcolor" attribute by reading a tiled exr that deliberately has
 # missing tiles. Make sure that we do the right thing in the presence of
 # missingcolor attribute.

--- a/testsuite/missingcolor/src/makepartialexr.py
+++ b/testsuite/missingcolor/src/makepartialexr.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python
+
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 from __future__ import print_function
 from __future__ import absolute_import
 import OpenImageIO as oiio

--- a/testsuite/nonwhole-tiles/run.py
+++ b/testsuite/nonwhole-tiles/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 # Regression test for stride bugs for tiled images where resolution isn't
 # a whole number of tiles.  This particular resolution mimics a particular
 # failure case known to cause problems that I debugged.

--- a/testsuite/null/run.py
+++ b/testsuite/null/run.py
@@ -1,3 +1,8 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 command += oiiotool ('-v -info -stats "foo.null?RES=640x480&CHANNELS=3&TYPE=uint8&PIXEL=0.25,0.5,1"')

--- a/testsuite/oiiotool-color/run.py
+++ b/testsuite/oiiotool-color/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 from __future__ import absolute_import
 import os
 

--- a/testsuite/oiiotool-composite/run.py
+++ b/testsuite/oiiotool-composite/run.py
@@ -1,4 +1,9 @@
-#!/usr/bin/env python 
+#!/usr/bin/env python
+
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 
 # Test for oiiotool application of the Porter/Duff compositing operations
 #

--- a/testsuite/oiiotool-control/run.py
+++ b/testsuite/oiiotool-control/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 # Create some test images we need
 # command += oiiotool ("--create 320x240 3 -d uint8 -o black.tif")
 # command += oiiotool ("--pattern constant:color=0.5,0.5,0.5 128x128 3 -d half -o grey128.exr")

--- a/testsuite/oiiotool-copy/run.py
+++ b/testsuite/oiiotool-copy/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 ####################################################################
 # This test exercises oiiotool functionality that is mostly about
 # copying pixels from one image to another.

--- a/testsuite/oiiotool-fixnan/run.py
+++ b/testsuite/oiiotool-fixnan/run.py
@@ -1,4 +1,9 @@
-#!/usr/bin/env python 
+#!/usr/bin/env python
+
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 
 redirect = " >> out.txt 2>&1"
 failureok = True

--- a/testsuite/oiiotool-pattern/run.py
+++ b/testsuite/oiiotool-pattern/run.py
@@ -1,4 +1,9 @@
-#!/usr/bin/env python 
+#!/usr/bin/env python
+
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 
 # test --create
 command += oiiotool ("--create 320x240 3 -d uint8 -o black.tif")

--- a/testsuite/oiiotool-readerror/run.py
+++ b/testsuite/oiiotool-readerror/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 # change redirection to send stderr to a separate file
 redirect = " >> out.txt 2> out.err.txt "
 

--- a/testsuite/oiiotool-subimage/run.py
+++ b/testsuite/oiiotool-subimage/run.py
@@ -1,4 +1,9 @@
-#!/usr/bin/env python 
+#!/usr/bin/env python
+
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 
 # Slightly bump allowable failures, for slightly shifting font rendering
 # with changed freetype versions.

--- a/testsuite/oiiotool-text/run.py
+++ b/testsuite/oiiotool-text/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 from __future__ import absolute_import
 import os
 

--- a/testsuite/openexr-compression/run.py
+++ b/testsuite/openexr-compression/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 imagedir = "../common"
 
 compressions = [

--- a/testsuite/openexr-damaged/run.py
+++ b/testsuite/openexr-damaged/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 import os
 import shutil
 import OpenImageIO as oiio

--- a/testsuite/openexr-window/run.py
+++ b/testsuite/openexr-window/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 # Make sure we can do a read-write-read round trip of all the OpenEXR
 # test images that exercise different display and pixel windows.
 

--- a/testsuite/png-damaged/run.py
+++ b/testsuite/png-damaged/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 # save the error output
 redirect = " >> out.txt 2>&1 "
 failureok = 1

--- a/testsuite/psd-colormodes/run.py
+++ b/testsuite/psd-colormodes/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 failthresh = 0.008
 anymatch = True
 imagedir = "src/"

--- a/testsuite/ptex/run.py
+++ b/testsuite/ptex/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 imagedir = "src"
 files = [ "triangle.ptx" ]
 for f in files:

--- a/testsuite/python-colorconfig/run.py
+++ b/testsuite/python-colorconfig/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 from __future__ import absolute_import
 import os
 

--- a/testsuite/python-deep/run.py
+++ b/testsuite/python-deep/run.py
@@ -1,4 +1,9 @@
-#!/usr/bin/env python 
+#!/usr/bin/env python
+
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 
 command += pythonbin + " src/test_deep.py > out.txt"
 

--- a/testsuite/python-deep/src/test_deep.py
+++ b/testsuite/python-deep/src/test_deep.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import

--- a/testsuite/python-imagebuf/run.py
+++ b/testsuite/python-imagebuf/run.py
@@ -1,4 +1,9 @@
-#!/usr/bin/env python 
+#!/usr/bin/env python
+
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 
 # Run the script 
 command += pythonbin + " src/test_imagebuf.py > out.txt ;"

--- a/testsuite/python-imagebuf/src/test_imagebuf.py
+++ b/testsuite/python-imagebuf/src/test_imagebuf.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 from __future__ import print_function
 from __future__ import absolute_import
 import array

--- a/testsuite/python-imagecache/run.py
+++ b/testsuite/python-imagecache/run.py
@@ -1,4 +1,9 @@
-#!/usr/bin/env python 
+#!/usr/bin/env python
+
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 
 # Run the script 
 command += pythonbin + " src/test_imagecache.py > out.txt ;"

--- a/testsuite/python-imagecache/src/test_imagecache.py
+++ b/testsuite/python-imagecache/src/test_imagecache.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 from __future__ import print_function
 from __future__ import absolute_import
 import array

--- a/testsuite/python-imageinput/run.py
+++ b/testsuite/python-imageinput/run.py
@@ -1,4 +1,9 @@
-#!/usr/bin/env python 
+#!/usr/bin/env python
+
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 
 shutil.copyfile ("../common/textures/grid.tx", "grid.tx")
 

--- a/testsuite/python-imagespec/run.py
+++ b/testsuite/python-imagespec/run.py
@@ -1,4 +1,9 @@
-#!/usr/bin/env python 
+#!/usr/bin/env python
+
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 
 command += pythonbin + " src/test_imagespec.py > out.txt"
 

--- a/testsuite/python-imagespec/src/test_imagespec.py
+++ b/testsuite/python-imagespec/src/test_imagespec.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 from __future__ import print_function
 from __future__ import absolute_import
 import numpy

--- a/testsuite/python-paramlist/run.py
+++ b/testsuite/python-paramlist/run.py
@@ -1,4 +1,9 @@
-#!/usr/bin/env python 
+#!/usr/bin/env python
+
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 
 command += pythonbin + " src/test_paramlist.py > out.txt"
 

--- a/testsuite/python-paramlist/src/test_paramlist.py
+++ b/testsuite/python-paramlist/src/test_paramlist.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 from __future__ import print_function
 from __future__ import absolute_import
 import numpy

--- a/testsuite/python-roi/run.py
+++ b/testsuite/python-roi/run.py
@@ -1,4 +1,9 @@
-#!/usr/bin/env python 
+#!/usr/bin/env python
+
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 
 command += pythonbin + " src/test_roi.py > out.txt"
 

--- a/testsuite/python-roi/src/test_roi.py
+++ b/testsuite/python-roi/src/test_roi.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 from __future__ import print_function
 from __future__ import absolute_import
 import OpenImageIO as oiio

--- a/testsuite/python-typedesc/run.py
+++ b/testsuite/python-typedesc/run.py
@@ -1,4 +1,9 @@
-#!/usr/bin/env python 
+#!/usr/bin/env python
+
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 
 command += pythonbin + " src/test_typedesc.py > out.txt"
 

--- a/testsuite/rational/run.py
+++ b/testsuite/rational/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 # Test reading and writing of files with "rational" metadata
 
 

--- a/testsuite/raw/run.py
+++ b/testsuite/raw/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 from __future__ import absolute_import
 import os
 

--- a/testsuite/sgi/run.py
+++ b/testsuite/sgi/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 imagedir = "ref/"
 files = [ "norle-8.sgi", "rle-8.sgi", "norle-16.sgi", "rle-16.sgi" ]
 for f in files:

--- a/testsuite/targa-thumbnail/run.py
+++ b/testsuite/targa-thumbnail/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 import OpenImageIO as oiio
 import os
 

--- a/testsuite/targa-thumbnail/src/extractthumb.py
+++ b/testsuite/targa-thumbnail/src/extractthumb.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 from __future__ import print_function
 from __future__ import absolute_import
 import OpenImageIO as oiio

--- a/testsuite/term/run.py
+++ b/testsuite/term/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 redirect = ' >> out.txt 2>&1 '
 
 command += oiiotool ("-pattern fill:topleft=1,0,0:topright=0,1,0:bottomleft=0,0,1:bottomright=1,1,1 60x40 3 -o ramp.exr")

--- a/testsuite/texture-blurtube/run.py
+++ b/testsuite/texture-blurtube/run.py
@@ -1,4 +1,9 @@
-#!/usr/bin/env python 
+#!/usr/bin/env python
+
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 
 # This test renders the "tube" pattern with a checker pattern (i.e.,
 # showing all angles and a wide range of anisotropy), at several

--- a/testsuite/texture-colorspace/run.py
+++ b/testsuite/texture-colorspace/run.py
@@ -1,4 +1,9 @@
-#!/usr/bin/env python 
+#!/usr/bin/env python
+
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 
 # This test just maps a 50% grey texture, once with default settings, and once
 # declaring that it thinks the texture is in sRGB texture space.

--- a/testsuite/texture-crop/run.py
+++ b/testsuite/texture-crop/run.py
@@ -1,4 +1,9 @@
-#!/usr/bin/env python 
+#!/usr/bin/env python
+
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 
 command += oiiotool("../common/grid.tif --crop 512x512+200+100 -o grid-crop.tif")
 command += maketx_command ("grid-crop.tif", "grid-crop.tx")

--- a/testsuite/texture-cropover/run.py
+++ b/testsuite/texture-cropover/run.py
@@ -1,4 +1,9 @@
-#!/usr/bin/env python 
+#!/usr/bin/env python
+
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 
 # Tests input image which is partial crop, partial overscan!
 

--- a/testsuite/texture-derivs/run.py
+++ b/testsuite/texture-derivs/run.py
@@ -1,4 +1,9 @@
-#!/usr/bin/env python 
+#!/usr/bin/env python
+
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 
 # OLD CODE: (result ramp.exr is now checked into src)
 # import OpenImageIO as oiio

--- a/testsuite/texture-env/run.py
+++ b/testsuite/texture-env/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 redirect = ">> out.txt 2>&1"
 # Create a ramped checker
 command += oiiotool("-pattern fill:topleft=0,0,0,1:topright=1,0,0,1:bottomleft=0,1,0,1:bottomright=1,1,0,1 256x128 4 "

--- a/testsuite/texture-fat/run.py
+++ b/testsuite/texture-fat/run.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 command = testtex_command ("src/horizgrid.tx", " --scalest 1 4")
 outputs = [ "out.exr" ]

--- a/testsuite/texture-fill/run.py
+++ b/testsuite/texture-fill/run.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 command = testtex_command ("src/gray.png", "-fill 0.05 --res 128 128 --nowarp")
 outputs = [ "out.exr" ]

--- a/testsuite/texture-filtersize-stochastic/run.py
+++ b/testsuite/texture-filtersize-stochastic/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 # This test just views the "miplevels" texture straight on, but it uses
 # -widthramp to smoothly blend between mipmap levels from left to right
 # (wanting the 256^2 level at the left and the 64^2 level at the right).

--- a/testsuite/texture-flipt/run.py
+++ b/testsuite/texture-flipt/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 command = oiiotool ("-pattern fill:topleft=0,0,0:topright=1,0,0:bottomleft=0,1,0:bottomright=1,1,1 "
                     + "64x64 3 -otex gradient.tx")
 command += testtex_command ("gradient.tx",

--- a/testsuite/texture-gettexels/run.py
+++ b/testsuite/texture-gettexels/run.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 command = testtex_command ("--gettexels -res 128 128 -d uint8 ../common/textures/grid.tx -o postage.tif")
 outputs = [ "postage.tif" ]

--- a/testsuite/texture-gray/run.py
+++ b/testsuite/texture-gray/run.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 command = testtex_command ("src/gray.png", " -fill 0.05 --graytorgb --res 128 128 --nowarp ")
 outputs = [ "out.exr" ]

--- a/testsuite/texture-half/run.py
+++ b/testsuite/texture-half/run.py
@@ -1,4 +1,9 @@
-#!/usr/bin/env python 
+#!/usr/bin/env python
+
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 
 command += maketx_command  ("../common/textures/grid.tx", "grid-half.exr",
                             "-d half", showinfo=True)

--- a/testsuite/texture-interp-bicubic/run.py
+++ b/testsuite/texture-interp-bicubic/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 command = testtex_command ("../common/textures/grid.tx",
                            extraargs = "-interpmode 2  -d uint8 -o out.tif")
 outputs = [ "out.tif" ]

--- a/testsuite/texture-interp-bilinear/run.py
+++ b/testsuite/texture-interp-bilinear/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 command = testtex_command ("../common/textures/grid.tx",
                            extraargs = "-interpmode 1  -d uint8 -o out.tif")
 outputs = [ "out.tif" ]

--- a/testsuite/texture-interp-closest/run.py
+++ b/testsuite/texture-interp-closest/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 # Adjust error thresholds a tad to account for platform-to-platform variation
 # in some math precision.
 hardfail = 0.032

--- a/testsuite/texture-levels-stochaniso/run.py
+++ b/testsuite/texture-levels-stochaniso/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 # Adjust error thresholds a tad to account for platform-to-platform variation
 # in some math precision.
 hardfail = 0.16

--- a/testsuite/texture-levels-stochmip/run.py
+++ b/testsuite/texture-levels-stochmip/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 # Adjust error thresholds a tad to account for platform-to-platform variation
 # in some math precision.
 hardfail = 0.16

--- a/testsuite/texture-maxres/run.py
+++ b/testsuite/texture-maxres/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 command = (oiio_app("testtex") + " -res 256 256 "
            + "-texoptions max_mip_res=128 "
            + OIIO_TESTSUITE_IMAGEDIR + "/miplevels.tx"

--- a/testsuite/texture-mip-nomip/run.py
+++ b/testsuite/texture-mip-nomip/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 command = testtex_command ("../common/textures/grid.tx",
                            extraargs = "-mipmode 1  -d uint8 -o out.tif")
 outputs = [ "out.tif" ]

--- a/testsuite/texture-mip-onelevel/run.py
+++ b/testsuite/texture-mip-onelevel/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 command = testtex_command ("../common/textures/grid.tx",
                            extraargs = "-mipmode 2  -d uint8 -o out.tif")
 outputs = [ "out.tif" ]

--- a/testsuite/texture-mip-stochasticaniso/run.py
+++ b/testsuite/texture-mip-stochasticaniso/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 # Adjust error thresholds a tad to account for platform-to-platform variation
 # in some math precision.
 hardfail = 0.16

--- a/testsuite/texture-mip-stochastictrilinear/run.py
+++ b/testsuite/texture-mip-stochastictrilinear/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 command = testtex_command ("../common/textures/grid.tx",
                            extraargs = "-mipmode 3 -stochastic 1 -d uint8 -o out.tif")
 outputs = [ "out.tif" ]

--- a/testsuite/texture-mip-trilinear/run.py
+++ b/testsuite/texture-mip-trilinear/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 command = testtex_command ("../common/textures/grid.tx",
                            extraargs = "-mipmode 3  -d uint8 -o out.tif")
 outputs = [ "out.tif" ]

--- a/testsuite/texture-missing/run.py
+++ b/testsuite/texture-missing/run.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 command = testtex_command ("missing.tx", "--missing 1 0 0 --res 8 8 missing.tx")
 outputs = [ "out.exr" ]

--- a/testsuite/texture-overscan/run.py
+++ b/testsuite/texture-overscan/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 # Creates a texture with overscan -- it looks like the usual grid in the
 # 0-1 (display) window, but is red checker for a while outside that window.
 #

--- a/testsuite/texture-pointsample/run.py
+++ b/testsuite/texture-pointsample/run.py
@@ -1,4 +1,9 @@
-#!/usr/bin/env python 
+#!/usr/bin/env python
+
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 
 command = testtex_command ("../common/textures/grid.tx", " -width 0")
 outputs = [ "out.exr" ]

--- a/testsuite/texture-skinny/run.py
+++ b/testsuite/texture-skinny/run.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 command = testtex_command ("src/vertgrid.tx", " --scalest 4 1 ")
 outputs = [ "out.exr" ]

--- a/testsuite/texture-stats/run.py
+++ b/testsuite/texture-stats/run.py
@@ -1,4 +1,9 @@
-#!/usr/bin/env python 
+#!/usr/bin/env python
+
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 
 redirect = " >> stats.txt"
 command = testtex_command ("../common/textures/grid.tx -res 64 48 -v --teststatquery --runstats")

--- a/testsuite/texture-texture3d/run.py
+++ b/testsuite/texture-texture3d/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 redirect = ">> out.txt 2>&1"
 
 # basic

--- a/testsuite/texture-threadtimes/run.py
+++ b/testsuite/texture-threadtimes/run.py
@@ -1,4 +1,9 @@
-#!/usr/bin/env python 
+#!/usr/bin/env python
+
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 
 command += testtex_command ("--maketests 10 \"test{:04}.exr\" --maketest-res 1024 --threadtimes 7 --wedge")
 

--- a/testsuite/texture-udim/run.py
+++ b/testsuite/texture-udim/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 command += oiiotool ("-pattern constant:color=.5,.1,.1 256x256 3 -text:size=50:x=75:y=140 1001 --attrib Make pet --attrib Model dog -d uint8 -otex file.1001.tx")
 command += oiiotool ("-pattern constant:color=.1,.5,.1 256x256 3 -text:size=50:x=75:y=140 1002 --attrib Make pet --attrib Model dog -d uint8 -otex file.1002.tx")
 # force DateTime to differ in these files

--- a/testsuite/texture-uint16/run.py
+++ b/testsuite/texture-uint16/run.py
@@ -1,4 +1,9 @@
-#!/usr/bin/env python 
+#!/usr/bin/env python
+
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 
 command += maketx_command  ("../common/textures/grid.tx",
                             "grid-uint16.tx",

--- a/testsuite/texture-uint8/run.py
+++ b/testsuite/texture-uint8/run.py
@@ -1,4 +1,9 @@
-#!/usr/bin/env python 
+#!/usr/bin/env python
+
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 
 command = testtex_command ("../common/textures/grid.tx")
 outputs = [ "out.exr" ]

--- a/testsuite/texture-width0blur/run.py
+++ b/testsuite/texture-width0blur/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 command = testtex_command ("../common/textures/grid.tx",
                            "-res 256 256 -nowarp --width 0 --blur 0.1 --wrap clamp -d uint8 -o out.tif")
 outputs = [ "out.tif" ]

--- a/testsuite/tiff-misc/run.py
+++ b/testsuite/tiff-misc/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 # Miscellaneous TIFF-related tests
 
 # save the error output

--- a/testsuite/zfile/run.py
+++ b/testsuite/zfile/run.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+
 imagedir = "ref/"
 command += oiiotool ("-pattern fill:topleft=0.1:topright=0.5:bottomleft=1.0:bottomright=0.3 64x64 1 -chnames Z -d float -o out.zfile")
 command += info_command ("out.zfile", extraargs="-stats")


### PR DESCRIPTION
Since LG has re-licensed all his old code under Apache-2.0, we can change the license notice from BSD to Apache-2.0 for all files in which LG is the only extant author.

Some files that LG authored (mostly test scripts) had no license notice, so in those cases, we added one.

