### PR TITLE
build: Fix broken OIIO_NO_NEON definition

### DIFF
--- a/src/include/OpenImageIO/simd.h
+++ b/src/include/OpenImageIO/simd.h
@@ -95,6 +95,9 @@
 #  ifndef OIIO_NO_AVX2
 #    define OIIO_NO_AVX2 1
 #  endif
+#endif
+
+#if !(defined(_M_ARM64) || defined(__aarch64) || defined(__aarch64__)) || defined(__CUDA_ARCH__)
 #  ifndef OIIO_NO_NEON
 #    define OIIO_NO_NEON 1
 #  endif


### PR DESCRIPTION
Clean up the `#if` tests that disable Intel SIMD when not on Intel architectures, which incorrectly disabled ARM NEON when on ARM.

Fixes #3909

