### PR TITLE
build(deps): Raise OpenEXR minimum from 2.3 to 2.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,12 +30,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - desc: gcc6/C++14 py2.7 boost1.66 exr2.3 ocio1.1
+          - desc: gcc6/C++14 py2.7 boost1.66 exr2.4 ocio1.1
             nametag: linux-vfx2019
             os: ubuntu-latest
             container: aswf/ci-osl:2019
             vfxyear: 2019
             cxx_std: 14
+            openexr_ver: v2.4.3
             python_ver: 2.7
             simd: sse4.2
             fmt_ver: 6.1.2
@@ -148,7 +149,7 @@ jobs:
             simd: "avx2,f16c"
             fmt_ver: 9.1.0
             pybind11_ver: v2.10.0
-          - desc: oldest/hobbled gcc6.3/C++14 py2.7 boost-1.66 exr-2.3 no-sse no-ocio
+          - desc: oldest/hobbled gcc6.3/C++14 py2.7 boost-1.66 exr-2.4 no-sse no-ocio
             # Oldest versions of the dependencies that we can muster, and various
             # things disabled (no SSE, OCIO, or OpenCV, don't embed plugins).
             nametag: linux-oldest
@@ -157,13 +158,13 @@ jobs:
             vfxyear: 2019
             cxx_std: 14
             fmt_ver: 6.1.2
-            openexr_ver: v2.3.0
+            openexr_ver: v2.4.0
             pybind11_ver: v2.4.2
             python_ver: 2.7
             simd: 0
             setenvs: export  EMBEDPLUGINS=0
                              CMAKE_VERSION=3.15.5
-                             PTEX_VERSION=v2.3.1
+                             PTEX_VERSION=v2.3.2
                              WEBP_VERSION=v1.0.0
                              USE_JPEGTURBO=0
                              USE_OPENCOLORIO=0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,10 @@
 Release 2.5 (summer 2023?) -- compared to 2.4
 -------------------------------------------------
 ### New minimum dependencies and compatibility changes:
-* LibRaw: minimum has ben raised from 0.15 to 0.18. (2.5.2.1)
+* CMake: minimum needed to build OpenImageIO has been raised from 3.12 to
+  3.15. #3924 (2.5.2.1)
+* LibRaw: minimum has ben raised from 0.15 to 0.18. #3921 (2.5.2.1)
+* The new OpenEXR minimum is 2.4 (raised from 2.3). #3928 (2.5.2.1)
 
 ### ⛰️  New features and public API changes:
 * TextureSystem color management: #3761 (2.5.1.0)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -20,7 +20,8 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
  * Compilers: gcc 6.1 - 12.1, clang 3.4 - 16, MSVS 2017 - 2019,
    Intel icc 17+, Intel OneAPI C++ compiler 2022+.
  * **CMake >= 3.15** (tested through 3.27)
- * OpenEXR/Imath >= 2.3 (recommended: 2.4 or higher; tested through 3.1 and main)
+ * **OpenEXR/Imath >= 2.4** (recommended: 3.1 or higher; tested through 3.2
+   and main) (ADVISORY: We expect that OIIO 2.6 in 2024 will require OpenEXR >= 3.1)
  * libTIFF >= 3.9 (recommended: 4.0+; tested through 4.5)
  * libjpeg >= 8, or libjpeg-turbo >= 1.1 (tested through jpeg9d and jpeg-turbo
    2.1)

--- a/src/build-scripts/build_openexr.bash
+++ b/src/build-scripts/build_openexr.bash
@@ -40,37 +40,21 @@ mkdir -p ${OPENEXR_INSTALL_DIR} && true
 pushd ${OPENEXR_SOURCE_DIR}
 git checkout ${OPENEXR_VERSION} --force
 
