### PR TITLE
Admin: Add Jesse Yurkovich to the TSC

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -133,6 +133,7 @@ Current voting members of the TSC are:
 * **Chair and TAC representative**: Daniel Greenstein - Sony Pictures Imageworks (possibly interim?)
 * **Chief Architect**: Larry Gritz - Sony Pictures Imageworks
 * Anton Dukhovnikov - Wētā Digital / Unity
+* Jesse Yurkovich - Blender
 * Joseph Goldstone - ARRI
 * Lewis Wakeland - Disney TV Animation
 * Luke Emrose - Animal Logic (interim?)


### PR DESCRIPTION
Proposal from Thiago to add Jesse Yurkovich, representing Blender, to the TSC.

We didn't have voting member quorum at the latest TSC meeting, so we'll do the vote by PR.

Voting TSC members: please poke the "approve" button on this PR or add an comment denoting approval (or a nay vote if that is your preference).

