### PR TITLE
admin: Copyright and license notice updates

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
 # https://github.com/OpenImageIO/oiio
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
 # https://github.com/OpenImageIO/oiio
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
 # https://github.com/OpenImageIO/oiio
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 #
 # Run 'make help' to list helpful targets.
 #
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
 # https://github.com/OpenImageIO/oiio
 #########################################################################

--- a/src/bmp.imageio/CMakeLists.txt
+++ b/src/bmp.imageio/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 # https://github.com/OpenImageIO/oiio
 

--- a/src/bmp.imageio/bmp_pvt.cpp
+++ b/src/bmp.imageio/bmp_pvt.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/bmp.imageio/bmp_pvt.h
+++ b/src/bmp.imageio/bmp_pvt.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/bmp.imageio/bmpinput.cpp
+++ b/src/bmp.imageio/bmpinput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/bmp.imageio/bmpoutput.cpp
+++ b/src/bmp.imageio/bmpoutput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/build-scripts/gh-win-installdeps.bash
+++ b/src/build-scripts/gh-win-installdeps.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 

--- a/src/cineon.imageio/CMakeLists.txt
+++ b/src/cineon.imageio/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 

--- a/src/cineon.imageio/cineoninput.cpp
+++ b/src/cineon.imageio/cineoninput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/cmake/check_is_enabled.cmake
+++ b/src/cmake/check_is_enabled.cmake
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 

--- a/src/cmake/colors.cmake
+++ b/src/cmake/colors.cmake
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 

--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
 # https://github.com/OpenImageIO/oiio
 

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
 # https://github.com/OpenImageIO/oiio
 

--- a/src/cmake/modules/FindFFmpeg.cmake
+++ b/src/cmake/modules/FindFFmpeg.cmake
@@ -16,7 +16,7 @@
 #   BSD license.
 #
 # Modifications:
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
 # https://github.com/OpenImageIO/oiio
 

--- a/src/cmake/pythonutils.cmake
+++ b/src/cmake/pythonutils.cmake
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 # https://github.com/OpenImageIO/oiio
 

--- a/src/dds.imageio/CMakeLists.txt
+++ b/src/dds.imageio/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 # https://github.com/OpenImageIO/oiio
 

--- a/src/dds.imageio/dds_pvt.h
+++ b/src/dds.imageio/dds_pvt.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/dds.imageio/ddsinput.cpp
+++ b/src/dds.imageio/ddsinput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/dicom.imageio/CMakeLists.txt
+++ b/src/dicom.imageio/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 

--- a/src/dicom.imageio/dicominput.cpp
+++ b/src/dicom.imageio/dicominput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/doc/CMakeLists.txt
+++ b/src/doc/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 # https://github.com/OpenImageIO/oiio
 

--- a/src/dpx.imageio/CMakeLists.txt
+++ b/src/dpx.imageio/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 

--- a/src/dpx.imageio/dpxinput.cpp
+++ b/src/dpx.imageio/dpxinput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/dpx.imageio/dpxoutput.cpp
+++ b/src/dpx.imageio/dpxoutput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/ffmpeg.imageio/CMakeLists.txt
+++ b/src/ffmpeg.imageio/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 # https://github.com/OpenImageIO/oiio
 

--- a/src/ffmpeg.imageio/ffmpeginput.cpp
+++ b/src/ffmpeg.imageio/ffmpeginput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/fits.imageio/CMakeLists.txt
+++ b/src/fits.imageio/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 

--- a/src/fits.imageio/fits_pvt.cpp
+++ b/src/fits.imageio/fits_pvt.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/fits.imageio/fits_pvt.h
+++ b/src/fits.imageio/fits_pvt.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/fits.imageio/fitsinput.cpp
+++ b/src/fits.imageio/fitsinput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/fits.imageio/fitsoutput.cpp
+++ b/src/fits.imageio/fitsoutput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/fonts/CMakeLists.txt
+++ b/src/fonts/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 # https://github.com/OpenImageIO/oiio
 

--- a/src/gif.imageio/CMakeLists.txt
+++ b/src/gif.imageio/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 # https://github.com/OpenImageIO/oiio
 

--- a/src/gif.imageio/gifinput.cpp
+++ b/src/gif.imageio/gifinput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/gif.imageio/gifoutput.cpp
+++ b/src/gif.imageio/gifoutput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/hdr.imageio/CMakeLists.txt
+++ b/src/hdr.imageio/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 

--- a/src/hdr.imageio/hdrinput.cpp
+++ b/src/hdr.imageio/hdrinput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/hdr.imageio/hdroutput.cpp
+++ b/src/hdr.imageio/hdroutput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/heif.imageio/CMakeLists.txt
+++ b/src/heif.imageio/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 

--- a/src/heif.imageio/heifinput.cpp
+++ b/src/heif.imageio/heifinput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/heif.imageio/heifoutput.cpp
+++ b/src/heif.imageio/heifoutput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/ico.imageio/CMakeLists.txt
+++ b/src/ico.imageio/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 

