### PR TITLE
admin: Relicense code under Apache 2.0

### DIFF
--- a/RELICENSING.md
+++ b/RELICENSING.md
@@ -23,7 +23,7 @@ the Developer Certificate of Origin, version 1.1:
 - Nathan Rusch (nrusch)
 - Ismael Cortes (leamsi)
 - AdamMainsTL
-- Sony Pictures Imageworks (cstein, olegul, fpsunflower, brianhall77, jeremyselan, drg)
+- Sony Pictures Imageworks (cstein, olegul, fpsunflower, brianhall77, jeremyselan, drg, richardssam, lecocqp)
 - Richard Shaw (hobbes1069)
 - Robert Matusewicz
 - Mariusz Szczepańczyk (mszczepanczyk)
@@ -86,6 +86,31 @@ the Developer Certificate of Origin, version 1.1:
 - Seifeddine Dridi (seifeddinedridi)
 - Daniel Dresser (danieldresser)
 - Luc Bournaud (DevilishSpirits)
+- Dennis Schridde (devurandom)
+- Dieter De Baets (debaetsd)
+- Gonzalo Garramuño (ggarra13)
+- Alan Jones (@skyphyr)
+- pumkinpal
+- Christopher Crosetto (ccrosetto)
+- Russell Greene (russelltg)
+- Sam Richards (richardssam)
+- Guillaume Chatelet (gchatelet)
+- extrowerk
+- Heiko Becker (heirecka)
+- Mark Visser (mjmvisser)
+- Harry Mallon (hjmallon)
+- Henri Fousse (darkhorse64)
+- Krzysztof Blicharski (blicharski)
+- Hugh Macdonald (HughMacdonald)
+- Pascal Lecocq (lecocqp)
+- Ramon Montoya Vozmediano (rmv)
+- Dan Wexler (danwexler)
+- Jérôme Duval (korli)
+- Tim Grant (timgrant)
+- Shane Ambler (sambler)
+- Wētā
+- Kimball Thurston (kdt3rd)
+- Anders Langlands (anderslanglands)
 
 **Prior authors, please submit a PR against this file that adds your name
 above. If, at the time of your prior contributions, you were employed by a

--- a/src/build-scripts/build_OpenJPEG.bash
+++ b/src/build-scripts/build_OpenJPEG.bash
@@ -3,7 +3,7 @@
 # Utility script to download and build OpenJPEG
 #
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 # Exit the whole script if any command fails.

--- a/src/build-scripts/build_gif.bash
+++ b/src/build-scripts/build_gif.bash
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 # Utility script to download and build giflib

--- a/src/build-scripts/build_libjpeg-turbo.bash
+++ b/src/build-scripts/build_libjpeg-turbo.bash
@@ -3,7 +3,7 @@
 # Utility script to download and build libjpeg-turbo
 #
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 # Exit the whole script if any command fails.

--- a/src/build-scripts/build_libpng.bash
+++ b/src/build-scripts/build_libpng.bash
@@ -3,7 +3,7 @@
 # Utility script to download and build libpng
 #
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 # Exit the whole script if any command fails.

--- a/src/build-scripts/build_libraw.bash
+++ b/src/build-scripts/build_libraw.bash
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 # Utility script to download and build LibRaw

--- a/src/build-scripts/build_libtiff.bash
+++ b/src/build-scripts/build_libtiff.bash
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 # Utility script to download and build libtiff

--- a/src/build-scripts/build_pugixml.bash
+++ b/src/build-scripts/build_pugixml.bash
@@ -3,7 +3,7 @@
 # Utility script to download and build pugixml
 #
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 # Exit the whole script if any command fails.

--- a/src/build-scripts/build_pybind11.bash
+++ b/src/build-scripts/build_pybind11.bash
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 # Utility script to download and build pybind11

--- a/src/build-scripts/build_webp.bash
+++ b/src/build-scripts/build_webp.bash
@@ -3,7 +3,7 @@
 # Utility script to download and build webp
 #
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 # Exit the whole script if any command fails.

--- a/src/build-scripts/build_zlib.bash
+++ b/src/build-scripts/build_zlib.bash
@@ -3,7 +3,7 @@
 # Utility script to download and build zlib
 #
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 # Exit the whole script if any command fails.

--- a/src/cmake/modules/FindOpenCV.cmake
+++ b/src/cmake/modules/FindOpenCV.cmake
@@ -1,5 +1,5 @@
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 # - Find OpenCV

--- a/src/cmake/pythonutils.cmake
+++ b/src/cmake/pythonutils.cmake
@@ -1,5 +1,5 @@
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 # Python-related options.

--- a/src/dpx.imageio/dpxinput.cpp
+++ b/src/dpx.imageio/dpxinput.cpp
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 #include <cmath>

--- a/src/gif.imageio/gifinput.cpp
+++ b/src/gif.imageio/gifinput.cpp
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 #include <fcntl.h>

--- a/src/heif.imageio/heifinput.cpp
+++ b/src/heif.imageio/heifinput.cpp
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 #include <OpenImageIO/filesystem.h>

--- a/src/heif.imageio/heifoutput.cpp
+++ b/src/heif.imageio/heifoutput.cpp
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/include/OpenImageIO/filesystem.h
+++ b/src/include/OpenImageIO/filesystem.h
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 // clang-format off

--- a/src/include/OpenImageIO/imagebufalgo_util.h
+++ b/src/include/OpenImageIO/imagebufalgo_util.h
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/include/OpenImageIO/strutil.h
+++ b/src/include/OpenImageIO/strutil.h
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 // clang-format off

--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 #include <algorithm>

--- a/src/libOpenImageIO/imageinout_test.cpp
+++ b/src/libOpenImageIO/imageinout_test.cpp
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 /////////////////////////////////////////////////////////////////////////

--- a/src/libOpenImageIO/imagespec_test.cpp
+++ b/src/libOpenImageIO/imagespec_test.cpp
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/libOpenImageIO/iptc.cpp
+++ b/src/libOpenImageIO/iptc.cpp
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 

--- a/src/libutil/strutil_test.cpp
+++ b/src/libutil/strutil_test.cpp
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 // clang-format off
 

--- a/src/libutil/ustring.cpp
+++ b/src/libutil/ustring.cpp
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 #include <string>

--- a/src/maketx/maketx.cpp
+++ b/src/maketx/maketx.cpp
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 #include <cmath>

--- a/src/openexr.imageio/exrinput_c.cpp
+++ b/src/openexr.imageio/exrinput_c.cpp
@@ -1,5 +1,5 @@
 // Copyright 2021-present Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/OpenImageIO/oiio
 
 #include <cerrno>

--- a/src/ptex.imageio/CMakeLists.txt
+++ b/src/ptex.imageio/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 if (Ptex_FOUND)

--- a/testsuite/heif/run.py
+++ b/testsuite/heif/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 imagedir = "ref/"

--- a/testsuite/maketx/run.py
+++ b/testsuite/maketx/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python 
 
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 failureok = 1

--- a/testsuite/oiiotool-maketx/run.py
+++ b/testsuite/oiiotool-maketx/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python 
 
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/OpenImageIO/oiio
 
 # Construct a command that will create a texture, appending console


### PR DESCRIPTION
This is Update 3, the original PR is ongoing and we will continue to update as additional people relicense.

Per PR #3905 (https://github.com/OpenImageIO/oiio/pull/3905), update the RELICENSING document with the names of people and companies who have signed on to the relicensing thus far, and update the SPDX license notices on source files whose extant authorship (per 'git blame') comprises only authors who have relicensed.
