### PR TITLE
admin: Relicense code under Apache 2.0

### DIFF
--- a/RELICENSING.md
+++ b/RELICENSING.md
@@ -10,8 +10,37 @@ relicensed to the Apache License, Version 2.0, and are submitted pursuant to
 the Developer Certificate of Origin, version 1.1:
 
 - Larry Gritz (@lgritz)
-
-
+- Chris Kulla (fpsunflower)
+- Brecht Van Lommel (brechtvl)
+- Daniel Flehner Heen (apetrynet)
+- Daniel Wyatt (dewyatt)
+- Aras Pranckevičius (aras-p)
+- Leszek Godlewski (inequation)
+- Dalai Felinto (dfelinto)
+- Jesse Yurkovich (jessey-git)
+- Sergey Sharybin (sergeyvfx)
+- Ray Molenkamp (LazyDodo)
+- Nathan Rusch (nrusch)
+- Ismael Cortes (leamsi)
+- AdamMainsTL
+- Sony Pictures Imageworks (cstein, olegul, fpsunflower, brianhall77, jeremyselan)
+- Richard Shaw (hobbes1069)
+- Robert Matusewicz
+- Mariusz Szczepańczyk (mszczepanczyk)
+- Scott Wilson
+- Kevin Brightwell (Nava2)
+- Simon Boorer
+- Alex Hughes (Ahuge)
+- Alister Chowdhury
+- Manuel Leonhardt (skycaptain)
+- Alexandre Gauthier (MrKepzie)
+- Mark Boorer (shootfast)
+- Povilas Kanapickas (p12tic)
+- Mikael Sundell
+- Roman Zulak (marsupial)
+- Autodesk (includes Thiago Ize, Elvic Liang, Wayne Arnold, William Krick, Brecht Van Lommel, Marcos Fajardo)
+- Thiago Ize
+- Nick Black (dankamongmen)
 
 **Prior authors, please submit a PR against this file that adds your name
 above. If, at the time of your prior contributions, you were employed by a

--- a/src/bmp.imageio/CMakeLists.txt
+++ b/src/bmp.imageio/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 add_oiio_plugin (bmpinput.cpp bmpoutput.cpp bmp_pvt.cpp)

--- a/src/build-scripts/gh-installdeps.bash
+++ b/src/build-scripts/gh-installdeps.bash
@@ -2,7 +2,7 @@
 #
 
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 

--- a/src/build-scripts/install_homebrew_deps.bash
+++ b/src/build-scripts/install_homebrew_deps.bash
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 # This script, which assumes it is running on a Mac OSX with Homebrew

--- a/src/cineon.imageio/cineoninput.cpp
+++ b/src/cineon.imageio/cineoninput.cpp
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 #include <cmath>

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -1,5 +1,5 @@
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 ###########################################################################

--- a/src/cmake/modules/FindNuke.cmake
+++ b/src/cmake/modules/FindNuke.cmake
@@ -1,5 +1,5 @@
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 # - CMake find module for Nuke

--- a/src/cmake/modules/FindOpenColorIO.cmake
+++ b/src/cmake/modules/FindOpenColorIO.cmake
@@ -1,5 +1,5 @@
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 # Module to find OpenColorIO

--- a/src/cmake/modules/FindOpenVDB.cmake
+++ b/src/cmake/modules/FindOpenVDB.cmake
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
 # - Find OPENVDB library
 # Find the native OPENVDB includes and library
 # This module defines

--- a/src/cmake/modules/FindR3DSDK.cmake
+++ b/src/cmake/modules/FindR3DSDK.cmake
@@ -1,5 +1,5 @@
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 # - Try to find R3D SDK

--- a/src/cmake/testing.cmake
+++ b/src/cmake/testing.cmake
@@ -1,5 +1,5 @@
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio/
 
 include (CTest)

--- a/src/dds.imageio/CMakeLists.txt
+++ b/src/dds.imageio/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 add_oiio_plugin (ddsinput.cpp)

--- a/src/dds.imageio/dds_pvt.h
+++ b/src/dds.imageio/dds_pvt.h
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 #pragma once

--- a/src/ffmpeg.imageio/CMakeLists.txt
+++ b/src/ffmpeg.imageio/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 if (FFmpeg_FOUND)