--- a/src/ico.imageio/ico.h
+++ b/src/ico.imageio/ico.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/ico.imageio/icoinput.cpp
+++ b/src/ico.imageio/icoinput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/ico.imageio/icooutput.cpp
+++ b/src/ico.imageio/icooutput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/iconvert/CMakeLists.txt
+++ b/src/iconvert/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 

--- a/src/iconvert/iconvert.cpp
+++ b/src/iconvert/iconvert.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/idiff/CMakeLists.txt
+++ b/src/idiff/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 

--- a/src/idiff/idiff.cpp
+++ b/src/idiff/idiff.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/iff.imageio/CMakeLists.txt
+++ b/src/iff.imageio/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 

--- a/src/iff.imageio/iff_pvt.h
+++ b/src/iff.imageio/iff_pvt.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/iff.imageio/iffinput.cpp
+++ b/src/iff.imageio/iffinput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 #include "iff_pvt.h"

--- a/src/iff.imageio/iffoutput.cpp
+++ b/src/iff.imageio/iffoutput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/iff.imageio/noproxy-iff_pvt.cpp
+++ b/src/iff.imageio/noproxy-iff_pvt.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 #include "noproxy-iff_pvt.h"

--- a/src/iff.imageio/noproxy-iff_pvt.h
+++ b/src/iff.imageio/noproxy-iff_pvt.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/iff.imageio/noproxy-iffinput.cpp
+++ b/src/iff.imageio/noproxy-iffinput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 #include "noproxy-iff_pvt.h"

--- a/src/iff.imageio/noproxy-iffoutput.cpp
+++ b/src/iff.imageio/noproxy-iffoutput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/igrep/CMakeLists.txt
+++ b/src/igrep/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 # https://github.com/OpenImageIO/oiio
 

--- a/src/igrep/igrep.cpp
+++ b/src/igrep/igrep.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/iinfo/CMakeLists.txt
+++ b/src/iinfo/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 # https://github.com/OpenImageIO/oiio
 

--- a/src/iinfo/iinfo.cpp
+++ b/src/iinfo/iinfo.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/include/CMakeLists.txt
+++ b/src/include/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
 # https://github.com/OpenImageIO/oiio
 

--- a/src/include/OpenImageIO/Imath.h.in
+++ b/src/include/OpenImageIO/Imath.h.in
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio/
 

--- a/src/include/OpenImageIO/argparse.h
+++ b/src/include/OpenImageIO/argparse.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/include/OpenImageIO/array_view.h
+++ b/src/include/OpenImageIO/array_view.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/include/OpenImageIO/atomic.h
+++ b/src/include/OpenImageIO/atomic.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/include/OpenImageIO/attrdelegate.h
+++ b/src/include/OpenImageIO/attrdelegate.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/include/OpenImageIO/benchmark.h
+++ b/src/include/OpenImageIO/benchmark.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/include/OpenImageIO/color.h
+++ b/src/include/OpenImageIO/color.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/include/OpenImageIO/dassert.h
+++ b/src/include/OpenImageIO/dassert.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/include/OpenImageIO/deepdata.h
+++ b/src/include/OpenImageIO/deepdata.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/include/OpenImageIO/detail/fmt.h
+++ b/src/include/OpenImageIO/detail/fmt.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/include/OpenImageIO/errorhandler.h
+++ b/src/include/OpenImageIO/errorhandler.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/include/OpenImageIO/export.h
+++ b/src/include/OpenImageIO/export.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/include/OpenImageIO/filesystem.h
+++ b/src/include/OpenImageIO/filesystem.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/include/OpenImageIO/filter.h
+++ b/src/include/OpenImageIO/filter.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/include/OpenImageIO/fmath.h
+++ b/src/include/OpenImageIO/fmath.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/include/OpenImageIO/fstream_mingw.h
+++ b/src/include/OpenImageIO/fstream_mingw.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/include/OpenImageIO/function_view.h
+++ b/src/include/OpenImageIO/function_view.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/include/OpenImageIO/half.h.in
+++ b/src/include/OpenImageIO/half.h.in
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio/
 

