### PR TITLE
fix runtime error: signed integer overflow in file src/bmp.imageio/bmpinput.cpp:302

### DIFF
--- a/src/bmp.imageio/bmpinput.cpp
+++ b/src/bmp.imageio/bmpinput.cpp
@@ -299,7 +299,7 @@ BmpInput::read_rle_image()
     int rletype = m_dib_header.compression == RLE4_COMPRESSION ? 4 : 8;
     m_spec.attribute("compression", rletype == 4 ? "rle4" : "rle8");
     m_uncompressed.clear();
-    m_uncompressed.resize(m_spec.height * m_spec.width);
+    m_uncompressed.resize(m_spec.image_pixels());
     // Note: the clear+resize zeroes out the buffer
     bool ok = true;
     int y = 0, x = 0;


### PR DESCRIPTION
## Description

fix #3947: runtime error: signed integer overflow in file src/bmp.imageio/bmpinput.cpp:302

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [Y] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [Y] My code follows the prevailing code style of this project.