--- a/src/gif.imageio/CMakeLists.txt
+++ b/src/gif.imageio/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 if (GIF_FOUND)

--- a/src/gif.imageio/gifoutput.cpp
+++ b/src/gif.imageio/gifoutput.cpp
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 #define USE_GIFH 1

--- a/src/ico.imageio/ico.h
+++ b/src/ico.imageio/ico.h
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 #pragma once

--- a/src/idiff/idiff.cpp
+++ b/src/idiff/idiff.cpp
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/iff.imageio/iff_pvt.h
+++ b/src/iff.imageio/iff_pvt.h
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 #pragma once

--- a/src/iff.imageio/iffinput.cpp
+++ b/src/iff.imageio/iffinput.cpp
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 #include "iff_pvt.h"
 

--- a/src/iff.imageio/iffoutput.cpp
+++ b/src/iff.imageio/iffoutput.cpp
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 #include "iff_pvt.h"

--- a/src/igrep/igrep.cpp
+++ b/src/igrep/igrep.cpp
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/iinfo/iinfo.cpp
+++ b/src/iinfo/iinfo.cpp
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/include/OpenImageIO/atomic.h
+++ b/src/include/OpenImageIO/atomic.h
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/include/OpenImageIO/detail/farmhash.h
+++ b/src/include/OpenImageIO/detail/farmhash.h
@@ -20,6 +20,11 @@
 //
 // FarmHash, by Geoff Pike
 
+// Additional modifications for OpenImageIO:
+// Copyright Contributors to the OpenImageIO project.
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/OpenImageIO/oiio
+
 // clang-format off
 
 // https://github.com/google/farmhash

--- a/src/include/OpenImageIO/strided_ptr.h
+++ b/src/include/OpenImageIO/strided_ptr.h
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/include/OpenImageIO/string_view.h
+++ b/src/include/OpenImageIO/string_view.h
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 // clang-format off

--- a/src/include/OpenImageIO/sysutil.h
+++ b/src/include/OpenImageIO/sysutil.h
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/include/OpenImageIO/texture.h
+++ b/src/include/OpenImageIO/texture.h
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 // clang-format off

--- a/src/include/OpenImageIO/unordered_map_concurrent.h
+++ b/src/include/OpenImageIO/unordered_map_concurrent.h
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/iv/ivgl.h
+++ b/src/iv/ivgl.h
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/iv/ivimage.cpp
+++ b/src/iv/ivimage.cpp
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/iv/ivutils.h
+++ b/src/iv/ivutils.h
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 #ifndef OPENIMAGEIO_IV_UTILS_H

--- a/src/libOpenImageIO/imagebufalgo.cpp
+++ b/src/libOpenImageIO/imagebufalgo.cpp
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 #include <cmath>

--- a/src/libOpenImageIO/imagebufalgo_pixelmath.cpp
+++ b/src/libOpenImageIO/imagebufalgo_pixelmath.cpp
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 /// \file

--- a/src/libOpenImageIO/imagebufalgo_xform.cpp
+++ b/src/libOpenImageIO/imagebufalgo_xform.cpp
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 /// \file

--- a/src/libtexture/texoptions.cpp
+++ b/src/libtexture/texoptions.cpp
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 #include <string>

--- a/src/libtexture/texture3d.cpp
+++ b/src/libtexture/texture3d.cpp
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/libutil/argparse.cpp
+++ b/src/libutil/argparse.cpp
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/libutil/atomic_test.cpp
+++ b/src/libutil/atomic_test.cpp
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/libutil/errorhandler.cpp
+++ b/src/libutil/errorhandler.cpp
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 #include <cstdio>

--- a/src/libutil/farmhash.cpp
+++ b/src/libutil/farmhash.cpp
@@ -20,6 +20,11 @@
 //
 // FarmHash, by Geoff Pike
 
+// Additional modifications for OpenImageIO:
+// Copyright Contributors to the OpenImageIO project.
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/OpenImageIO/oiio
+
 // clang-format off
 
 // https://github.com/google/farmhash

--- a/src/libutil/filter.cpp
+++ b/src/libutil/filter.cpp
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/libutil/hash_test.cpp
+++ b/src/libutil/hash_test.cpp
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/libutil/paramlist.cpp
+++ b/src/libutil/paramlist.cpp
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 #include <algorithm>