--- a/src/include/OpenImageIO/hash.h
+++ b/src/include/OpenImageIO/hash.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/include/OpenImageIO/image_view.h
+++ b/src/include/OpenImageIO/image_view.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/include/OpenImageIO/imagebufalgo_util.h
+++ b/src/include/OpenImageIO/imagebufalgo_util.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/include/OpenImageIO/imagecache.h
+++ b/src/include/OpenImageIO/imagecache.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/include/OpenImageIO/missing_math.h
+++ b/src/include/OpenImageIO/missing_math.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/include/OpenImageIO/oiioversion.h.in
+++ b/src/include/OpenImageIO/oiioversion.h.in
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/include/OpenImageIO/optparser.h
+++ b/src/include/OpenImageIO/optparser.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/include/OpenImageIO/parallel.h
+++ b/src/include/OpenImageIO/parallel.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/include/OpenImageIO/paramlist.h
+++ b/src/include/OpenImageIO/paramlist.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/include/OpenImageIO/platform.h
+++ b/src/include/OpenImageIO/platform.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/include/OpenImageIO/plugin.h
+++ b/src/include/OpenImageIO/plugin.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/include/OpenImageIO/refcnt.h
+++ b/src/include/OpenImageIO/refcnt.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/include/OpenImageIO/simd.h
+++ b/src/include/OpenImageIO/simd.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/include/OpenImageIO/span.h
+++ b/src/include/OpenImageIO/span.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/include/OpenImageIO/strided_ptr.h
+++ b/src/include/OpenImageIO/strided_ptr.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/include/OpenImageIO/string_view.h
+++ b/src/include/OpenImageIO/string_view.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/include/OpenImageIO/strutil.h
+++ b/src/include/OpenImageIO/strutil.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/include/OpenImageIO/sysutil.h
+++ b/src/include/OpenImageIO/sysutil.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/include/OpenImageIO/texture.h
+++ b/src/include/OpenImageIO/texture.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/include/OpenImageIO/thread.h
+++ b/src/include/OpenImageIO/thread.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/include/OpenImageIO/tiffutils.h
+++ b/src/include/OpenImageIO/tiffutils.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/include/OpenImageIO/timer.h
+++ b/src/include/OpenImageIO/timer.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/include/OpenImageIO/type_traits.h
+++ b/src/include/OpenImageIO/type_traits.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/include/OpenImageIO/typedesc.h
+++ b/src/include/OpenImageIO/typedesc.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/include/OpenImageIO/unittest.h
+++ b/src/include/OpenImageIO/unittest.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/include/OpenImageIO/unordered_map_concurrent.h
+++ b/src/include/OpenImageIO/unordered_map_concurrent.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/include/OpenImageIO/ustring.h
+++ b/src/include/OpenImageIO/ustring.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/include/OpenImageIO/varyingref.h
+++ b/src/include/OpenImageIO/varyingref.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/include/OpenImageIO/vecparam.h
+++ b/src/include/OpenImageIO/vecparam.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/iv/CMakeLists.txt
+++ b/src/iv/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
 # https://github.com/OpenImageIO/oiio
 

--- a/src/iv/imageviewer.cpp
+++ b/src/iv/imageviewer.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/iv/imageviewer.h
+++ b/src/iv/imageviewer.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/iv/ivgl.cpp
+++ b/src/iv/ivgl.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/iv/ivgl.h
+++ b/src/iv/ivgl.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/iv/ivimage.cpp
+++ b/src/iv/ivimage.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/iv/ivinfowin.cpp
+++ b/src/iv/ivinfowin.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/iv/ivmain.cpp
+++ b/src/iv/ivmain.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/iv/ivpref.cpp
+++ b/src/iv/ivpref.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/jpeg.imageio/CMakeLists.txt
+++ b/src/jpeg.imageio/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 # https://github.com/OpenImageIO/oiio
 

--- a/src/jpeg.imageio/jpeg_pvt.h
+++ b/src/jpeg.imageio/jpeg_pvt.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/jpeg.imageio/jpeginput.cpp
+++ b/src/jpeg.imageio/jpeginput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/jpeg.imageio/jpegoutput.cpp
+++ b/src/jpeg.imageio/jpegoutput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/jpeg2000.imageio/CMakeLists.txt
+++ b/src/jpeg2000.imageio/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 

