### PR TITLE
Adding IOProxy support to ICOInput

### DIFF
--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -816,6 +816,24 @@ Windows.  ICO files use the file extension :file:`.ico`.
      - int
      - if nonzero, will cause the ICO to be written out using PNG format.
 
+**Configuration settings for ICO input**
+
+When opening an ICO ImageInput with a *configuration* (see
+Section :ref:`sec-input-with-config`), the following special configuration
+attributes are supported:
+
+.. list-table::
+   :widths: 30 10 65
+   :header-rows: 1
+
+   * - Input Configuration Attribute
+     - Type
+     - Meaning
+   * - ``oiio:ioproxy``
+     - ptr
+     - Pointer to a ``Filesystem::IOProxy`` that will handle the I/O, for
+       example by reading from memory rather than the file system.    
+
 **Configuration settings for ICO output**
 
 When opening an ICO ImageOutput, the following special metadata tokens

--- a/src/ico.imageio/icoinput.cpp
+++ b/src/ico.imageio/icoinput.cpp
@@ -25,6 +25,10 @@ public:
     ICOInput() { init(); }
     ~ICOInput() override { close(); }
     const char* format_name(void) const override { return "ico"; }
+    int supports(string_view feature) const override
+    {
+        return feature == "ioproxy";
+    }
     bool open(const std::string& name, ImageSpec& newspec) override;
     bool close() override;
     int current_subimage(void) const override
@@ -38,7 +42,6 @@ public:
 
 private:
     std::string m_filename;            ///< Stash the filename
-    FILE* m_file;                      ///< Open image handle
     ico_header m_ico;                  ///< ICO header
     std::vector<unsigned char> m_buf;  ///< Buffer the image pixels
     int m_subimage;                    ///< What subimage are we looking at?
@@ -58,25 +61,26 @@ private:
     void init()
     {
         m_subimage = -1;
-        m_file     = NULL;
         m_png      = NULL;
         m_info     = NULL;
         memset(&m_ico, 0, sizeof(m_ico));
         m_buf.clear();
+        ioproxy_clear();
     }
 
     /// Helper function: read the image.
     ///
     bool readimg();
 
-    /// Helper: read, with error detection
-    ///
-    bool fread(void* buf, size_t itemsize, size_t nitems)
+    // Callback for PNG that reads from an IOProxy.
+    static void PngReadCallback(png_structp png_ptr, png_bytep data,
+                                png_size_t length)
     {
-        size_t n = ::fread(buf, itemsize, nitems, m_file);
-        if (n != nitems)
-            errorf("Read error");
-        return n == nitems;
+        ICOInput* icoinput = (ICOInput*)png_get_io_ptr(png_ptr);
+        OIIO_DASSERT(icoinput);
+        if (!icoinput->ioread(data, length)) {
+            png_chunk_error(png_ptr, icoinput->geterror(false).c_str());
+        }
     }
 };
 
