### PR TITLE
Silence gcc new/delete warnings for texturesys

### DIFF
--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -82,9 +82,9 @@ static const OIIO_SIMD4_ALIGN vbool4 channel_masks[5] = {
 TextureSystem*
 TextureSystem::create(bool shared, ImageCache* imagecache)
 {
-// Because the shared_texturesys is never deleted (by design)
-// we silence the otherwise useful compiler warning on newer GCC versions
-OIIO_PRAGMA_WARNING_PUSH
+    // Because the shared_texturesys is never deleted (by design)
+    // we silence the otherwise useful compiler warning on newer GCC versions
+    OIIO_PRAGMA_WARNING_PUSH
 #if OIIO_GNUC_VERSION > 100000
     OIIO_GCC_ONLY_PRAGMA(GCC diagnostic ignored "-Wmismatched-new-delete")
 #endif
@@ -113,7 +113,7 @@ OIIO_PRAGMA_WARNING_PUSH
 #if 0
     std::cerr << "creating new ImageCache " << (void *)ts << "\n";
 #endif
-OIIO_PRAGMA_WARNING_POP
+    OIIO_PRAGMA_WARNING_POP
     return ts;
 }
 

--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -82,6 +82,12 @@ static const OIIO_SIMD4_ALIGN vbool4 channel_masks[5] = {
 TextureSystem*
 TextureSystem::create(bool shared, ImageCache* imagecache)
 {
+// Because the shared_texturesys is never deleted (by design)
+// we silence the otherwise useful compiler warning on newer GCC versions
+OIIO_PRAGMA_WARNING_PUSH
+#if OIIO_GNUC_VERSION > 100000
+    OIIO_GCC_ONLY_PRAGMA(GCC diagnostic ignored "-Wmismatched-new-delete")
+#endif
     if (shared) {
         // They requested a shared texture system.  If a shared one already
         // exists, just return it, otherwise record the new texture system
@@ -107,6 +113,7 @@ TextureSystem::create(bool shared, ImageCache* imagecache)
 #if 0
     std::cerr << "creating new ImageCache " << (void *)ts << "\n";
 #endif
+OIIO_PRAGMA_WARNING_POP
     return ts;
 }
 


### PR DESCRIPTION
## Description

Disable GCC warnings around mismatched new/delete for shared_texturesys creation

## Tests

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [X] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [X] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [X] My code follows the prevailing code style of this project.