--- a/src/jpeg2000.imageio/jpeg2000input.cpp
+++ b/src/jpeg2000.imageio/jpeg2000input.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/jpeg2000.imageio/jpeg2000output.cpp
+++ b/src/jpeg2000.imageio/jpeg2000output.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libOpenImageIO/bluenoise.cpp
+++ b/src/libOpenImageIO/bluenoise.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libOpenImageIO/color_test.cpp
+++ b/src/libOpenImageIO/color_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libOpenImageIO/compute_test.cpp
+++ b/src/libOpenImageIO/compute_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libOpenImageIO/deepdata.cpp
+++ b/src/libOpenImageIO/deepdata.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libOpenImageIO/exif-canon.cpp
+++ b/src/libOpenImageIO/exif-canon.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libOpenImageIO/exif.cpp
+++ b/src/libOpenImageIO/exif.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libOpenImageIO/exif.h
+++ b/src/libOpenImageIO/exif.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libOpenImageIO/icc.cpp
+++ b/src/libOpenImageIO/icc.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libOpenImageIO/imagebuf_test.cpp
+++ b/src/libOpenImageIO/imagebuf_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libOpenImageIO/imagebufalgo.cpp
+++ b/src/libOpenImageIO/imagebufalgo.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libOpenImageIO/imagebufalgo_addsub.cpp
+++ b/src/libOpenImageIO/imagebufalgo_addsub.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libOpenImageIO/imagebufalgo_channels.cpp
+++ b/src/libOpenImageIO/imagebufalgo_channels.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libOpenImageIO/imagebufalgo_compare.cpp
+++ b/src/libOpenImageIO/imagebufalgo_compare.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libOpenImageIO/imagebufalgo_copy.cpp
+++ b/src/libOpenImageIO/imagebufalgo_copy.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libOpenImageIO/imagebufalgo_deep.cpp
+++ b/src/libOpenImageIO/imagebufalgo_deep.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libOpenImageIO/imagebufalgo_draw.cpp
+++ b/src/libOpenImageIO/imagebufalgo_draw.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libOpenImageIO/imagebufalgo_mad.cpp
+++ b/src/libOpenImageIO/imagebufalgo_mad.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libOpenImageIO/imagebufalgo_minmaxchan.cpp
+++ b/src/libOpenImageIO/imagebufalgo_minmaxchan.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libOpenImageIO/imagebufalgo_muldiv.cpp
+++ b/src/libOpenImageIO/imagebufalgo_muldiv.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libOpenImageIO/imagebufalgo_opencv.cpp
+++ b/src/libOpenImageIO/imagebufalgo_opencv.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libOpenImageIO/imagebufalgo_orient.cpp
+++ b/src/libOpenImageIO/imagebufalgo_orient.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libOpenImageIO/imagebufalgo_pixelmath.cpp
+++ b/src/libOpenImageIO/imagebufalgo_pixelmath.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libOpenImageIO/imagebufalgo_test.cpp
+++ b/src/libOpenImageIO/imagebufalgo_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libOpenImageIO/imagebufalgo_xform.cpp
+++ b/src/libOpenImageIO/imagebufalgo_xform.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libOpenImageIO/imagebufalgo_yee.cpp
+++ b/src/libOpenImageIO/imagebufalgo_yee.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libOpenImageIO/imagecache_test.cpp
+++ b/src/libOpenImageIO/imagecache_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libOpenImageIO/imageinout_test.cpp
+++ b/src/libOpenImageIO/imageinout_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libOpenImageIO/imageinput.cpp
+++ b/src/libOpenImageIO/imageinput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libOpenImageIO/imageio_pvt.h.in
+++ b/src/libOpenImageIO/imageio_pvt.h.in
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libOpenImageIO/imageioplugin.cpp
+++ b/src/libOpenImageIO/imageioplugin.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libOpenImageIO/imageoutput.cpp
+++ b/src/libOpenImageIO/imageoutput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libOpenImageIO/imagespec_test.cpp
+++ b/src/libOpenImageIO/imagespec_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libOpenImageIO/imagespeed_test.cpp
+++ b/src/libOpenImageIO/imagespeed_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libOpenImageIO/iptc.cpp
+++ b/src/libOpenImageIO/iptc.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libOpenImageIO/printinfo.cpp
+++ b/src/libOpenImageIO/printinfo.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libOpenImageIO/xmp.cpp
+++ b/src/libOpenImageIO/xmp.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libtexture/environment.cpp
+++ b/src/libtexture/environment.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libtexture/imagecache_pvt.h
+++ b/src/libtexture/imagecache_pvt.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libtexture/texoptions.cpp
+++ b/src/libtexture/texoptions.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libtexture/texture3d.cpp
+++ b/src/libtexture/texture3d.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libtexture/texture_pvt.h
+++ b/src/libtexture/texture_pvt.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libutil/argparse.cpp
+++ b/src/libutil/argparse.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libutil/argparse_test.cpp
+++ b/src/libutil/argparse_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libutil/atomic_test.cpp
+++ b/src/libutil/atomic_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libutil/benchmark.cpp
+++ b/src/libutil/benchmark.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libutil/errorhandler.cpp
+++ b/src/libutil/errorhandler.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libutil/filesystem_test.cpp
+++ b/src/libutil/filesystem_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libutil/filter.cpp
+++ b/src/libutil/filter.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libutil/filter_test.cpp
+++ b/src/libutil/filter_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libutil/fmath.cpp
+++ b/src/libutil/fmath.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libutil/fmath_test.cpp
+++ b/src/libutil/fmath_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libutil/hash_test.cpp
+++ b/src/libutil/hash_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libutil/optparser_test.cpp
+++ b/src/libutil/optparser_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libutil/parallel_test.cpp
+++ b/src/libutil/parallel_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libutil/paramlist.cpp
+++ b/src/libutil/paramlist.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libutil/paramlist_test.cpp
+++ b/src/libutil/paramlist_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libutil/plugin.cpp
+++ b/src/libutil/plugin.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libutil/simd_test.cpp
+++ b/src/libutil/simd_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libutil/span_test.cpp
+++ b/src/libutil/span_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libutil/spin_rw_test.cpp
+++ b/src/libutil/spin_rw_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libutil/spinlock_test.cpp
+++ b/src/libutil/spinlock_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libutil/strutil_test.cpp
+++ b/src/libutil/strutil_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 // clang-format off

