### PR TITLE
exr: Re-enable openexr core default when recent enough

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,7 +256,7 @@ jobs:
             cxx_compiler: g++-11
             cxx_std: 17
             fmt_ver: 9.1.0
-            openexr_ver: v3.1.10
+            openexr_ver: v3.1.11
             pybind11_ver: v2.11.1
             python_ver: "3.10"
             simd: avx2,f16c
@@ -297,7 +297,7 @@ jobs:
             cc_compiler: clang
             cxx_std: 20
             fmt_ver: 9.0.0
-            openexr_ver: v3.1.10
+            openexr_ver: v3.1.11
             pybind11_ver: v2.9.2
             python_ver: 3.8
             simd: avx2,f16c

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,7 +256,7 @@ jobs:
             cxx_compiler: g++-11
             cxx_std: 17
             fmt_ver: 9.1.0
-            openexr_ver: v3.1.7
+            openexr_ver: v3.1.10
             pybind11_ver: v2.11.1
             python_ver: "3.10"
             simd: avx2,f16c
@@ -297,7 +297,7 @@ jobs:
             cc_compiler: clang
             cxx_std: 20
             fmt_ver: 9.0.0
-            openexr_ver: v3.1.5
+            openexr_ver: v3.1.10
             pybind11_ver: v2.9.2
             python_ver: 3.8
             simd: avx2,f16c

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,6 +17,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
  * C++14 or higher (also builds with C++17, and C++20)
      * The default build mode is C++14. This can be controlled by via the
        CMake configuration flag: `-DCMAKE_CXX_STANDARD=17`, etc.
+     * ADVISORY: We expect that OIIO 2.6 in 2024 will require C++17 or higher.
  * Compilers: gcc 6.1 - 12.1, clang 3.4 - 16, MSVS 2017 - 2019,
    Intel icc 17+, Intel OneAPI C++ compiler 2022+.
  * **CMake >= 3.15** (tested through 3.27)

--- a/src/cmake/testing.cmake
+++ b/src/cmake/testing.cmake
@@ -274,15 +274,19 @@ macro (oiio_add_all_tests)
     set (all_openexr_tests
          openexr-suite openexr-multires openexr-chroma
          openexr-v2 openexr-window perchannel oiiotool-deep)
+    if (OpenEXR_VERSION VERSION_GREATER_EQUAL 3.1.10)
+        # OpenEXR 3.1.10 is the first release where the exr core library
+        # properly supported all compression types (DWA in particular).
+        list (APPEND all_openexr_tests openexr-compression)
+    endif ()
     # Run all OpenEXR tests without core library
-    oiio_add_tests (${all_openexr_tests} openexr-compression
+    oiio_add_tests (${all_openexr_tests}
                     ENVIRONMENT OPENIMAGEIO_OPTIONS=openexr:core=0
                     IMAGEDIR openexr-images
                     URL http://github.com/AcademySoftwareFoundation/openexr-images)
     # For OpenEXR >= 3.1, be sure to test with the core option on
     if (OpenEXR_VERSION VERSION_GREATER_EQUAL 3.1)
         oiio_add_tests (${all_openexr_tests}
-                            # N.B. doesn't work yet: openexr-compression
                         SUFFIX ".core"
                         ENVIRONMENT OPENIMAGEIO_OPTIONS=openexr:core=1
                         IMAGEDIR openexr-images

--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -103,6 +103,18 @@ if (EMBEDPLUGINS)
     endforeach ()
 endif ()
 
+# Enable default use of OpenEXR core library for versions of the library
+# new enough to support DWA compression in exrcore.
+if (OPENEXR_VERSION VERSION_GREATER_EQUAL 3.1.10)
+    target_compile_definitions(OpenImageIO
+                               PRIVATE OIIO_OPENEXR_CORE_DEFAULT=1)
+    message (STATUS "OpenEXR core library will be used by default")
+else ()
+    target_compile_definitions(OpenImageIO
+                               PRIVATE OIIO_OPENEXR_CORE_DEFAULT=0)
+    message (STATUS "OpenEXR core library will not be used by default")
+endif ()
+
 # Source groups for libutil and libtexture
 source_group ("libutil"    REGULAR_EXPRESSION ".+/libutil/.+")
 source_group ("libtexture" REGULAR_EXPRESSION ".+/libtexture/.+")

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -41,7 +41,11 @@ atomic_int oiio_threads(threads_default());
 atomic_int oiio_exr_threads(threads_default());
 atomic_int oiio_read_chunk(256);
 atomic_int oiio_try_all_readers(1);
-int openexr_core(0);  // Should we use "Exr core C library"?
+#ifndef OIIO_OPENEXR_CORE_DEFAULT
+#    define OIIO_OPENEXR_CORE_DEFAULT 0
+#endif
+// Should we use "Exr core C library"?
+int openexr_core(OIIO_OPENEXR_CORE_DEFAULT);
 int tiff_half(0);
 int tiff_multithread(1);
 int dds_bc5normal(0);

--- a/src/openexr.imageio/CMakeLists.txt
+++ b/src/openexr.imageio/CMakeLists.txt
@@ -10,6 +10,16 @@ if (OIIO_USE_EXR_C_API AND TARGET OpenEXR::OpenEXRCore)
     list (APPEND openexr_src exrinput_c.cpp)
 endif()
 
+# Enable default use of OpenEXR core library for versions of the library
+# new enough to support DWA compression in exrcore.
+if (OPENEXR_VERSION VERSION_GREATER_EQUAL 3.1.10)
+    list (APPEND openexr_defs OIIO_OPENEXR_CORE_DEFAULT=1)
+    message (STATUS "OpenEXR core library will be used by default")
+else ()
+    list (APPEND openexr_defs OIIO_OPENEXR_CORE_DEFAULT=0)
+    message (STATUS "OpenEXR core library will not be used by default")
+endif ()
+
 add_oiio_plugin (${openexr_src}
     INCLUDE_DIRS ${OPENEXR_INCLUDES} ${IMATH_INCLUDE_DIR}/OpenEXR
     LINK_LIBRARIES


### PR DESCRIPTION
We had disabled the use of the "openexr core" library by default, even for OpenEXR versions that nominally support it, when it was discovered that it stil didn't support the DWA compression types.

That has finally been added to the OpenEXR trunk as well as the OpenEXR 3.1.10 release. When we are building against a sufficiently new OpenEXR to fully support all the compression types for exr core, then re-enable it by default.

Bump the "latest" CI tests to OpenEXR 3.1.11.
