### PR TITLE
dev(ustring.h): string literal operator for ustring and ustringhash

### DIFF
--- a/src/include/OpenImageIO/platform.h
+++ b/src/include/OpenImageIO/platform.h
@@ -527,6 +527,15 @@
 #endif
 
 
+// OIIO_DEVICE_CONSTEXPR is like OIIO_HOSTDEVICE, but it's `constexpr` only on
+// the Cuda device side, and merely inline (not constexpr) on the host side.
+#ifdef __CUDA_ARCH__
+#    define OIIO_DEVICE_CONSTEXPR __device__ constexpr
+#else
+#    define OIIO_DEVICE_CONSTEXPR /*__host__*/ inline
+#endif
+
+
 
 // OIIO_PRETTY_FUNCTION gives a text string of the current function
 // declaration.

--- a/src/include/OpenImageIO/ustring.h
+++ b/src/include/OpenImageIO/ustring.h
@@ -818,18 +818,24 @@ public:
     OIIO_DEVICE_CONSTEXPR explicit ustringhash(const char* str)
     {
 #ifdef __CUDA_ARCH__
-        m_hash = Strutil::strhash(str);  // GPU: just compute the hash
+        // GPU: just compute the hash. This can be constexpr!
+        m_hash = Strutil::strhash(str);
 #else
-        m_hash = ustring(str).hash();       // CPU: make ustring, get its hash
+        // CPU: make ustring, get its hash. Note that ustring ctr can't be
+        // constexpr because it has to modify the internal ustring table.
+        m_hash = ustring(str).hash();
 #endif
     }
 
     OIIO_DEVICE_CONSTEXPR explicit ustringhash(const char* str, size_t len)
     {
 #ifdef __CUDA_ARCH__
-        m_hash = Strutil::strhash(len, str);  // GPU: just compute the hash
+        // GPU: just compute the hash. This can be constexpr!
+        m_hash = Strutil::strhash(len, str);
 #else
-        m_hash = ustring(str, len).hash();  // CPU: make ustring, get its hash
+        // CPU: make ustring, get its hash. Note that ustring ctr can't be
+        // constexpr because it has to modify the internal ustring table.
+        m_hash = ustring(str, len).hash();
 #endif
     }
 
@@ -838,9 +844,12 @@ public:
     OIIO_DEVICE_CONSTEXPR explicit ustringhash(string_view str)
     {
 #ifdef __CUDA_ARCH__
-        m_hash = Strutil::strhash(str);  // GPU: just compute the hash
+        // GPU: just compute the hash. This can be constexpr!
+        m_hash = Strutil::strhash(str);
 #else
-        m_hash = ustring(str).hash();       // CPU: make ustring, get its hash
+        // CPU: make ustring, get its hash. Note that ustring ctr can't be
+        // constexpr because it has to modify the internal ustring table.
+        m_hash = ustring(str).hash();
 #endif
     }
 

--- a/src/include/OpenImageIO/ustring.h
+++ b/src/include/OpenImageIO/ustring.h
@@ -815,23 +815,32 @@ public:
     }
 
     /// Construct a ustringhash from a null-terminated C string (char *).
-    OIIO_HOSTDEVICE explicit ustringhash(const char* str)
+    OIIO_DEVICE_CONSTEXPR explicit ustringhash(const char* str)
     {
 #ifdef __CUDA_ARCH__
         m_hash = Strutil::strhash(str);  // GPU: just compute the hash
 #else
-        m_hash = ustring(str).hash();  // CPU: make ustring, get its hash
+        m_hash = ustring(str).hash();       // CPU: make ustring, get its hash
+#endif
+    }
+
+    OIIO_DEVICE_CONSTEXPR explicit ustringhash(const char* str, size_t len)
+    {
+#ifdef __CUDA_ARCH__
+        m_hash = Strutil::strhash(len, str);  // GPU: just compute the hash
+#else
+        m_hash = ustring(str, len).hash();  // CPU: make ustring, get its hash
 #endif
     }
 
     /// Construct a ustringhash from a string_view, which can be
     /// auto-converted from either a std::string.
-    OIIO_HOSTDEVICE explicit ustringhash(string_view str)
+    OIIO_DEVICE_CONSTEXPR explicit ustringhash(string_view str)
     {
 #ifdef __CUDA_ARCH__
         m_hash = Strutil::strhash(str);  // GPU: just compute the hash
 #else
-        m_hash = ustring(str).hash();  // CPU: make ustring, get its hash
+        m_hash = ustring(str).hash();       // CPU: make ustring, get its hash
 #endif
     }
 
@@ -1010,6 +1019,22 @@ inline ustring::ustring(ustringhash hash)
     m_chars = ustring::from_hash(hash.hash()).c_str();
 }
 #endif
+
+
+
+/// ustring string literal operator
+inline ustring operator""_us(const char* str, std::size_t len)
+{
+    return ustring(str, len);
+}
+
+
+/// ustringhash string literal operator
+OIIO_DEVICE_CONSTEXPR ustringhash operator""_ush(const char* str,
+                                                 std::size_t len)
+{
+    return ustringhash(str, len);
+}
 
 
 

--- a/src/libutil/ustring_test.cpp
+++ b/src/libutil/ustring_test.cpp
@@ -156,6 +156,12 @@ test_ustring()
 
     // std::hash
     OIIO_CHECK_EQUAL(std::hash<ustring> {}(foo), foo.hash());
+
+    // string literals
+    auto whichtype = "foo"_us;
+    OIIO_CHECK_EQUAL(whichtype, ustring("foo"));
+    OIIO_CHECK_ASSERT((std::is_same<decltype(whichtype), ustring>::value));
+    OIIO_CHECK_ASSERT(!(std::is_same<decltype(whichtype), const char*>::value));
 }
 
 
@@ -227,6 +233,12 @@ test_ustringhash()
 
     // formatting string
     OIIO_CHECK_EQUAL(Strutil::fmt::format("{}", hfoo), "foo");
+
+    // string literals
+    auto whichtype = "foo"_ush;
+    OIIO_CHECK_EQUAL(whichtype, ustringhash("foo"));
+    OIIO_CHECK_ASSERT((std::is_same<decltype(whichtype), ustringhash>::value));
+    OIIO_CHECK_ASSERT(!(std::is_same<decltype(whichtype), const char*>::value));
 }
 
 


### PR DESCRIPTION
* Add string literal operators for ustring and ustringhash so you can write: ``` "foo"_us "bar"_ush ``` Note that on Cuda (but not on the host), this ustringhash construction is constexpr.

* Add a new `ustringhash(const char*, size_t)` constructor, which is also constexpr on the device side.

* Mark the existing `ustringhash(string_view)` constructor as constexpr on the device side.

We can mark those things as constexpr on the device side because on the Cuda side, the implementation only takes the hash (which is constexpr), and does not actually add a ustring to the table (which cannot be constexpr). To make such declarations easy, add a new macro to platform.h, `OIIO_DEVICE_CONSTEXPR` which is constexpr for the device, merely inline for the host.