-if [[ ${OPENEXR_VERSION} == "v2.3.0" ]] ; then
-    # Simplified setup for 2.3+
-    cmake   -S . -B ${OPENEXR_BUILD_DIR} \
-            -DCMAKE_BUILD_TYPE=${OPENEXR_BUILD_TYPE} \
-            -DCMAKE_INSTALL_PREFIX="${OPENEXR_INSTALL_DIR}" \
-            -DCMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}" \
-            -DILMBASE_PACKAGE_PREFIX="${OPENEXR_INSTALL_DIR}" \
-            -DOPENEXR_BUILD_UTILS=0 \
-            -DOPENEXR_BUILD_TESTS=0 \
-            -DOPENEXR_BUILD_PYTHON_LIBS=0 \
-            -DCMAKE_CXX_FLAGS="${OPENEXR_CXX_FLAGS}" \
-            ${OPENEXR_CMAKE_FLAGS}
-    time cmake --build ${OPENEXR_BUILD_DIR} --target install --config ${OPENEXR_BUILD_TYPE}
-else
-    # Simplified setup for 2.4+
-    cmake   -S . -B ${OPENEXR_BUILD_DIR} \
-            -DCMAKE_BUILD_TYPE=${OPENEXR_BUILD_TYPE} \
-            -DCMAKE_INSTALL_PREFIX="${OPENEXR_INSTALL_DIR}" \
-            -DCMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}" \
-            -DILMBASE_PACKAGE_PREFIX="${OPENEXR_INSTALL_DIR}" \
-            -DOPENEXR_BUILD_UTILS=0 \
-            -DBUILD_TESTING=0 \
-            -DPYILMBASE_ENABLE=0 \
-            -DOPENEXR_VIEWERS_ENABLE=0 \
-            -DINSTALL_OPENEXR_EXAMPLES=0 \
-            -DOPENEXR_INSTALL_EXAMPLES=0 \
-            -DCMAKE_INSTALL_LIBDIR=lib \
-            -DCMAKE_CXX_FLAGS="${OPENEXR_CXX_FLAGS}" \
-            ${OPENEXR_CMAKE_FLAGS}
-    time cmake --build ${OPENEXR_BUILD_DIR} --target install --config ${OPENEXR_BUILD_TYPE}
-fi
+cmake   -S . -B ${OPENEXR_BUILD_DIR} \
+        -DCMAKE_BUILD_TYPE=${OPENEXR_BUILD_TYPE} \
+        -DCMAKE_INSTALL_PREFIX="${OPENEXR_INSTALL_DIR}" \
+        -DCMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}" \
+        -DILMBASE_PACKAGE_PREFIX="${OPENEXR_INSTALL_DIR}" \
+        -DOPENEXR_BUILD_UTILS=0 \
+        -DBUILD_TESTING=0 \
+        -DPYILMBASE_ENABLE=0 \
+        -DOPENEXR_VIEWERS_ENABLE=0 \
+        -DINSTALL_OPENEXR_EXAMPLES=0 \
+        -DOPENEXR_INSTALL_EXAMPLES=0 \
+        -DCMAKE_INSTALL_LIBDIR=lib \
+        -DCMAKE_CXX_FLAGS="${OPENEXR_CXX_FLAGS}" \
+        ${OPENEXR_CMAKE_FLAGS}
+time cmake --build ${OPENEXR_BUILD_DIR} --target install --config ${OPENEXR_BUILD_TYPE}
 
 popd
 

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -96,8 +96,8 @@ checked_find_package (TIFF REQUIRED
 
 # IlmBase & OpenEXR
 checked_find_package (OpenEXR REQUIRED
-                      VERSION_MIN 2.3
-                      RECOMMEND_MIN 2.4
+                      VERSION_MIN 2.4
+                      RECOMMEND_MIN 3.1
                       PRINT IMATH_INCLUDES OPENEXR_INCLUDES)
 # Force Imath includes to be before everything else to ensure that we have
 # the right Imath/OpenEXR version, not some older version in the system
@@ -120,18 +120,14 @@ set (OPENIMAGEIO_IMATH_TARGETS
             # For OpenEXR >= 2.4/2.5 with reliable exported targets
             $<TARGET_NAME_IF_EXISTS:IlmBase::Imath>
             $<TARGET_NAME_IF_EXISTS:IlmBase::Half>
-            $<TARGET_NAME_IF_EXISTS:IlmBase::Iex>
-            # For OpenEXR <= 2.3:
-            ${ILMBASE_LIBRARIES} )
+            $<TARGET_NAME_IF_EXISTS:IlmBase::Iex> )
 set (OPENIMAGEIO_OPENEXR_TARGETS
             # For OpenEXR/Imath 3.x:
             $<TARGET_NAME_IF_EXISTS:OpenEXR::OpenEXR>
             # For OpenEXR >= 2.4/2.5 with reliable exported targets
             $<TARGET_NAME_IF_EXISTS:OpenEXR::IlmImf>
             $<TARGET_NAME_IF_EXISTS:IlmBase::IlmThread>
-            $<TARGET_NAME_IF_EXISTS:IlmBase::Iex>
-            # For OpenEXR <= 2.3:
-            ${OPENEXR_LIBRARIES} )
+            $<TARGET_NAME_IF_EXISTS:IlmBase::Iex> )
 set (OPENIMAGEIO_IMATH_DEPENDENCY_VISIBILITY "PUBLIC" CACHE STRING
      "Should we expose Imath library dependency as PUBLIC or PRIVATE")
 set (OPENIMAGEIO_CONFIG_DO_NOT_FIND_IMATH OFF CACHE BOOL

--- a/src/cmake/modules/FindOpenEXR.cmake
+++ b/src/cmake/modules/FindOpenEXR.cmake
@@ -1,5 +1,5 @@
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 # Module to find OpenEXR and Imath.
@@ -7,7 +7,7 @@
 # I'm afraid this is a mess, due to needing to support a wide range of
 # OpenEXR versions.
 #
-# For OpenEXR & Imath 3.0, this will establish the following imported
+# For OpenEXR & Imath 3.x, this will establish the following imported
 # targets:
 #
 #    Imath::Imath
@@ -24,14 +24,12 @@
 #    IlmBase::IlmThread
 #    OpenEXR::IlmImf
 #
-# For all versions -- but for OpenEXR < 2.4 the only thing this sets --
-# are the following CMake variables:
+# For all version, the following CMake variables:
 #
 #   OPENEXR_FOUND          true, if found
 #   OPENEXR_INCLUDES       directory where OpenEXR headers are found
 #   OPENEXR_LIBRARIES      libraries for OpenEXR + IlmBase
-#   OPENEXR_VERSION        OpenEXR version (accurate for >= 2.0.0,
-#                              otherwise will just guess 1.6.1)
+#   OPENEXR_VERSION        OpenEXR version
 #   IMATH_INCLUDES         directory where Imath headers are found
 #   ILMBASE_INCLUDES       directory where IlmBase headers are found
 #   ILMBASE_LIBRARIES      libraries just IlmBase
@@ -110,163 +108,5 @@ elseif (TARGET OpenEXR::IlmImf AND TARGET IlmBase::Imath AND
     string(REGEX REPLACE "include/OpenEXR$" "include" ILMBASE_INCLUDES "${ILMBASE_INCLUDES}")
     string(REGEX REPLACE "include/OpenEXR$" "include" IMATH_INCLUDES "${IMATH_INCLUDES}")
     string(REGEX REPLACE "include/OpenEXR$" "include" OPENEXR_INCLUDES "${OPENEXR_INCLUDES}")
-
-else ()
-    # OpenEXR 2.x older versions without a config or whose configs we don't
-    # trust.
-
-    set (FOUND_OPENEXR_WITH_CONFIG 0)
-
-# Other standard issue macros
-include (FindPackageHandleStandardArgs)
-include (SelectLibraryConfigurations)
-
-find_package (ZLIB REQUIRED)
-
-# Link with pthreads if required
-find_package (Threads)
-if (CMAKE_USE_PTHREADS_INIT)
-    set (ILMBASE_PTHREADS ${CMAKE_THREAD_LIBS_INIT})
-endif ()
-
-# Attempt to find OpenEXR with pkgconfig
-find_package(PkgConfig)
-if (PKG_CONFIG_FOUND)
-    if (NOT Ilmbase_ROOT AND NOT ILMBASE_ROOT
-        AND NOT DEFINED ENV{Ilmbase_ROOT} AND NOT DEFINED ENV{ILMBASE_ROOT})
-        pkg_check_modules(_ILMBASE QUIET IlmBase>=2.0.0)
-    endif ()
-    if (NOT OpenEXR_ROOT AND NOT OPENEXR_ROOT
-        AND NOT DEFINED ENV{OpenEXR_ROOT} AND NOT DEFINED ENV{OPENEXR_ROOT})
-        pkg_check_modules(_OPENEXR QUIET OpenEXR>=2.0.0)
-    endif ()
-endif (PKG_CONFIG_FOUND)
-
-# List of likely places to find the headers -- note priority override of
-# ${OPENEXR_ROOT}/include.
-# ILMBASE is needed in case ilmbase an openexr are installed in separate
-# directories, like NixOS does
-set (GENERIC_INCLUDE_PATHS
-    ${OPENEXR_ROOT}/include
-    $ENV{OPENEXR_ROOT}/include
-    ${ILMBASE_ROOT}/include
-    $ENV{ILMBASE_ROOT}/include
-    ${_ILMBASE_INCLUDEDIR}
-    ${_OPENEXR_INCLUDEDIR}
-    /usr/local/include
-    /usr/include
-    /usr/include/${CMAKE_LIBRARY_ARCHITECTURE}
-    /sw/include
-    /opt/local/include )
-
-# Find the include file locations.
-find_path (ILMBASE_INCLUDE_PATH OpenEXR/IlmBaseConfig.h
-           HINTS ${ILMBASE_INCLUDE_DIR} ${OPENEXR_INCLUDE_DIR}
-                 ${GENERIC_INCLUDE_PATHS} )
-find_path (OPENEXR_INCLUDE_PATH OpenEXR/OpenEXRConfig.h
-           HINTS ${OPENEXR_INCLUDE_DIR}
-                 ${GENERIC_INCLUDE_PATHS} )
-
-# Try to figure out version number
-if (DEFINED _OPENEXR_VERSION AND NOT "${_OPENEXR_VERSION}" STREQUAL "")
-    set (OPENEXR_VERSION "${_OPENEXR_VERSION}")
-    set (OpenEXR_VERSION "${_OPENEXR_VERSION}")
-    string (REGEX REPLACE "([0-9]+)\\.[0-9\\.]+" "\\1" OpenEXR_VERSION_MAJOR "${_OPENEXR_VERSION}")
-    string (REGEX REPLACE "[0-9]+\\.([0-9]+)(\\.[0-9]+)?" "\\1" OpenEXR_VERSION_MINOR "${_OPENEXR_VERSION}")
-elseif (EXISTS "${OPENEXR_INCLUDE_PATH}/OpenEXR/ImfMultiPartInputFile.h")
-    # Must be at least 2.0
-    file(STRINGS "${OPENEXR_INCLUDE_PATH}/OpenEXR/OpenEXRConfig.h" TMP REGEX "^#define OPENEXR_VERSION_STRING .*$")
-    string (REGEX MATCHALL "[0-9]+[.0-9]+" OpenEXR_VERSION ${TMP})
-    file(STRINGS "${OPENEXR_INCLUDE_PATH}/OpenEXR/OpenEXRConfig.h" TMP REGEX "^#define OPENEXR_VERSION_MAJOR .*$")
-    string (REGEX MATCHALL "[0-9]+" OpenEXR_VERSION_MAJOR ${TMP})
-    file(STRINGS "${OPENEXR_INCLUDE_PATH}/OpenEXR/OpenEXRConfig.h" TMP REGEX "^#define OPENEXR_VERSION_MINOR .*$")
-    string (REGEX MATCHALL "[0-9]+" OpenEXR_VERSION_MINOR ${TMP})
-else ()
-    # Assume an old one, predates 2.x that had versions
-    set (OPENEXR_VERSION 1.6.1)
-    set (OpenEXR_VERSION 1.6.1)
-    set (OpenEXR_VERSION_MAJOR 1)
-    set (OpenEXR_VERSION_MINOR 6)
-endif ()
-
-
-# List of likely places to find the libraries -- note priority override of
-# ${OPENEXR_ROOT}/lib.
-set (GENERIC_LIBRARY_PATHS
-    ${OPENEXR_ROOT}/lib
-    ${ILMBASE_ROOT}/lib
-    ${OPENEXR_INCLUDE_PATH}/../lib
-    ${ILMBASE_INCLUDE_PATH}/../lib
-    ${_ILMBASE_LIBDIR}
-    ${_OPENEXR_LIBDIR}
-    /usr/local/lib
-    /usr/local/lib/${CMAKE_LIBRARY_ARCHITECTURE}
-    /usr/lib
-    /usr/lib/${CMAKE_LIBRARY_ARCHITECTURE}
-    /sw/lib
-    /opt/local/lib
-    $ENV{PROGRAM_FILES}/OpenEXR/lib/static )
-
-# message (STATUS "Generic lib paths: ${GENERIC_LIBRARY_PATHS}")
-
-# Handle request for static libs by altering CMAKE_FIND_LIBRARY_SUFFIXES.
-# We will restore it at the end of this file.
-set (_openexr_orig_suffixes ${CMAKE_FIND_LIBRARY_SUFFIXES})
-if (OpenEXR_USE_STATIC_LIBS)
-    if (WIN32)
-        set (CMAKE_FIND_LIBRARY_SUFFIXES .lib .a ${CMAKE_FIND_LIBRARY_SUFFIXES})
-    else ()
-        set (CMAKE_FIND_LIBRARY_SUFFIXES .a)
-    endif ()
-endif ()
-
-# Look for the libraries themselves, for all the components.
-# This is complicated because the OpenEXR libraries may or may not be
-# built with version numbers embedded.
-set (_openexr_components IlmThread IlmImf Imath Iex Half)
-foreach (COMPONENT ${_openexr_components})
-    string (TOUPPER ${COMPONENT} UPPERCOMPONENT)
-    # First try with the version embedded
-    find_library (OPENEXR_${UPPERCOMPONENT}_LIBRARY
-                  NAMES ${COMPONENT}-${OpenEXR_VERSION_MAJOR}_${OpenEXR_VERSION_MINOR}
-                        ${COMPONENT}
-                        ${COMPONENT}-${OpenEXR_VERSION_MAJOR}_${OpenEXR_VERSION_MINOR}_d
-                        ${COMPONENT}_d
-                  HINTS ${OPENEXR_LIBRARY_DIR} $ENV{OPENEXR_LIBRARY_DIR}
-                        ${GENERIC_LIBRARY_PATHS} )
-endforeach ()
-
-find_package_handle_standard_args (OpenEXR
-    REQUIRED_VARS ILMBASE_INCLUDE_PATH OPENEXR_INCLUDE_PATH
-                  OPENEXR_IMATH_LIBRARY OPENEXR_ILMIMF_LIBRARY
-                  OPENEXR_IEX_LIBRARY OPENEXR_HALF_LIBRARY
-    )
-
-if (OPENEXR_FOUND)
-    set (OPENEXR_VERSION_MAJOR ${OpenEXR_VERSION_MAJOR})
-    set (OPENEXR_VERSION_MINOR ${OpenEXR_VERSION_MINOR})
-    set (Imath_VERSION_MAJOR ${OpenEXR_VERSION_MAJOR})
-    set (Imath_VERSION_MINOR ${OpenEXR_VERSION_MINOR})
-    set (ILMBASE_FOUND TRUE)
-    set (ILMBASE_INCLUDES ${ILMBASE_INCLUDE_PATH})
-    set (IMATH_INCLUDES ${ILMBASE_INCLUDE_PATH})
-    set (OPENEXR_INCLUDES ${OPENEXR_INCLUDE_PATH})
-    set (ILMBASE_INCLUDE_DIR ${ILMBASE_INCLUDE_PATH})
-    set (IMATH_INCLUDE_DIR ${ILMBASE_INCLUDE_PATH})
-    set (OPENEXR_INCLUDE_DIR ${OPENEXR_INCLUDE_PATH})
-    set (ILMBASE_LIBRARIES ${OPENEXR_IMATH_LIBRARY} ${OPENEXR_IEX_LIBRARY} ${OPENEXR_HALF_LIBRARY} ${OPENEXR_ILMTHREAD_LIBRARY} ${ILMBASE_PTHREADS} CACHE STRING "The libraries needed to use IlmBase")
-    set (OPENEXR_LIBRARIES ${OPENEXR_ILMIMF_LIBRARY} ${ILMBASE_LIBRARIES} ${ZLIB_LIBRARIES} CACHE STRING "The libraries needed to use OpenEXR")
-    set (FINDOPENEXR_FALLBACK TRUE)
-endif ()
-
-mark_as_advanced(
-    OPENEXR_ILMIMF_LIBRARY
-    OPENEXR_IMATH_LIBRARY
-    OPENEXR_IEX_LIBRARY
-    OPENEXR_HALF_LIBRARY
-    OPENEXR_VERSION)
-
-# Restore the original CMAKE_FIND_LIBRARY_SUFFIXES
-set (CMAKE_FIND_LIBRARY_SUFFIXES ${_openexr_orig_suffixes})
 
 endif ()

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -572,18 +572,10 @@ OpenEXRInput::PartInfo::parse_header(OpenEXRInput* in,
         case Imf::ZIP_COMPRESSION: comp = "zip"; break;
         case Imf::PIZ_COMPRESSION: comp = "piz"; break;
         case Imf::PXR24_COMPRESSION: comp = "pxr24"; break;
-#ifdef IMF_B44_COMPRESSION
-            // The enum Imf::B44_COMPRESSION is not defined in older versions
-            // of OpenEXR, and there are no explicit version numbers in the
-            // headers.  BUT this other related #define is present only in
-            // the newer version.
         case Imf::B44_COMPRESSION: comp = "b44"; break;
         case Imf::B44A_COMPRESSION: comp = "b44a"; break;
-#endif
-#if OPENEXR_CODED_VERSION >= 20200
         case Imf::DWAA_COMPRESSION: comp = "dwaa"; break;
         case Imf::DWAB_COMPRESSION: comp = "dwab"; break;
-#endif
         default: break;
         }
         if (comp)


### PR DESCRIPTION
This will not be backported to the release branch, it's only for OIIO 2.5 and later.
