### PR TITLE
api: extend TypeDesc and ParamType to represent ustringhash

### DIFF
--- a/src/include/OpenImageIO/paramlist.h
+++ b/src/include/OpenImageIO/paramlist.h
@@ -110,6 +110,11 @@ public:
         : ParamValue(_name, ustring(value))
     {
     }
+    ParamValue(string_view _name, ustringhash value) noexcept
+    {
+        init_noclear(ustring(_name), TypeDesc::USTRINGHASH, 1, &value,
+                     Copy(true));
+    }
 
     // Set from string -- parse
     ParamValue(string_view _name, TypeDesc type, string_view value);

--- a/src/include/OpenImageIO/typedesc.h
+++ b/src/include/OpenImageIO/typedesc.h
@@ -83,6 +83,7 @@ struct OIIO_UTIL_API TypeDesc {
         DOUBLE,             ///< 64-bit IEEE floating point values, (C/C++ `double`).
         STRING,             ///< Character string.
         PTR,                ///< A pointer value.
+        USTRINGHASH,        ///< The hash of a ustring
         LASTBASE
     };
 
@@ -404,6 +405,7 @@ OIIO_INLINE_CONSTEXPR TypeDesc TypeTimeCode (TypeDesc::UINT, TypeDesc::SCALAR, T
 OIIO_INLINE_CONSTEXPR TypeDesc TypeKeyCode (TypeDesc::INT, TypeDesc::SCALAR, TypeDesc::KEYCODE, 7);
 OIIO_INLINE_CONSTEXPR TypeDesc TypeRational(TypeDesc::INT, TypeDesc::VEC2, TypeDesc::RATIONAL);
 OIIO_INLINE_CONSTEXPR TypeDesc TypePointer(TypeDesc::PTR);
+OIIO_INLINE_CONSTEXPR TypeDesc TypeUstringhash(TypeDesc::USTRINGHASH);
 
 
 
@@ -485,6 +487,10 @@ template<> struct TypeDescFromC<Imath::Box3i> { static const constexpr TypeDesc 
 #endif
 
 
+class ustringhash;  // forward declaration
+
+
+
 /// A template mechanism for getting C type of TypeDesc::BASETYPE.
 ///
 template<int b> struct CType {};
@@ -501,6 +507,7 @@ template<> struct CType<(int)TypeDesc::HALF> { typedef half type; };
 #endif
 template<> struct CType<(int)TypeDesc::FLOAT> { typedef float type; };
 template<> struct CType<(int)TypeDesc::DOUBLE> { typedef double type; };
+template<> struct CType<(int)TypeDesc::USTRINGHASH> { typedef ustringhash type; };
 
 
 

--- a/src/libutil/paramlist_test.cpp
+++ b/src/libutil/paramlist_test.cpp
@@ -104,7 +104,16 @@ test_value_types()
         const char* val = "hello";
         ParamValue p("name", val);
         OIIO_CHECK_EQUAL(p.get<ustring>(), "hello");
+        OIIO_CHECK_EQUAL(p.get_ustring(), "hello");
         OIIO_CHECK_EQUAL(p.get_string(), "hello");
+    }
+
+    {
+        ustringhash val("hello");
+        ParamValue p("name", val);
+        OIIO_CHECK_EQUAL(p.get_string(), "hello");
+        OIIO_CHECK_EQUAL(p.get_ustring(), "hello");
+        OIIO_CHECK_EQUAL(p.get<ustringhash>(), val);
     }
 
     {

--- a/src/libutil/typedesc_test.cpp
+++ b/src/libutil/typedesc_test.cpp
@@ -18,6 +18,7 @@
 
 #include <OpenImageIO/typedesc.h>
 #include <OpenImageIO/unittest.h>
+#include <OpenImageIO/ustring.h>
 
 
 using namespace OIIO;
@@ -144,6 +145,8 @@ main(int /*argc*/, char* /*argv*/[])
                           TypeFloat4, {});
     test_type<const char*>("string", TypeDesc(TypeDesc::STRING), TypeString,
                            "hello", "hello");
+    test_type<ustringhash>("ustringhash", TypeDesc(TypeDesc::USTRINGHASH),
+                           TypeUstringhash, ustringhash("hello"), "hello");
     int i2[2] = { 1, 2 };
     test_type<int[2]>("rational",
                       TypeDesc(TypeDesc::INT, TypeDesc::VEC2,


### PR DESCRIPTION
I think it will be handy to be able to have ParamValue contain ustringhashes and have a TypeDesc that can describe it explicitly.