--- a/src/libutil/sysutil.cpp
+++ b/src/libutil/sysutil.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libutil/thread.cpp
+++ b/src/libutil/thread.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libutil/thread_test.cpp
+++ b/src/libutil/thread_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libutil/timer.cpp
+++ b/src/libutil/timer.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libutil/timer_test.cpp
+++ b/src/libutil/timer_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libutil/type_traits_test.cpp
+++ b/src/libutil/type_traits_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libutil/typedesc.cpp
+++ b/src/libutil/typedesc.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libutil/typedesc_test.cpp
+++ b/src/libutil/typedesc_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libutil/ustring.cpp
+++ b/src/libutil/ustring.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/libutil/ustring_test.cpp
+++ b/src/libutil/ustring_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/maketx/CMakeLists.txt
+++ b/src/maketx/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 

--- a/src/maketx/maketx.cpp
+++ b/src/maketx/maketx.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/nuke/txWriter/CMakeLists.txt
+++ b/src/nuke/txWriter/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 # https://github.com/OpenImageIO/oiio
 

--- a/src/null.imageio/CMakeLists.txt
+++ b/src/null.imageio/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 

--- a/src/null.imageio/nullimageio.cpp
+++ b/src/null.imageio/nullimageio.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/oiiotool/CMakeLists.txt
+++ b/src/oiiotool/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 # https://github.com/OpenImageIO/oiio
 

--- a/src/oiiotool/diff.cpp
+++ b/src/oiiotool/diff.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/oiiotool/imagerec.cpp
+++ b/src/oiiotool/imagerec.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/oiiotool/printinfo.cpp
+++ b/src/oiiotool/printinfo.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/openexr.imageio/CMakeLists.txt
+++ b/src/openexr.imageio/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause
 # https://github.com/OpenImageIO/oiio
 

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/openvdb.imageio/CMakeLists.txt
+++ b/src/openvdb.imageio/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 # https://github.com/OpenImageIO/oiio
 

--- a/src/openvdb.imageio/openvdbinput.cpp
+++ b/src/openvdb.imageio/openvdbinput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/png.imageio/CMakeLists.txt
+++ b/src/png.imageio/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 

--- a/src/png.imageio/png_pvt.h
+++ b/src/png.imageio/png_pvt.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/png.imageio/pnginput.cpp
+++ b/src/png.imageio/pnginput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/png.imageio/pngoutput.cpp
+++ b/src/png.imageio/pngoutput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/pnm.imageio/CMakeLists.txt
+++ b/src/pnm.imageio/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 # https://github.com/OpenImageIO/oiio
 

--- a/src/pnm.imageio/pnminput.cpp
+++ b/src/pnm.imageio/pnminput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/pnm.imageio/pnmoutput.cpp
+++ b/src/pnm.imageio/pnmoutput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/psd.imageio/CMakeLists.txt
+++ b/src/psd.imageio/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 # https://github.com/OpenImageIO/oiio
 

--- a/src/psd.imageio/psd_pvt.h
+++ b/src/psd.imageio/psd_pvt.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/psd.imageio/psdinput.cpp
+++ b/src/psd.imageio/psdinput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/ptex.imageio/CMakeLists.txt
+++ b/src/ptex.imageio/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 # https://github.com/OpenImageIO/oiio
 

--- a/src/ptex.imageio/ptexinput.cpp
+++ b/src/ptex.imageio/ptexinput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 

--- a/src/python/py_colorconfig.cpp
+++ b/src/python/py_colorconfig.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/python/py_deepdata.cpp
+++ b/src/python/py_deepdata.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/python/py_imagebuf.cpp
+++ b/src/python/py_imagebuf.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/python/py_imagebufalgo.cpp
+++ b/src/python/py_imagebufalgo.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/python/py_imagecache.cpp
+++ b/src/python/py_imagecache.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/python/py_imageinput.cpp
+++ b/src/python/py_imageinput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/python/py_imageoutput.cpp
+++ b/src/python/py_imageoutput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/python/py_imagespec.cpp
+++ b/src/python/py_imagespec.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/python/py_oiio.cpp
+++ b/src/python/py_oiio.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/python/py_oiio.h
+++ b/src/python/py_oiio.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/python/py_paramvalue.cpp
+++ b/src/python/py_paramvalue.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/python/py_roi.cpp
+++ b/src/python/py_roi.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/python/py_texturesys.cpp
+++ b/src/python/py_texturesys.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/python/py_typedesc.cpp
+++ b/src/python/py_typedesc.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/r3d.imageio/CMakeLists.txt
+++ b/src/r3d.imageio/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 # https://github.com/OpenImageIO/oiio
 