@@ -110,13 +114,10 @@ ICOInput::open(const std::string& name, ImageSpec& newspec)
 {
     m_filename = name;
 
-    m_file = Filesystem::fopen(name, "rb");
-    if (!m_file) {
-        errorf("Could not open file \"%s\"", name);
+    if (!ioproxy_use_or_open(name))
         return false;
-    }
 
-    if (!fread(&m_ico, 1, sizeof(m_ico)))
+    if (!ioread(&m_ico, 1, sizeof(m_ico)))
         return false;
 
     if (bigendian()) {
@@ -163,10 +164,9 @@ ICOInput::seek_subimage(int subimage, int miplevel)
     m_subimage = subimage;
 
     // read subimage header
-    fseek(m_file, sizeof(ico_header) + m_subimage * sizeof(ico_subimage),
-          SEEK_SET);
+    ioseek(sizeof(ico_header) + m_subimage * sizeof(ico_subimage), SEEK_SET);
     ico_subimage subimg;
-    if (!fread(&subimg, 1, sizeof(subimg)))
+    if (!ioread(&subimg, 1, sizeof(subimg)))
         return false;
 
     if (bigendian()) {
@@ -179,11 +179,11 @@ ICOInput::seek_subimage(int subimage, int miplevel)
         swap_endian(&subimg.numColours);
     }
 
-    fseek(m_file, subimg.ofs, SEEK_SET);
+    ioseek(subimg.ofs, SEEK_SET);
 
     // test for a PNG icon
     char temp[8];
-    if (!fread(temp, 1, sizeof(temp)))
+    if (!ioread(temp, 1, sizeof(temp)))
         return false;
     if (temp[1] == 'P' && temp[2] == 'N' && temp[3] == 'G') {
         // standard PNG initialization
@@ -201,8 +201,9 @@ ICOInput::seek_subimage(int subimage, int miplevel)
         }
 
         //std::cerr << "[ico] reading PNG info\n";
+        // Tell libpng to use our read callback to read from the IOProxy
+        png_set_read_fn(m_png, this, PngReadCallback);
 
-        png_init_io(m_png, m_file);
         png_set_sig_bytes(m_png, 8);  // already read 8 bytes
 
         PNG_pvt::read_info(m_png, m_info, m_bpp, m_color_type, m_interlace_type,
@@ -215,10 +216,10 @@ ICOInput::seek_subimage(int subimage, int miplevel)
 
     // otherwise it's a plain, ol' windoze DIB (device-independent bitmap)
     // roll back to where we began and read in the DIB header
-    fseek(m_file, subimg.ofs, SEEK_SET);
+    ioseek(subimg.ofs, SEEK_SET);
 
     ico_bitmapinfo bmi;
-    if (!fread(&bmi, 1, sizeof(bmi)))
+    if (!ioread(&bmi, 1, sizeof(bmi)))
         return false;
     if (bigendian()) {
         // ICOs are little endian
@@ -297,7 +298,7 @@ ICOInput::readimg()
     std::vector<ico_palette_entry> palette(m_palette_size);
     if (m_bpp < 16) {  // >= 16-bit icons are unpaletted
         for (int i = 0; i < m_palette_size; i++)
-            if (!fread(&palette[i], 1, sizeof(ico_palette_entry)))
+            if (!ioread(&palette[i], 1, sizeof(ico_palette_entry)))
                 return false;
     }
 
@@ -310,7 +311,7 @@ ICOInput::readimg()
     int k;
     int index;
     for (int y = m_spec.height - 1; y >= 0; y--) {
-        if (!fread(&scanline[0], 1, slb))
+        if (!ioread(&scanline[0], 1, slb))
             return false;
         for (int x = 0; x < m_spec.width; x++) {
             k = y * m_spec.width * 4 + x * 4;
@@ -398,7 +399,7 @@ ICOInput::readimg()
               + (4 - ((m_spec.width + 7) / 8) % 4) % 4;  // padding
         scanline.resize(slb);
         for (int y = m_spec.height - 1; y >= 0; y--) {
-            if (!fread(&scanline[0], 1, slb))
+            if (!ioread(&scanline[0], 1, slb))
                 return false;
             for (int x = 0; x < m_spec.width; x += 8) {
                 for (int b = 0; b < 8; b++) {  // bit
@@ -422,10 +423,6 @@ ICOInput::close()
 {
     if (m_png && m_info)
         PNG_pvt::destroy_read_struct(m_png, m_info);
-    if (m_file) {
-        fclose(m_file);
-        m_file = NULL;
-    }
 
     init();  // Reset to initial state
     return true;

--- a/src/ico.imageio/icoinput.cpp
+++ b/src/ico.imageio/icoinput.cpp
@@ -30,6 +30,8 @@ public:
         return feature == "ioproxy";
     }
     bool open(const std::string& name, ImageSpec& newspec) override;
+    bool open(const std::string& name, ImageSpec& newspec,
+              const ImageSpec& config) override;
     bool close() override;
     int current_subimage(void) const override
     {
@@ -107,15 +109,24 @@ OIIO_EXPORT const char* ico_input_extensions[] = { "ico", nullptr };
 
 OIIO_PLUGIN_EXPORTS_END
 
-
-
 bool
 ICOInput::open(const std::string& name, ImageSpec& newspec)
 {
+    ImageSpec emptyconfig;
+    return open(name, newspec, emptyconfig);
+}
+
+bool
+ICOInput::open(const std::string& name, ImageSpec& newspec,
+               const ImageSpec& config)
+{
     m_filename = name;
 
+    ioproxy_retrieve_from_config(config);
     if (!ioproxy_use_or_open(name))
         return false;
+
+    ioseek(0);
 
     if (!ioread(&m_ico, 1, sizeof(m_ico)))
         return false;


### PR DESCRIPTION
## Description

This updates ICOInput to use the IOProxy model so it can read from files or the IOMemReader

## Tests

The current ICO tests still pass exercising the new code. I didn't see anything in the other formats with IOProxy support to explicitly test the in memory options


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