--- a/src/libutil/paramlist_test.cpp
+++ b/src/libutil/paramlist_test.cpp
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/libutil/ustring_test.cpp
+++ b/src/libutil/ustring_test.cpp
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/make/detectplatform.mk
+++ b/src/make/detectplatform.mk
@@ -1,5 +1,5 @@
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 

--- a/src/nuke/txReader/CMakeLists.txt
+++ b/src/nuke/txReader/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 

--- a/src/nuke/txReader/txReader.cpp
+++ b/src/nuke/txReader/txReader.cpp
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 #ifndef _WIN32

--- a/src/nuke/txWriter/CMakeLists.txt
+++ b/src/nuke/txWriter/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 add_library (txWriter MODULE txWriter.cpp)

--- a/src/oiiotool/diff.cpp
+++ b/src/oiiotool/diff.cpp
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/oiiotool/printinfo.cpp
+++ b/src/oiiotool/printinfo.cpp
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/openvdb.imageio/CMakeLists.txt
+++ b/src/openvdb.imageio/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 if (OpenVDB_FOUND)

--- a/src/openvdb.imageio/openvdbinput.cpp
+++ b/src/openvdb.imageio/openvdbinput.cpp
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 #include <OpenImageIO/Imath.h>

--- a/src/psd.imageio/CMakeLists.txt
+++ b/src/psd.imageio/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 add_oiio_plugin (psdinput.cpp)

--- a/src/psd.imageio/psd_pvt.h
+++ b/src/psd.imageio/psd_pvt.h
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 #pragma once

--- a/src/python/py_colorconfig.cpp
+++ b/src/python/py_colorconfig.cpp
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 #include "py_oiio.h"

--- a/src/python/py_texturesys.cpp
+++ b/src/python/py_texturesys.cpp
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 #include "py_oiio.h"

--- a/src/r3d.imageio/CMakeLists.txt
+++ b/src/r3d.imageio/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 # Require the R3DSDK

--- a/src/raw.imageio/CMakeLists.txt
+++ b/src/raw.imageio/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 if (LIBRAW_FOUND)

--- a/src/rla.imageio/rla_pvt.h
+++ b/src/rla.imageio/rla_pvt.h
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 #pragma once

--- a/src/rla.imageio/rlainput.cpp
+++ b/src/rla.imageio/rlainput.cpp
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 #include <cassert>

--- a/src/sgi.imageio/sgi_pvt.h
+++ b/src/sgi.imageio/sgi_pvt.h
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 #pragma once

--- a/src/targa.imageio/CMakeLists.txt
+++ b/src/targa.imageio/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 add_oiio_plugin (targainput.cpp targaoutput.cpp)

--- a/src/targa.imageio/targa_pvt.h
+++ b/src/targa.imageio/targa_pvt.h
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 #pragma once

--- a/src/webp.imageio/CMakeLists.txt
+++ b/src/webp.imageio/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 if (WebP_FOUND)

--- a/testsuite/bmp/run.py
+++ b/testsuite/bmp/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 # save the error output

--- a/testsuite/dds/run.py
+++ b/testsuite/dds/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 failureok = 1

--- a/testsuite/dpx/run.py
+++ b/testsuite/dpx/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 files = [ "dpx_nuke_10bits_rgb.dpx", "dpx_nuke_16bits_rgba.dpx" ]

--- a/testsuite/fits/run.py
+++ b/testsuite/fits/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 # ../fits-image/pg93:

--- a/testsuite/gif/run.py
+++ b/testsuite/gif/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 files = ["gif_animation.gif", "gif_oiio_logo_with_alpha.gif",

--- a/testsuite/gpsread/run.py
+++ b/testsuite/gpsread/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 filename = (OIIO_TESTSUITE_IMAGEDIR + "/tahoe-gps.jpg")

--- a/testsuite/ico/run.py
+++ b/testsuite/ico/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 command = rw_command (OIIO_TESTSUITE_IMAGEDIR, "oiio.ico")

--- a/testsuite/iff/run.py
+++ b/testsuite/iff/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 command += oiiotool (OIIO_TESTSUITE_IMAGEDIR+"/grid.tif --scanline -o gridscanline.iff")

--- a/testsuite/jpeg2000/run.py
+++ b/testsuite/jpeg2000/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 # Allow some LSB slop -- necessary because of the alpha disassociation

--- a/testsuite/oiiotool-attribs/run.py
+++ b/testsuite/oiiotool-attribs/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 # Test oiiotool's ability to add and delete attributes

--- a/testsuite/oiiotool-deep/run.py
+++ b/testsuite/oiiotool-deep/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python 
 
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 exrdir = OIIO_TESTSUITE_IMAGEDIR + "/v2/LowResLeftView"

--- a/testsuite/oiiotool-spi/run.py
+++ b/testsuite/oiiotool-spi/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 imagedir = OIIO_TESTSUITE_IMAGEDIR

--- a/testsuite/oiiotool-xform/run.py
+++ b/testsuite/oiiotool-xform/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 #import OpenImageIO as oiio

--- a/testsuite/openexr-chroma/run.py
+++ b/testsuite/openexr-chroma/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 # ../openexr-images/Chromaticities:

--- a/testsuite/openexr-multires/run.py
+++ b/testsuite/openexr-multires/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 # ../openexr-images/MultiResolution:

--- a/testsuite/openexr-suite/run.py
+++ b/testsuite/openexr-suite/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 # ../openexr-images/ScanLines:

--- a/testsuite/openexr-v2/run.py
+++ b/testsuite/openexr-v2/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 imagedir = OIIO_TESTSUITE_IMAGEDIR + "/v2/Stereo"

--- a/testsuite/openvdb/run.py
+++ b/testsuite/openvdb/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 outputs = []

--- a/testsuite/perchannel/run.py
+++ b/testsuite/perchannel/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 # Test reading and writing of files with per-channel data formats.

--- a/testsuite/python-colorconfig/src/test_colorconfig.py
+++ b/testsuite/python-colorconfig/src/test_colorconfig.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 from __future__ import print_function

--- a/testsuite/python-imagebufalgo/run.py
+++ b/testsuite/python-imagebufalgo/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 refdirlist = [

--- a/testsuite/python-imagebufalgo/src/test_imagebufalgo.py
+++ b/testsuite/python-imagebufalgo/src/test_imagebufalgo.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 from __future__ import print_function

--- a/testsuite/python-imageinput/src/test_imageinput.py
+++ b/testsuite/python-imageinput/src/test_imageinput.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 from __future__ import print_function

--- a/testsuite/python-imageoutput/run.py
+++ b/testsuite/python-imageoutput/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python 
 
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 # Copy the grid to both a tiled and scanline version

--- a/testsuite/python-texturesys/run.py
+++ b/testsuite/python-texturesys/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python 
 
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 # Set up some udims

--- a/testsuite/python-texturesys/src/test_texture_sys.py
+++ b/testsuite/python-texturesys/src/test_texture_sys.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 from __future__ import print_function

--- a/testsuite/python-typedesc/src/test_typedesc.py
+++ b/testsuite/python-typedesc/src/test_typedesc.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 from __future__ import print_function

--- a/testsuite/rla/run.py
+++ b/testsuite/rla/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 redirect = " >> out.txt 2>&1"

--- a/testsuite/targa/run.py
+++ b/testsuite/targa/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 redirect = " >> out.txt 2>&1"

--- a/testsuite/texture-filtersize/run.py
+++ b/testsuite/texture-filtersize/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 # This test verifies that the TextureSystem is sampling the correct

--- a/testsuite/texture-icwrite/run.py
+++ b/testsuite/texture-icwrite/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 # test 1: seed top level, no MIP map

--- a/testsuite/texture-res/run.py
+++ b/testsuite/texture-res/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 command = (oiio_app("testtex") + " -res 256 256 --nowarp "

--- a/testsuite/tiff-depths/run.py
+++ b/testsuite/tiff-depths/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 

--- a/testsuite/tiff-suite/run.py
+++ b/testsuite/tiff-suite/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 

--- a/testsuite/webp/run.py
+++ b/testsuite/webp/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 files = [ "1.webp", "2.webp", "3.webp", "4.webp" ]


### PR DESCRIPTION
Per PR #3905 (https://github.com/OpenImageIO/oiio/pull/3905), update the RELICENSING document with the names of people and companies who have signed on to the relicensing thus far, and update the SPDX license notices on source files whose extant authorship (per 'git blame') comprises only authors who have relicensed.

This is part 1, the original PR is ongoing and we will continue to update as additional people relicense.