--- a/src/raw.imageio/CMakeLists.txt
+++ b/src/raw.imageio/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 # https://github.com/OpenImageIO/oiio
 

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/rla.imageio/CMakeLists.txt
+++ b/src/rla.imageio/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 # https://github.com/OpenImageIO/oiio
 

--- a/src/rla.imageio/rla_pvt.h
+++ b/src/rla.imageio/rla_pvt.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/rla.imageio/rlainput.cpp
+++ b/src/rla.imageio/rlainput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/rla.imageio/rlaoutput.cpp
+++ b/src/rla.imageio/rlaoutput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/sgi.imageio/CMakeLists.txt
+++ b/src/sgi.imageio/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 # https://github.com/OpenImageIO/oiio
 

--- a/src/sgi.imageio/sgi_pvt.h
+++ b/src/sgi.imageio/sgi_pvt.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/sgi.imageio/sgiinput.cpp
+++ b/src/sgi.imageio/sgiinput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/sgi.imageio/sgioutput.cpp
+++ b/src/sgi.imageio/sgioutput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/softimage.imageio/CMakeLists.txt
+++ b/src/softimage.imageio/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 

--- a/src/softimage.imageio/softimage_pvt.cpp
+++ b/src/softimage.imageio/softimage_pvt.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/softimage.imageio/softimage_pvt.h
+++ b/src/softimage.imageio/softimage_pvt.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/softimage.imageio/softimageinput.cpp
+++ b/src/softimage.imageio/softimageinput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/targa.imageio/CMakeLists.txt
+++ b/src/targa.imageio/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 # https://github.com/OpenImageIO/oiio
 

--- a/src/targa.imageio/targa_pvt.h
+++ b/src/targa.imageio/targa_pvt.h
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/targa.imageio/targainput.cpp
+++ b/src/targa.imageio/targainput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/targa.imageio/targaoutput.cpp
+++ b/src/targa.imageio/targaoutput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/term.imageio/CMakeLists.txt
+++ b/src/term.imageio/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 

--- a/src/term.imageio/termoutput.cpp
+++ b/src/term.imageio/termoutput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/testtex/CMakeLists.txt
+++ b/src/testtex/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 

--- a/src/testtex/testtex.cpp
+++ b/src/testtex/testtex.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/tiff.imageio/CMakeLists.txt
+++ b/src/tiff.imageio/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 # https://github.com/OpenImageIO/oiio
 

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/tiff.imageio/tiffoutput.cpp
+++ b/src/tiff.imageio/tiffoutput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/webp.imageio/CMakeLists.txt
+++ b/src/webp.imageio/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 # https://github.com/OpenImageIO/oiio
 

--- a/src/webp.imageio/webpinput.cpp
+++ b/src/webp.imageio/webpinput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/OpenImageIO/oiio
 

--- a/src/webp.imageio/webpoutput.cpp
+++ b/src/webp.imageio/webpoutput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/src/zfile.imageio/CMakeLists.txt
+++ b/src/zfile.imageio/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the OpenImageIO project.
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 

--- a/src/zfile.imageio/zfile.cpp
+++ b/src/zfile.imageio/zfile.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-present Contributors to the OpenImageIO project.
+// Copyright Contributors to the OpenImageIO project.
 // SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
 // https://github.com/OpenImageIO/oiio
 

--- a/testsuite/dds/run.py
+++ b/testsuite/dds/run.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 failureok = 1
 redirect = ' >> out.txt 2>&1 '
 files = [

--- a/testsuite/dpx/run.py
+++ b/testsuite/dpx/run.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 files = [ "dpx_nuke_10bits_rgb.dpx", "dpx_nuke_16bits_rgba.dpx" ]
 for f in files:
     command += rw_command (OIIO_TESTSUITE_IMAGEDIR, f)

--- a/testsuite/fits/run.py
+++ b/testsuite/fits/run.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 # ../fits-image/pg93:
 # tst0001.fits to tst0014.fits
 imagedir = OIIO_TESTSUITE_IMAGEDIR + "/pg93"

--- a/testsuite/gif/run.py
+++ b/testsuite/gif/run.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 files = ["gif_animation.gif", "gif_oiio_logo_with_alpha.gif",
          "gif_tahoe.gif", "gif_tahoe_interlaced.gif",
          "gif_bluedot.gif", "gif_diagonal_interlaced.gif",

--- a/testsuite/gpsread/run.py
+++ b/testsuite/gpsread/run.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 filename = (OIIO_TESTSUITE_IMAGEDIR + "/tahoe-gps.jpg")
 command += info_command (filename)
 command += oiiotool (filename + " -o ./tahoe-gps.jpg")

--- a/testsuite/heif/run.py
+++ b/testsuite/heif/run.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 imagedir = "ref/"
 files = [ "IMG_7702_small.heic", "Chimera-AV1-8bit-162.avif" ]
 for f in files:

--- a/testsuite/ico/run.py
+++ b/testsuite/ico/run.py
@@ -1,3 +1,7 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 command = rw_command (OIIO_TESTSUITE_IMAGEDIR, "oiio.ico")

--- a/testsuite/jpeg2000/run.py
+++ b/testsuite/jpeg2000/run.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 # Allow some LSB slop -- necessary because of the alpha disassociation
 # combined with implied sRGB conversion.
 failthresh = 0.02

--- a/testsuite/maketx/run.py
+++ b/testsuite/maketx/run.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python 
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 failureok = 1
 
 outputs = [ ]

--- a/testsuite/oiiotool-attribs/run.py
+++ b/testsuite/oiiotool-attribs/run.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 # Test oiiotool's ability to add and delete attributes
 
 

--- a/testsuite/oiiotool-deep/run.py
+++ b/testsuite/oiiotool-deep/run.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python 
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 exrdir = OIIO_TESTSUITE_IMAGEDIR + "/v2/LowResLeftView"
 
 # test --flatten : turn deep into composited non-deep

--- a/testsuite/oiiotool-maketx/run.py
+++ b/testsuite/oiiotool-maketx/run.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python 
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 # Construct a command that will create a texture, appending console
 # output to the file "out.txt".
 def omaketx_command (infile, outfile, extraargs="",

--- a/testsuite/oiiotool-spi/run.py
+++ b/testsuite/oiiotool-spi/run.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 imagedir = OIIO_TESTSUITE_IMAGEDIR
 refdir = imagedir + "/ref/"
 refdirlist = [ "ref/", refdir ]

--- a/testsuite/oiiotool-xform/run.py
+++ b/testsuite/oiiotool-xform/run.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python
+
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 #import OpenImageIO as oiio
 from __future__ import division
 from __future__ import absolute_import

--- a/testsuite/oiiotool/run.py
+++ b/testsuite/oiiotool/run.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 # Create some test images we need
 command += oiiotool ("--create 320x240 3 -d uint8 -o black.tif")
 command += oiiotool ("--pattern constant:color=0.5,0.5,0.5 128x128 3 -d half -o grey128.exr")

--- a/testsuite/openexr-chroma/run.py
+++ b/testsuite/openexr-chroma/run.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 # ../openexr-images/Chromaticities:
 # README         Rec709.exr     Rec709_YC.exr  XYZ.exr        XYZ_YC.exr
 imagedir = OIIO_TESTSUITE_IMAGEDIR + "/Chromaticities"

--- a/testsuite/openexr-multires/run.py
+++ b/testsuite/openexr-multires/run.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 # ../openexr-images/MultiResolution:
 # Bonita.exr              MirrorPattern.exr       StageEnvCube.exr
 # ColorCodedLevels.exr    OrientationCube.exr     StageEnvLatLong.exr

--- a/testsuite/openexr-suite/run.py
+++ b/testsuite/openexr-suite/run.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 # ../openexr-images/ScanLines:
 # Blobbies.exr     Cannon.exr  MtTamWest.exr     StillLife.exr
 # CandleGlass.exr  Desk.exr    PrismsLenses.exr  Tree.exr

--- a/testsuite/openexr-v2/run.py
+++ b/testsuite/openexr-v2/run.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 imagedir = OIIO_TESTSUITE_IMAGEDIR + "/v2/Stereo"
 
 # Multi-part, not deep

--- a/testsuite/openvdb/run.py
+++ b/testsuite/openvdb/run.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 outputs = []
 
 for f in [ "sphere.vdb", "sphereCd.vdb" ]:

--- a/testsuite/perchannel/run.py
+++ b/testsuite/perchannel/run.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 # Test reading and writing of files with per-channel data formats.
 
 

--- a/testsuite/pnm/run.py
+++ b/testsuite/pnm/run.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 imagedir = OIIO_TESTSUITE_IMAGEDIR + "/pnm"
 
 for f in [ "bw-ascii.pbm", "bw-binary.pbm",

--- a/testsuite/python-colorconfig/src/test_colorconfig.py
+++ b/testsuite/python-colorconfig/src/test_colorconfig.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 from __future__ import print_function
 from __future__ import absolute_import
 import os

--- a/testsuite/python-imagebufalgo/run.py
+++ b/testsuite/python-imagebufalgo/run.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 refdirlist = [
     OIIO_TESTSUITE_ROOT + "/oiiotool/ref/",
     OIIO_TESTSUITE_ROOT + "/oiiotool-color/ref/",

--- a/testsuite/python-imagebufalgo/src/test_imagebufalgo.py
+++ b/testsuite/python-imagebufalgo/src/test_imagebufalgo.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 from __future__ import print_function
 from __future__ import absolute_import
 import math, os

--- a/testsuite/python-imageinput/src/test_imageinput.py
+++ b/testsuite/python-imageinput/src/test_imageinput.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 from __future__ import print_function
 from __future__ import absolute_import
 import OpenImageIO as oiio

--- a/testsuite/python-imageoutput/run.py
+++ b/testsuite/python-imageoutput/run.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python 
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 # Copy the grid to both a tiled and scanline version
 imagedir = OIIO_TESTSUITE_IMAGEDIR
 command += oiio_app("iconvert") + "../common/grid.tif --scanline scanline.tif > out.txt ;" 

--- a/testsuite/python-imageoutput/src/test_imageoutput.py
+++ b/testsuite/python-imageoutput/src/test_imageoutput.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 from __future__ import print_function
 from __future__ import absolute_import
 import OpenImageIO as oiio

--- a/testsuite/python-texturesys/run.py
+++ b/testsuite/python-texturesys/run.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python 
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 # Set up some udims
 command += oiiotool ("-pattern constant:color=.5,.1,.1 256x256 3 -text:size=50:x=75:y=140 1001 --attrib Make pet --attrib Model dog -d uint8 -otex file.1001.tx")
 command += oiiotool ("-pattern constant:color=.1,.5,.1 256x256 3 -text:size=50:x=75:y=140 1002 --attrib Make pet --attrib Model dog -d uint8 -otex file.1002.tx")

--- a/testsuite/python-texturesys/src/test_texture_sys.py
+++ b/testsuite/python-texturesys/src/test_texture_sys.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 from __future__ import print_function
 from __future__ import absolute_import
 import os

--- a/testsuite/python-typedesc/src/test_typedesc.py
+++ b/testsuite/python-typedesc/src/test_typedesc.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 from __future__ import print_function
 from __future__ import absolute_import
 import OpenImageIO as oiio

--- a/testsuite/rla/run.py
+++ b/testsuite/rla/run.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 redirect = " >> out.txt 2>&1"
 
 files = [ "ginsu_a_nc10.rla", "ginsu_a_ncf.rla", "ginsu_rgba_nc8.rla",

--- a/testsuite/targa/run.py
+++ b/testsuite/targa/run.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 redirect = " >> out.txt 2>&1"
 
 imagedir = OIIO_TESTSUITE_IMAGEDIR + "/targa"

--- a/testsuite/texture-filtersize/run.py
+++ b/testsuite/texture-filtersize/run.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 # This test verifies that the TextureSystem is sampling the correct
 # MIPmap levels given the input derivatives.
 #

--- a/testsuite/texture-icwrite/run.py
+++ b/testsuite/texture-icwrite/run.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 # test 1: seed top level, no MIP map
 command += testtex_command (OIIO_TESTSUITE_IMAGEDIR + " -res 256 256 -d uint8 -o out1.tif --testicwrite 1 blah")
 # test 2: seed top level, automip

--- a/testsuite/texture-res/run.py
+++ b/testsuite/texture-res/run.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 command = (oiio_app("testtex") + " -res 256 256 --nowarp "
            + OIIO_TESTSUITE_IMAGEDIR + "/miplevels.tx"
            + " -o out.tif ;\n")

--- a/testsuite/texture-udim2/run.py
+++ b/testsuite/texture-udim2/run.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# https://github.com/OpenImageIO/oiio
 
 
 command += oiiotool ("-pattern constant:color=.5,.1,.1 256x256 3 -text:size=50:x=75:y=140 u1v1 --attrib Make pet --attrib Model dog -d uint8 -otex file_u1v1.tx")

--- a/testsuite/texture-wrapfill/run.py
+++ b/testsuite/texture-wrapfill/run.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 # This tests a particular tricky case: the interplay of "black" wrap mode
 # with fill color.  Outside the s,t [0,1] range, it should be black, NOT
 # fill color.  

--- a/testsuite/tiff-depths/run.py
+++ b/testsuite/tiff-depths/run.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 
-# FIXME -- eventually, we want more (all?) of these to work
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 
 outputs = []
 imagedir = OIIO_TESTSUITE_IMAGEDIR + "/depth"

--- a/testsuite/tiff-suite/run.py
+++ b/testsuite/tiff-suite/run.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 
 # caspian.tif	279x220 64-bit floating point (deflate) Caspian Sea from space
 command += rw_command (OIIO_TESTSUITE_IMAGEDIR, "caspian.tif")

--- a/testsuite/webp/run.py
+++ b/testsuite/webp/run.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
 files = [ "1.webp", "2.webp", "3.webp", "4.webp" ]
 for f in files:
     command += info_command (OIIO_TESTSUITE_IMAGEDIR + "/" + f)


### PR DESCRIPTION
* Add copyright/license notices to some mixed-authorship files that lacked them before (all related to tests)
* Get rid of the pointless year in many copyright notices (change to the current LF recommended wording)
