### PR TITLE
fix implicit 64 to 32 bit conversion warnings

### DIFF
--- a/src/bmp.imageio/bmpoutput.cpp
+++ b/src/bmp.imageio/bmpoutput.cpp
@@ -148,7 +148,7 @@ BmpOutput::write_scanline(int y, int z, TypeDesc format, const void* data,
 
     // Swap RGB pixels into BGR format
     if (m_spec.nchannels >= 3)
-        for (int i = 0, iend = m_buf.size() - 2; i < iend;
+        for (size_t i = 0, iend = m_buf.size() - 2; i < iend;
              i += m_spec.nchannels)
             std::swap(m_buf[i], m_buf[i + 2]);
 
@@ -202,7 +202,7 @@ BmpOutput::create_and_write_file_header(void)
     int64_t data_size  = m_padded_scanline_size * m_spec.height;
     int palettesize    = (m_spec.nchannels == 1) ? 4 * 256 : 0;
     int64_t file_size  = data_size + BMP_HEADER_SIZE + WINDOWS_V3 + palettesize;
-    m_bmp_header.fsize = file_size;
+    m_bmp_header.fsize = (int32_t)file_size;
     m_bmp_header.res1  = 0;
     m_bmp_header.res2  = 0;
     m_bmp_header.offset = BMP_HEADER_SIZE + WINDOWS_V3 + palettesize;

--- a/src/cineon.imageio/libcineon/EndianSwap.h
+++ b/src/cineon.imageio/libcineon/EndianSwap.h
@@ -86,7 +86,7 @@ inline char SwapBytes( char& value )
 
 
 template <typename T>
-void SwapBuffer(T *buf, unsigned int len)
+void SwapBuffer(T *buf, size_t len)
 {
 	for (unsigned int i = 0; i < len; i++)
 		SwapBytes(buf[i]);
@@ -94,7 +94,7 @@ void SwapBuffer(T *buf, unsigned int len)
 
 
 template <DataSize SIZE>
-void EndianSwapImageBuffer(void *data, int length)
+void EndianSwapImageBuffer(void *data, size_t length)
 {
 	switch (SIZE)
 	{
@@ -116,7 +116,7 @@ void EndianSwapImageBuffer(void *data, int length)
 }
 
 
-inline void EndianSwapImageBuffer(DataSize size, void *data, int length)
+inline void EndianSwapImageBuffer(DataSize size, void *data, size_t length)
 {
 	switch (size)
 	{

--- a/src/cineon.imageio/libcineon/EndianSwap.h
+++ b/src/cineon.imageio/libcineon/EndianSwap.h
@@ -88,7 +88,7 @@ inline char SwapBytes( char& value )
 template <typename T>
 void SwapBuffer(T *buf, size_t len)
 {
-	for (unsigned int i = 0; i < len; i++)
+	for (size_t i = 0; i < len; i++)
 		SwapBytes(buf[i]);
 }
 

--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -148,9 +148,12 @@ if (CMAKE_COMPILER_IS_CLANG OR CMAKE_COMPILER_IS_APPLECLANG)
         # Don't warn about using unknown preprocessor symbols in `#if`
         add_compile_options ("-Wno-expansion-to-defined")
     endif ()
-    if (CMAKE_GENERATOR MATCHES "Xcode")
-        add_compile_options ("-Wno-shorten-64-to-32")
-    endif ()
+#    if (CMAKE_GENERATOR MATCHES "Xcode")
+#        add_compile_options ("-Wno-shorten-64-to-32")
+#    endif ()
+    add_compile_options ("-Wshorten-64-to-32")
+    add_compile_options ("-Wsign-compare")
+
 endif ()
 
 if (CMAKE_COMPILER_IS_GNUCC AND NOT (CMAKE_COMPILER_IS_CLANG OR CMAKE_COMPILER_IS_APPLECLANG))

--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -151,8 +151,11 @@ if (CMAKE_COMPILER_IS_CLANG OR CMAKE_COMPILER_IS_APPLECLANG)
 #    if (CMAKE_GENERATOR MATCHES "Xcode")
 #        add_compile_options ("-Wno-shorten-64-to-32")
 #    endif ()
-    add_compile_options ("-Wshorten-64-to-32")
-    add_compile_options ("-Wsign-compare")
+
+    if (NOT WIN32)
+        add_compile_options ("-Wshorten-64-to-32")
+        add_compile_options ("-Wsign-compare")
+    endif ()
 
 endif ()
 

--- a/src/dds.imageio/ddsinput.cpp
+++ b/src/dds.imageio/ddsinput.cpp
@@ -572,10 +572,10 @@ DDSInput::internal_seek_subimage(int cubeface, int miplevel, unsigned int& w,
     // we can easily calculate the offsets because both compressed and
     // uncompressed images have predictable length
     // calculate the offset; start with after the header
-    unsigned int ofs = sizeof(dds_header);
+    size_t ofs = sizeof(dds_header);
     if (m_dds.fmt.fourCC == DDS_4CC_DX10)
         ofs += sizeof(dds_header_dx10);
-    unsigned int len;
+    size_t len;
     // this loop is used to iterate over cube map sides, or run once in the
     // case of ordinary 2D or 3D images
     for (int j = 0; j <= cubeface; j++) {

--- a/src/dicom.imageio/dicominput.cpp
+++ b/src/dicom.imageio/dicominput.cpp
@@ -160,8 +160,8 @@ DICOMInput::seek_subimage(int subimage, int miplevel)
             errorf("Unable to open DICOM file %s", m_filename);
             return false;
         }
-        m_framecount = m_img->getFrameCount();
-        m_firstframe = m_img->getFirstFrame();
+        m_framecount = (int)m_img->getFrameCount();
+        m_firstframe = (int)m_img->getFirstFrame();
     }
 
     if (subimage >= m_firstframe + m_framecount) {
@@ -226,7 +226,7 @@ DICOMInput::seek_subimage(int subimage, int miplevel)
         }
     }
 
-    m_spec = ImageSpec(m_img->getWidth(), m_img->getHeight(), nchannels,
+    m_spec = ImageSpec((int)m_img->getWidth(), (int)m_img->getHeight(), nchannels,
                        format);
 
     m_bitspersample = m_img->getDepth();
@@ -337,7 +337,7 @@ DICOMInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
     memcpy(data, m_internal_data + y * size, size);
 
     // Handle non-full bit depths
-    int bits = m_spec.format.size() * 8;
+    int bits = (int)m_spec.format.size() * 8;
     if (bits != m_bitspersample) {
         size_t n = m_spec.width * m_spec.nchannels;
         if (m_spec.format == TypeDesc::UINT8) {

--- a/src/dpx.imageio/dpxoutput.cpp
+++ b/src/dpx.imageio/dpxoutput.cpp
@@ -483,7 +483,7 @@ DPXOutput::prep_subimage(int s, bool allocate)
     }
 
     // calculate target bit depth
-    m_bitdepth = spec_s.format.size() * 8;
+    m_bitdepth = (int)spec_s.format.size() * 8;
     if (spec_s.format == TypeDesc::UINT16) {
         m_bitdepth = spec_s.get_int_attribute("oiio:BitsPerSample", 16);
         if (m_bitdepth != 10 && m_bitdepth != 12 && m_bitdepth != 16) {

--- a/src/dpx.imageio/libdpx/EndianSwap.h
+++ b/src/dpx.imageio/libdpx/EndianSwap.h
@@ -86,7 +86,7 @@ inline char SwapBytes( char& value )
 
 
 template <typename T>
-void SwapBuffer(T *buf, unsigned int len)
+void SwapBuffer(T *buf, size_t len)
 {
 	for (unsigned int i = 0; i < len; i++)
 		SwapBytes(buf[i]);
@@ -94,7 +94,7 @@ void SwapBuffer(T *buf, unsigned int len)
 
 
 template <DataSize SIZE>
-void EndianSwapImageBuffer(void *data, int length)
+void EndianSwapImageBuffer(void *data, size_t length)
 {
 	switch (SIZE)
 	{
@@ -120,7 +120,7 @@ void EndianSwapImageBuffer(void *data, int length)
 }
 
 
-inline void EndianSwapImageBuffer(DataSize size, void *data, int length)
+inline void EndianSwapImageBuffer(DataSize size, void *data, size_t length)
 {
 	switch (size)
 	{

--- a/src/dpx.imageio/libdpx/Writer.cpp
+++ b/src/dpx.imageio/libdpx/Writer.cpp
@@ -138,7 +138,7 @@ bool dpx::Writer::WriteHeader()
 
 void dpx::Writer::SetUserData(const long size)
 {
-	this->header.SetUserSize(size);
+	this->header.SetUserSize((U32)size);
 }
 
 
@@ -185,8 +185,8 @@ void dpx::Writer::SetElement(const int num, const Descriptor desc, const U8 bitD
 bool
 dpx::Writer::WritePadData(const int alignment)
 {
-    int imageoffset = ((this->fileLoc + alignment - 1)/alignment)*alignment;
-    int padsize = imageoffset - this->fileLoc;
+    long imageoffset = ((this->fileLoc + alignment - 1)/alignment)*alignment;
+    long padsize = imageoffset - this->fileLoc;
     if (padsize > 0) {
         std::vector<dpx::U8> pad (padsize, 0xff);
         this->fileLoc += this->fd->Write (&pad[0], padsize);
@@ -213,7 +213,7 @@ bool dpx::Writer::WriteElement(const int element, void *data, const long count)
 		return false;
 
 	// update file ptr
-	this->header.SetDataOffset(element, this->fileLoc);
+	this->header.SetDataOffset(element, (U32)this->fileLoc);
 	this->fileLoc += count;
 		
 	// write
@@ -253,8 +253,8 @@ bool dpx::Writer::WriteElement(const int element, void *data, const DataSize siz
 
 	// mark location in headers
 	if (element == 0)
-		this->header.SetImageOffset(this->fileLoc);
-	this->header.SetDataOffset(element, this->fileLoc);
+		this->header.SetImageOffset((U32)this->fileLoc);
+	this->header.SetDataOffset(element, (U32)this->fileLoc);
 	
 	// reverse the order of the components
 	bool reverse = false;
@@ -426,7 +426,7 @@ bool dpx::Writer::WriteThrough(void *data, const U32 width, const U32 height, co
 bool dpx::Writer::Finish()
 {
 	// write the file size in the header
-	this->header.SetFileSize(this->fileLoc);
+	this->header.SetFileSize((U32)this->fileLoc);
 	
 	// rewrite all of the offsets in the header
 	return this->header.WriteOffsetData(this->fd);

--- a/src/fits.imageio/fits_pvt.h
+++ b/src/fits.imageio/fits_pvt.h
@@ -28,7 +28,7 @@ namespace fits_pvt {
 // struct in which we store information about one subimage. This information
 // allow us to set up pointer at the beginning of given subimage
 struct Subimage {
-    int number;
+    size_t number;
     size_t offset;
 };
 

--- a/src/hdr.imageio/hdrinput.cpp
+++ b/src/hdr.imageio/hdrinput.cpp
@@ -48,7 +48,7 @@ public:
     bool read_native_scanline(int subimage, int miplevel, int y, int z,
                               void* data) override;
     bool close() override;
-    int current_subimage(void) const override { return m_subimage; }
+    int current_subimage(void) const override { return (int)m_subimage; }
     bool seek_subimage(int subimage, int miplevel) override;
 
 private:
@@ -488,7 +488,7 @@ HdrInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
     if (m_next_scanline != y) {
         // For random access, use cached file offsets of scanlines. This avoids
         // re-reading the same pixels many times over.
-        m_next_scanline = std::min((size_t)y, m_scanline_offsets.size() - 1);
+        m_next_scanline = std::min(y, (int)m_scanline_offsets.size() - 1);
         ioseek(m_scanline_offsets[m_next_scanline]);
     }
 

--- a/src/heif.imageio/heifoutput.cpp
+++ b/src/heif.imageio/heifoutput.cpp
@@ -204,7 +204,7 @@ HeifOutput::close()
         exifblob.insert(exifblob.begin(), head.begin(), head.end());
         try {
             m_ctx->add_exif_metadata(m_ihandle, exifblob.data(),
-                                     exifblob.size());
+                                     (int)exifblob.size());
         } catch (const heif::Error& err) {
 #ifdef DEBUG
             std::string e = err.get_message();

--- a/src/ico.imageio/icooutput.cpp
+++ b/src/ico.imageio/icooutput.cpp
@@ -225,7 +225,7 @@ ICOOutput::open(const std::string& name, const ImageSpec& userspec,
         // need to move stuff around to make room for another subimage header
         int subimage = ico.count++;
         fseek(m_file, 0, SEEK_END);
-        int len = ftell(m_file);
+        long len = ftell(m_file);
         unsigned char buf[512];
         // append null data at the end of file so that we don't seek beyond eof
         if (!fwrite(buf, sizeof(ico_subimage))) {
@@ -234,8 +234,8 @@ ICOOutput::open(const std::string& name, const ImageSpec& userspec,
 
         // do the actual moving, 0.5kB per iteration
         int skip = sizeof(ico_header) + sizeof(ico_subimage) * (subimage - 1);
-        for (int left = len - skip; left > 0; left -= sizeof(buf)) {
-            int amount = std::min(left, (int)sizeof(buf));
+        for (long left = len - skip; left > 0; left -= sizeof(buf)) {
+            long amount = std::min(left, (long)sizeof(buf));
             /*std::cerr << "[ico] moving " << amount << " bytes (" << left
                       << " vs " << sizeof (buf) << ")\n";*/
             fseek(m_file, skip + left - amount, SEEK_SET);
@@ -284,7 +284,7 @@ ICOOutput::open(const std::string& name, const ImageSpec& userspec,
         }
 
         // offset at which we'll be writing new image data
-        m_offset = len + sizeof(ico_subimage);
+        m_offset = (int)(len + sizeof(ico_subimage));
 
         // next part of code expects the file pointer to be where the new
         // subimage header is to be written

--- a/src/iff.imageio/iffinput.cpp
+++ b/src/iff.imageio/iffinput.cpp
@@ -562,7 +562,7 @@ IffInput::readimg()
                 // tile compress.
                 if (tile_compress) {
                     // map BGR(A) to RGB(A)
-                    for (size_t c = (channels * m_spec.channel_bytes()) - 1;
+                    for (int c = (int)(channels * m_spec.channel_bytes()) - 1;
                          c >= 0; --c) {
                         std::vector<uint8_t> in(tw * th);
                         uint8_t* in_p = &in[0];

--- a/src/iff.imageio/iffinput.cpp
+++ b/src/iff.imageio/iffinput.cpp
@@ -361,7 +361,7 @@ IffInput::read_header()
                                     // tbmp position for later user in in
                                     // read_native_tile
 
-                                    m_iff_header.tbmp_start = iotell();
+                                    m_iff_header.tbmp_start = (uint32_t)iotell();
 
                                     // read first RGBA block to detect tile size.
 
@@ -537,7 +537,7 @@ IffInput::readimg()
             uint8_t channels = m_iff_header.pixel_channels;
 
             // set tile size
-            uint32_t tile_size = tw * th * channels * m_spec.channel_bytes()
+            size_t tile_size = tw * th * channels * m_spec.channel_bytes()
                                  + 8;
 
             // test if compressed
@@ -562,7 +562,7 @@ IffInput::readimg()
                 // tile compress.
                 if (tile_compress) {
                     // map BGR(A) to RGB(A)
-                    for (int c = (channels * m_spec.channel_bytes()) - 1;
+                    for (size_t c = (channels * m_spec.channel_bytes()) - 1;
                          c >= 0; --c) {
                         std::vector<uint8_t> in(tw * th);
                         uint8_t* in_p = &in[0];
@@ -644,7 +644,7 @@ IffInput::readimg()
                     }
 
                     // map BGR(A)BGR(A) to RRGGBB(AA)
-                    for (int c = (channels * m_spec.channel_bytes()) - 1;
+                    for (size_t c = (channels * m_spec.channel_bytes()) - 1;
                          c >= 0; --c) {
                         int mc = map[c];
 
@@ -724,7 +724,7 @@ IffInput::readimg()
     // flip buffer to make read_native_tile easier,
     // from tga.imageio:
 
-    int bytespp = m_spec.pixel_bytes();
+    size_t bytespp = m_spec.pixel_bytes();
 
     std::vector<unsigned char> flip(m_spec.width * bytespp);
     unsigned char *src, *dst, *tmp = &flip[0];

--- a/src/iff.imageio/iffoutput.cpp
+++ b/src/iff.imageio/iffoutput.cpp
@@ -263,7 +263,7 @@ IffOutput::write_header(IffFileHeader& header)
     write_meta_string("DATE", header.date);
 
     // for4 position for later user in close
-    header.for4_start = iotell();
+    header.for4_start = (uint32_t)iotell();
 
     // write 'FOR4' type, with 0 length to reserve it for now
     if (!write_str("FOR4") || !write_int(0))
@@ -350,7 +350,7 @@ IffOutput::close(void)
         // flip buffer to make write tile easier,
         // from tga.imageio:
 
-        int bytespp = m_spec.pixel_bytes();
+        size_t bytespp = m_spec.pixel_bytes();
 
         std::vector<unsigned char> flip(m_spec.width * bytespp);
         unsigned char *src, *dst, *tmp = &flip[0];
@@ -388,7 +388,7 @@ IffOutput::close(void)
                     return false;
 
                 // length.
-                uint32_t length = tw * th * m_spec.pixel_bytes();
+                uint32_t length = tw * th * (uint32_t)m_spec.pixel_bytes();
 
                 // tile length.
                 uint32_t tile_length = length;
@@ -411,14 +411,15 @@ IffOutput::close(void)
                 // handle 8-bit data
                 if (m_spec.format == TypeDesc::UINT8) {
                     if (tile_compress) {
-                        uint32_t index = 0, size = 0;
+                        uint32_t index = 0;
+                        size_t size = 0;
                         std::vector<uint8_t> tmp;
 
                         // set bytes.
                         tmp.resize(tile_length * 2);
 
                         // map: RGB(A) to BGRA
-                        for (int c = (channels * m_spec.channel_bytes()) - 1;
+                        for (long c = (channels * m_spec.channel_bytes()) - 1;
                              c >= 0; --c) {
                             std::vector<uint8_t> in(tw * th);
                             uint8_t* in_p = &in[0];
@@ -497,7 +498,8 @@ IffOutput::close(void)
                 // handle 16-bit data
                 else if (m_spec.format == TypeDesc::UINT16) {
                     if (tile_compress) {
-                        uint32_t index = 0, size = 0;
+                        uint32_t index = 0;
+                        size_t size = 0;
                         std::vector<uint8_t> tmp;
 
                         // set bytes.
@@ -525,7 +527,7 @@ IffOutput::close(void)
                         }
 
                         // map: RRGGBB(AA) to BGR(A)BGR(A)
-                        for (int c = (channels * m_spec.channel_bytes()) - 1;
+                        for (long c = (channels * m_spec.channel_bytes()) - 1;
                              c >= 0; --c) {
                             int mc = map[c];
 
@@ -624,7 +626,7 @@ IffOutput::close(void)
         }
 
         // set sizes
-        uint32_t pos(iotell());
+        uint32_t pos((uint32_t)iotell());
 
         uint32_t p0 = pos - 8;
         uint32_t p1 = p0 - m_iff_header.for4_start;

--- a/src/igrep/igrep.cpp
+++ b/src/igrep/igrep.cpp
@@ -86,8 +86,8 @@ grep_file(const std::string& filename, std::regex& re,
         for (auto&& p : spec.extra_attribs) {
             TypeDesc t = p.type();
             if (t.elementtype() == TypeDesc::STRING) {
-                int n = t.numelements();
-                for (int i = 0; i < n; ++i) {
+                size_t n = t.numelements();
+                for (size_t i = 0; i < n; ++i) {
                     bool match = false;
                     try {
                         match = std::regex_search(((const char**)p.data())[i],

--- a/src/iinfo/iinfo.cpp
+++ b/src/iinfo/iinfo.cpp
@@ -362,7 +362,7 @@ print_info(const std::string& filename, size_t namefieldlength,
               spec.depth > 1 ? "volume " : "");
         if (spec.channelformats.size()) {
             for (size_t c = 0; c < spec.channelformats.size(); ++c)
-                print("{}{}", c ? "/" : "", spec.channelformat(c));
+                print("{}{}", c ? "/" : "", spec.channelformat((int)c));
         } else {
             int bits = spec.get_int_attribute("oiio:BitsPerSample", 0);
             print("{}", extended_format_name(spec.format, bits));
@@ -390,7 +390,7 @@ print_info(const std::string& filename, size_t namefieldlength,
         for (int i = 0; i < num_of_subimages; ++i) {
             input->seek_subimage(i, 0, spec);
             int bits = spec.get_int_attribute("oiio:BitsPerSample",
-                                              spec.format.size() * 8);
+                                              (int)spec.format.size() * 8);
             if (i)
                 print(", ");
             if (spec.depth > 1)

--- a/src/include/OpenImageIO/argparse.h
+++ b/src/include/OpenImageIO/argparse.h
@@ -669,7 +669,7 @@ public:
             ParamValueList& pl(arg.argparse().params());
             ParamValue* pv = pl.find_pv(arg.dest());
             // TypeDesc t = pv ? pv->type() : TypeUnknown;
-            int nold = pv ? pv->type().basevalues() : 0;
+            int nold = pv ? int(pv->type().basevalues()) : 0;
             int nnew = int(myarg.size());
             int n    = nold + nnew;
             T* vals  = OIIO_ALLOCA(T, n);

--- a/src/include/OpenImageIO/detail/farmhash.h
+++ b/src/include/OpenImageIO/detail/farmhash.h
@@ -629,7 +629,7 @@ STATIC_INLINE uint64_t HashLen0to16(const char *s, size_t len) {
     uint8_t b = s[len >> 1];
     uint8_t c = s[len - 1];
     uint32_t y = static_cast<uint32_t>(a) + (static_cast<uint32_t>(b) << 8);
-    uint32_t z = len + (static_cast<uint32_t>(c) << 2);
+    uint32_t z = static_cast<uint32_t>(len) + (static_cast<uint32_t>(c) << 2);
     return ShiftMix(y * inlined::k2 ^ z * inlined::k0) * inlined::k2;
   }
   return inlined::k2;
@@ -1169,7 +1169,7 @@ namespace farmhashnt {
 
 STATIC_INLINE uint32_t Hash32(const char *s, size_t len) {
   FARMHASH_DIE_IF_MISCONFIGURED;
-  return s == NULL ? 0 : len;
+  return s == NULL ? 0 : static_cast<uint32_t>(len);
 }
 
 STATIC_INLINE uint32_t Hash32WithSeed(const char *s, size_t len, uint32_t seed) {
@@ -1210,7 +1210,7 @@ STATIC_INLINE uint32_t Hash32Len13to24(const char *s, size_t len, uint32_t seed 
   uint32_t d = Fetch(s + (len >> 1));
   uint32_t e = Fetch(s);
   uint32_t f = Fetch(s + len - 4);
-  uint32_t h = d * inlined::c1 + len + seed;
+  uint32_t h = d * inlined::c1 + static_cast<uint32_t>(len) + seed;
   a = Rotate(a, 12) + f;
   h = inlined::Mur(c, h) + a;
   a = Rotate(a, 3) + c;
@@ -1228,10 +1228,10 @@ STATIC_INLINE uint32_t Hash32Len0to4(const char *s, size_t len, uint32_t seed = 
     b = b * inlined::c1 + v;
     c ^= b;
   }
-  return fmix(inlined::Mur(b, inlined::Mur(len, c)));
+  return fmix(inlined::Mur(b, inlined::Mur(static_cast<uint32_t>(len), c)));
 }
 
-STATIC_INLINE uint32_t Hash32Len5to12(const char *s, size_t len, uint32_t seed = 0) {
+STATIC_INLINE uint32_t Hash32Len5to12(const char *s, uint32_t len, uint32_t seed = 0) {
   uint32_t a = len, b = len * 5, c = 9, d = b + seed;
   a += Fetch(s);
   b += Fetch(s + len - 4);
@@ -1239,7 +1239,7 @@ STATIC_INLINE uint32_t Hash32Len5to12(const char *s, size_t len, uint32_t seed =
   return fmix(seed ^ inlined::Mur(c, inlined::Mur(b, inlined::Mur(a, d))));
 }
 
-STATIC_INLINE uint32_t Hash32(const char *s, size_t len) {
+STATIC_INLINE uint32_t Hash32(const char *s, uint32_t len) {
   if (len <= 24) {
     return len <= 12 ?
         (len <= 4 ? Hash32Len0to4(s, len) : Hash32Len5to12(s, len)) :
@@ -1297,7 +1297,7 @@ STATIC_INLINE uint32_t Hash32(const char *s, size_t len) {
   return h;
 }
 
-STATIC_INLINE uint32_t Hash32WithSeed(const char *s, size_t len, uint32_t seed) {
+STATIC_INLINE uint32_t Hash32WithSeed(const char *s, uint32_t len, uint32_t seed) {
   if (len <= 24) {
     if (len >= 13) return Hash32Len13to24(s, len, seed * inlined::c1);
     else if (len >= 5) return Hash32Len5to12(s, len, seed);
@@ -1310,12 +1310,12 @@ STATIC_INLINE uint32_t Hash32WithSeed(const char *s, size_t len, uint32_t seed) 
 namespace farmhashsu {
 #if !can_use_sse42 || !can_use_aesni
 
-STATIC_INLINE uint32_t Hash32(const char *s, size_t len) {
+STATIC_INLINE uint32_t Hash32(const char *s, uint32_t len) {
   FARMHASH_DIE_IF_MISCONFIGURED;
   return s == NULL ? 0 : len;
 }
 
-STATIC_INLINE uint32_t Hash32WithSeed(const char *s, size_t len, uint32_t seed) {
+STATIC_INLINE uint32_t Hash32WithSeed(const char *s, uint32_t len, uint32_t seed) {
   FARMHASH_DIE_IF_MISCONFIGURED;
   return seed + Hash32(s, len);
 }
@@ -1530,12 +1530,12 @@ STATIC_INLINE uint32_t Hash32WithSeed(const char *s, size_t len, uint32_t seed) 
 namespace farmhashsa {
 #if !can_use_sse42
 
-STATIC_INLINE uint32_t Hash32(const char *s, size_t len) {
+STATIC_INLINE uint32_t Hash32(const char *s, uint32_t len) {
   FARMHASH_DIE_IF_MISCONFIGURED;
   return s == NULL ? 0 : len;
 }
 
-STATIC_INLINE uint32_t Hash32WithSeed(const char *s, size_t len, uint32_t seed) {
+STATIC_INLINE uint32_t Hash32WithSeed(const char *s, uint32_t len, uint32_t seed) {
   FARMHASH_DIE_IF_MISCONFIGURED;
   return seed + Hash32(s, len);
 }
@@ -1754,7 +1754,7 @@ namespace farmhashcc {
 #undef fmix
 #define fmix farmhash::inlined::fmix
 
-STATIC_INLINE uint32_t Hash32Len13to24(const char *s, size_t len) {
+STATIC_INLINE uint32_t Hash32Len13to24(const char *s, uint32_t len) {
   uint32_t a = Fetch(s - 4 + (len >> 1));
   uint32_t b = Fetch(s + 4);
   uint32_t c = Fetch(s + len - 8);
@@ -1766,7 +1766,7 @@ STATIC_INLINE uint32_t Hash32Len13to24(const char *s, size_t len) {
   return fmix(inlined::Mur(f, inlined::Mur(e, inlined::Mur(d, inlined::Mur(c, inlined::Mur(b, inlined::Mur(a, h)))))));
 }
 
-STATIC_INLINE uint32_t Hash32Len0to4(const char *s, size_t len) {
+STATIC_INLINE uint32_t Hash32Len0to4(const char *s, uint32_t len) {
   uint32_t b = 0;
   uint32_t c = 9;
   for (size_t i = 0; i < len; i++) {
@@ -1777,7 +1777,7 @@ STATIC_INLINE uint32_t Hash32Len0to4(const char *s, size_t len) {
   return fmix(inlined::Mur(b, inlined::Mur(len, c)));
 }
 
-STATIC_INLINE uint32_t Hash32Len5to12(const char *s, size_t len) {
+STATIC_INLINE uint32_t Hash32Len5to12(const char *s, uint32_t len) {
   uint32_t a = len, b = len * 5, c = 9, d = b;
   a += Fetch(s);
   b += Fetch(s + len - 4);
@@ -1785,7 +1785,7 @@ STATIC_INLINE uint32_t Hash32Len5to12(const char *s, size_t len) {
   return fmix(inlined::Mur(c, inlined::Mur(b, inlined::Mur(a, d))));
 }
 
-STATIC_INLINE uint32_t Hash32(const char *s, size_t len) {
+STATIC_INLINE uint32_t Hash32(const char *s, uint32_t len) {
   if (len <= 24) {
     return len <= 12 ?
         (len <= 4 ? Hash32Len0to4(s, len) : Hash32Len5to12(s, len)) :
@@ -1854,7 +1854,7 @@ STATIC_INLINE uint32_t Hash32(const char *s, size_t len) {
   return h;
 }
 
-STATIC_INLINE uint32_t Hash32WithSeed(const char *s, size_t len, uint32_t seed) {
+STATIC_INLINE uint32_t Hash32WithSeed(const char *s, uint32_t len, uint32_t seed) {
   if (len <= 24) {
     if (len >= 13) return farmhashmk::Hash32Len13to24(s, len, seed * inlined::c1);
     else if (len >= 5) return farmhashmk::Hash32Len5to12(s, len, seed);
@@ -1913,7 +1913,7 @@ STATIC_INLINE uint64_t HashLen0to16(const char *s, size_t len) {
     uint8_t b = s[len >> 1];
     uint8_t c = s[len - 1];
     uint32_t y = static_cast<uint32_t>(a) + (static_cast<uint32_t>(b) << 8);
-    uint32_t z = len + (static_cast<uint32_t>(c) << 2);
+    uint32_t z = static_cast<uint32_t>(len) + (static_cast<uint32_t>(c) << 2);
     return ShiftMix(y * inlined::k2 ^ z * inlined::k0) * inlined::k2;
   }
   return inlined::k2;
@@ -2062,7 +2062,7 @@ namespace inlined {
 // Hash function for a byte array.  See also Hash(), below.
 // May change from time to time, may differ on different platforms, may differ
 // depending on NDEBUG.
-STATIC_INLINE uint32_t Hash32(const char* s, size_t len) {
+STATIC_INLINE uint32_t Hash32(const char* s, uint32_t len) {
   return DebugTweak(
       (can_use_sse41 & x86_64) ? farmhashnt::Hash32(s, len) :
       (can_use_sse42 & can_use_aesni) ? farmhashsu::Hash32(s, len) :
@@ -2074,7 +2074,7 @@ STATIC_INLINE uint32_t Hash32(const char* s, size_t len) {
 // hashed into the result.
 // May change from time to time, may differ on different platforms, may differ
 // depending on NDEBUG.
-STATIC_INLINE uint32_t Hash32WithSeed(const char* s, size_t len, uint32_t seed) {
+STATIC_INLINE uint32_t Hash32WithSeed(const char* s, uint32_t len, uint32_t seed) {
   return DebugTweak(
       (can_use_sse41 & x86_64) ? farmhashnt::Hash32WithSeed(s, len, seed) :
       (can_use_sse42 & can_use_aesni) ? farmhashsu::Hash32WithSeed(s, len, seed) :
@@ -2136,7 +2136,7 @@ STATIC_INLINE uint128_t Hash128WithSeed(const char* s, size_t len, uint128_t see
 // FINGERPRINTING (i.e., good, portable, forever-fixed hash functions)
 
 // Fingerprint function for a byte array.  Most useful in 32-bit binaries.
-STATIC_INLINE uint32_t Fingerprint32(const char* s, size_t len) {
+STATIC_INLINE uint32_t Fingerprint32(const char* s, uint32_t len) {
   return farmhashmk::Hash32(s, len);
 }
 

--- a/src/include/OpenImageIO/detail/fmt.h
+++ b/src/include/OpenImageIO/detail/fmt.h
@@ -113,7 +113,7 @@ struct index_formatter : format_parser_with_separator {
     {
         std::string vspec = elem_fmt.size() ? fmt::format("{{:{}}}", elem_fmt)
                                             : std::string("{}");
-        for (size_t i = 0; i < size_t(v.size()); ++i) {
+        for (int i = 0; i < (int)v.size(); ++i) {
             if (i)
                 fmt::format_to(ctx.out(), "{}", sep == ',' ? ", " : " ");
 #if FMT_VERSION >= 80000

--- a/src/include/OpenImageIO/fmath.h
+++ b/src/include/OpenImageIO/fmath.h
@@ -838,7 +838,7 @@ OIIO_FORCEINLINE OIIO_HOSTDEVICE float bitcast_to_float (int x) {
 /// unsigned int, float, long long, pointers.
 template<class T>
 inline OIIO_HOSTDEVICE void
-swap_endian (T *f, int len=1)
+swap_endian (T *f, size_t len=1)
 {
     for (char *c = (char *) f;  len--;  c += sizeof(T)) {
         if (sizeof(T) == 2) {
@@ -859,74 +859,74 @@ swap_endian (T *f, int len=1)
 #if (OIIO_GNUC_VERSION || OIIO_ANY_CLANG || OIIO_INTEL_CLASSIC_COMPILER_VERSION) && !defined(__CUDACC__)
 // CPU gcc and compatible can use these intrinsics, 8-15x faster
 
-template<> inline void swap_endian(uint16_t* f, int len) {
-    for (int i = 0; i < len; ++i)
+template<> inline void swap_endian(uint16_t* f, size_t len) {
+    for (size_t i = 0; i < len; ++i)
         f[i] = __builtin_bswap16(f[i]);
 }
 
-template<> inline void swap_endian(uint32_t* f, int len) {
-    for (int i = 0; i < len; ++i)
+template<> inline void swap_endian(uint32_t* f, size_t len) {
+    for (size_t i = 0; i < len; ++i)
         f[i] = __builtin_bswap32(f[i]);
 }
 
-template<> inline void swap_endian(uint64_t* f, int len) {
-    for (int i = 0; i < len; ++i)
+template<> inline void swap_endian(uint64_t* f, size_t len) {
+    for (size_t i = 0; i < len; ++i)
         f[i] = __builtin_bswap64(f[i]);
 }
 
-template<> inline void swap_endian(int16_t* f, int len) {
-    for (int i = 0; i < len; ++i)
+template<> inline void swap_endian(int16_t* f, size_t len) {
+    for (size_t i = 0; i < len; ++i)
         f[i] = __builtin_bswap16(f[i]);
 }
 
-template<> inline void swap_endian(int32_t* f, int len) {
-    for (int i = 0; i < len; ++i)
+template<> inline void swap_endian(int32_t* f, size_t len) {
+    for (size_t i = 0; i < len; ++i)
         f[i] = __builtin_bswap32(f[i]);
 }
 
-template<> inline void swap_endian(int64_t* f, int len) {
-    for (int i = 0; i < len; ++i)
+template<> inline void swap_endian(int64_t* f, size_t len) {
+    for (size_t i = 0; i < len; ++i)
         f[i] = __builtin_bswap64(f[i]);
 }
 
-template<> inline void swap_endian(float* f, int len) {
+template<> inline void swap_endian(float* f, size_t len) {
     swap_endian((uint32_t*)f, len);
 }
 
-template<> inline void swap_endian(double* f, int len) {
+template<> inline void swap_endian(double* f, size_t len) {
     swap_endian((uint64_t*)f, len);
 }
 
 #elif defined(_MSC_VER) && !defined(__CUDACC__)
 // CPU MSVS can use these intrinsics
 
-template<> inline void swap_endian(uint16_t* f, int len) {
-    for (int i = 0; i < len; ++i)
+template<> inline void swap_endian(uint16_t* f, size_t len) {
+    for (size_t i = 0; i < len; ++i)
         f[i] = _byteswap_ushort(f[i]);
 }
 
-template<> inline void swap_endian(uint32_t* f, int len) {
-    for (int i = 0; i < len; ++i)
+template<> inline void swap_endian(uint32_t* f, size_t len) {
+    for (size_t i = 0; i < len; ++i)
         f[i] = _byteswap_ulong(f[i]);
 }
 
-template<> inline void swap_endian(uint64_t* f, int len) {
-    for (int i = 0; i < len; ++i)
+template<> inline void swap_endian(uint64_t* f, size_t len) {
+    for (size_t i = 0; i < len; ++i)
         f[i] = _byteswap_uint64(f[i]);
 }
 
-template<> inline void swap_endian(int16_t* f, int len) {
-    for (int i = 0; i < len; ++i)
+template<> inline void swap_endian(int16_t* f, size_t len) {
+    for (size_t i = 0; i < len; ++i)
         f[i] = _byteswap_ushort(f[i]);
 }
 
-template<> inline void swap_endian(int32_t* f, int len) {
-    for (int i = 0; i < len; ++i)
+template<> inline void swap_endian(int32_t* f, size_t len) {
+    for (size_t i = 0; i < len; ++i)
         f[i] = _byteswap_ulong(f[i]);
 }
 
-template<> inline void swap_endian(int64_t* f, int len) {
-    for (int i = 0; i < len; ++i)
+template<> inline void swap_endian(int64_t* f, size_t len) {
+    for (size_t i = 0; i < len; ++i)
         f[i] = _byteswap_uint64(f[i]);
 }
 #endif

--- a/src/include/OpenImageIO/imagebufalgo_util.h
+++ b/src/include/OpenImageIO/imagebufalgo_util.h
@@ -74,7 +74,7 @@ parallel_image(ROI roi, paropt opt, std::function<void(ROI)> f)
 
     auto task = [&](int64_t xbegin, int64_t xend, int64_t ybegin,
                     int64_t yend) {
-        f(ROI(xbegin, xend, ybegin, yend, roi.zbegin, roi.zend, roi.chbegin,
+        f(ROI((int)xbegin, (int)xend, (int)ybegin, (int)yend, roi.zbegin, roi.zend, roi.chbegin,
               roi.chend));
     };
     parallel_for_chunked_2D(roi.xbegin, roi.xend, xchunk, roi.ybegin, roi.yend,

--- a/src/include/OpenImageIO/parallel.h
+++ b/src/include/OpenImageIO/parallel.h
@@ -144,8 +144,8 @@ public:
         return *this;
     }
 
-    constexpr int minitems() const noexcept { return m_minitems; }
-    paropt& minitems(int m) noexcept
+    constexpr size_t minitems() const noexcept { return m_minitems; }
+    paropt& minitems(size_t m) noexcept
     {
         m_minitems = m;
         return *this;

--- a/src/include/OpenImageIO/paramlist.h
+++ b/src/include/OpenImageIO/paramlist.h
@@ -465,11 +465,11 @@ public:
 
     /// Array indexing by integer will return a reference to the ParamValue
     /// in that position of the list.
-    ParamValue& operator[](int index)
+    ParamValue& operator[](size_t index)
     {
         return std::vector<ParamValue>::operator[](index);
     }
-    const ParamValue& operator[](int index) const
+    const ParamValue& operator[](size_t index) const
     {
         return std::vector<ParamValue>::operator[](index);
     }

--- a/src/iv/imageviewer.cpp
+++ b/src/iv/imageviewer.cpp
@@ -674,7 +674,7 @@ ImageViewer::open()
     openPath          = dialog.directory().path();
     QStringList names = dialog.selectedFiles();
 
-    int old_lastimage = m_images.size() - 1;
+    int old_lastimage = (int)m_images.size() - 1;
     for (auto& name : names) {
         std::string filename = name.toUtf8().data();
         if (filename.empty())
@@ -703,7 +703,7 @@ ImageViewer::openRecentFile()
         // (and reload) rather than loading a second copy.
         for (size_t i = 0; i < m_images.size(); ++i) {
             if (m_images[i]->name() == filename) {
-                current_image(i);
+                current_image((int)i);
                 reload();
                 return;
             }
@@ -712,7 +712,7 @@ ImageViewer::openRecentFile()
         add_image(filename);
         if (m_images.size() > 1) {
             // Otherwise, add_image already did this for us.
-            current_image(m_images.size() - 1);
+            current_image((int)m_images.size() - 1);
             fitWindowToImage(true, true);
         }
     }
@@ -1370,7 +1370,7 @@ ImageViewer::slideShow()
 {
     fullScreenToggle();
     connect(slideTimer, SIGNAL(timeout()), this, SLOT(slideImages()));
-    slideTimer->start(slideDuration_ms);
+    slideTimer->start((int)slideDuration_ms);
     updateActions();
 }
 
@@ -1413,7 +1413,7 @@ compName(IvImage* first, IvImage* second)
 void
 ImageViewer::sortByName()
 {
-    int numImg = m_images.size();
+    size_t numImg = m_images.size();
     if (numImg < 2)
         return;
     std::sort(m_images.begin(), m_images.end(), &compName);
@@ -1437,7 +1437,7 @@ compPath(IvImage* first, IvImage* second)
 void
 ImageViewer::sortByPath()
 {
-    int numImg = m_images.size();
+    size_t numImg = m_images.size();
     if (numImg < 2)
         return;
     std::sort(m_images.begin(), m_images.end(), &compPath);
@@ -1513,7 +1513,7 @@ compImageDate(IvImage* first, IvImage* second)
 void
 ImageViewer::sortByImageDate()
 {
-    int numImg = m_images.size();
+    size_t numImg = m_images.size();
     if (numImg < 2)
         return;
     std::sort(m_images.begin(), m_images.end(), &compImageDate);
@@ -1546,7 +1546,7 @@ compFileDate(IvImage* first, IvImage* second)
 void
 ImageViewer::sortByFileDate()
 {
-    int numImg = m_images.size();
+    size_t numImg = m_images.size();
     if (numImg < 2)
         return;
     std::sort(m_images.begin(), m_images.end(), &compFileDate);
@@ -1560,7 +1560,7 @@ ImageViewer::sortByFileDate()
 void
 ImageViewer::sortReverse()
 {
-    int numImg = m_images.size();
+    size_t numImg = m_images.size();
     if (numImg < 2)
         return;
     std::reverse(m_images.begin(), m_images.end());

--- a/src/jpeg.imageio/jpegoutput.cpp
+++ b/src/jpeg.imageio/jpegoutput.cpp
@@ -226,7 +226,7 @@ JpgOutput::open(const std::string& name, const ImageSpec& newspec,
     std::string comment = m_spec.get_string_attribute("ImageDescription");
     if (comment.size()) {
         jpeg_write_marker(&m_cinfo, JPEG_COM, (JOCTET*)comment.c_str(),
-                          comment.size() + 1);
+                          (unsigned int)comment.size() + 1);
     }
 
     if (Strutil::iequals(m_spec.get_string_attribute("oiio:ColorSpace"), "sRGB"))
@@ -244,7 +244,7 @@ JpgOutput::open(const std::string& name, const ImageSpec& newspec,
     exif.push_back(0);
     encode_exif(m_spec, exif);
     jpeg_write_marker(&m_cinfo, JPEG_APP0 + 1, (JOCTET*)exif.data(),
-                      exif.size());
+                      (unsigned int)exif.size());
 
     // Write IPTC IIM metadata tags, if we have anything
     std::vector<char> iptc;
@@ -264,7 +264,7 @@ JpgOutput::open(const std::string& name, const ImageSpec& newspec,
         head.push_back((char)(iptc.size() & 0xff));
         iptc.insert(iptc.begin(), head.begin(), head.end());
         jpeg_write_marker(&m_cinfo, JPEG_APP0 + 13, (JOCTET*)iptc.data(),
-                          iptc.size());
+                          (unsigned int)iptc.size());
     }
 
     // Write XMP packet, if we have anything
@@ -274,7 +274,7 @@ JpgOutput::open(const std::string& name, const ImageSpec& newspec,
         std::vector<char> block(prefix, prefix + strlen(prefix) + 1);
         block.insert(block.end(), xmp.c_str(), xmp.c_str() + xmp.length());
         jpeg_write_marker(&m_cinfo, JPEG_APP0 + 1, (JOCTET*)&block[0],
-                          block.size());
+                          (unsigned int)block.size());
     }
 
     m_spec.set_format(TypeDesc::UINT8);  // JPG is only 8 bit
@@ -285,7 +285,7 @@ JpgOutput::open(const std::string& name, const ImageSpec& newspec,
     if (icc_profile_parameter != NULL) {
         unsigned char* icc_profile
             = (unsigned char*)icc_profile_parameter->data();
-        unsigned int icc_profile_length = icc_profile_parameter->type().size();
+        unsigned int icc_profile_length = (unsigned int)icc_profile_parameter->type().size();
         if (icc_profile && icc_profile_length) {
             /* Calculate the number of markers we'll need, rounding up of course */
             int num_markers = icc_profile_length / MAX_DATA_BYTES_IN_MARKER;

--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -464,7 +464,7 @@ ColorConfig::Impl::test_conversion_yields(const char* from, const char* to,
     if (!proc)
         return false;
     OIIO_DASSERT(test_colors.size() == result_colors.size());
-    int n              = std::ssize(test_colors);
+    int n              = (int)std::ssize(test_colors);
     Imath::C3f* colors = OIIO_ALLOCA(Imath::C3f, n);
     std::copy(test_colors.data(), test_colors.data() + n, colors);
     proc->apply((float*)colors, n, 1, 3, sizeof(float), 3 * sizeof(float),
@@ -845,7 +845,7 @@ ColorConfig::getAliases(string_view color_space) const
     if (config) {
         auto cs = config->getColorSpace(c_str(color_space));
         if (cs) {
-            for (int i = 0, e = cs->getNumAliases(); i < e; ++i)
+            for (size_t i = 0, e = cs->getNumAliases(); i < e; ++i)
                 result.emplace_back(cs->getAlias(i));
         }
     }

--- a/src/libOpenImageIO/deepdata.cpp
+++ b/src/libOpenImageIO/deepdata.cpp
@@ -91,7 +91,7 @@ public:
             spin_lock lock(m_mutex);
             if (!m_allocated) {
                 // m_cumcapacity.resize (npixels);
-                size_t totalcapacity = 0;
+                int totalcapacity = 0;
                 for (size_t i = 0; i < npixels; ++i) {
                     m_cumcapacity[i] = totalcapacity;
                     totalcapacity += m_capacity[i];
@@ -1030,7 +1030,7 @@ namespace {
 // Comparator functor for depth sorting sample indices of a deep pixel.
 class SampleComparator {
 public:
-    SampleComparator(const DeepData& dd, int pixel, int zchan, int zbackchan)
+    SampleComparator(const DeepData& dd, int64_t pixel, int zchan, int zbackchan)
         : deepdata(dd)
         , pixel(pixel)
         , zchan(zchan)
@@ -1054,7 +1054,7 @@ public:
 
 private:
     const DeepData& deepdata;
-    int pixel;
+    int64_t pixel;
     int zchan, zbackchan;
 };
 

--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -234,7 +234,7 @@ ImageSpec::pixel_bytes(bool native) const noexcept
     if (nchannels < 0)
         return 0;
     if (!native || channelformats.empty())
-        return clamped_mult32((size_t)nchannels, channel_bytes());
+        return clamped_mult32((uint32_t)nchannels, (uint32_t)channel_bytes());
     else {
         size_t sum = 0;
         for (int i = 0; i < nchannels; ++i)
@@ -252,7 +252,7 @@ ImageSpec::pixel_bytes(int chbegin, int chend, bool native) const noexcept
         return 0;
     chend = std::max(chend, chbegin);
     if (!native || channelformats.empty())
-        return clamped_mult32((size_t)(chend - chbegin), channel_bytes());
+        return clamped_mult32((uint32_t)(chend - chbegin), (uint32_t)channel_bytes());
     else {
         size_t sum = 0;
         for (int i = chbegin; i < chend; ++i)

--- a/src/libOpenImageIO/imagebufalgo_compare.cpp
+++ b/src/libOpenImageIO/imagebufalgo_compare.cpp
@@ -138,7 +138,7 @@ computePixelStats_(const ImageBuf& src, ImageBufAlgo::PixelStats& stats,
     if (src.deep()) {
         parallel_for_chunked(roi.ybegin, roi.yend, 64,
                              [&](int64_t ybegin, int64_t yend) {
-            ROI subroi(roi.xbegin, roi.xend, ybegin, yend, roi.zbegin,
+            ROI subroi(roi.xbegin, roi.xend, (int)ybegin, (int)yend, roi.zbegin,
                        roi.zend, roi.chbegin, roi.chend);
             ImageBufAlgo::PixelStats tmp(nchannels);
             for (ImageBuf::ConstIterator<T> s(src, subroi); !s.done();
@@ -160,7 +160,7 @@ computePixelStats_(const ImageBuf& src, ImageBufAlgo::PixelStats& stats,
     } else {  // Non-deep case
         parallel_for_chunked(roi.ybegin, roi.yend, 64,
                              [&](int64_t ybegin, int64_t yend) {
-            ROI subroi(roi.xbegin, roi.xend, ybegin, yend, roi.zbegin,
+            ROI subroi(roi.xbegin, roi.xend, (int)ybegin, (int)yend, roi.zbegin,
                        roi.zend, roi.chbegin, roi.chend);
             ImageBufAlgo::PixelStats tmp(nchannels);
             for (ImageBuf::ConstIterator<T> s(src, subroi); !s.done();
@@ -895,8 +895,8 @@ ImageBufAlgo::computePixelHashSHA1(const ImageBuf& src, string_view extrainfo,
                          [&](int64_t ybegin, int64_t yend) {
         int64_t b   = (ybegin - src.ybegin()) / blocksize;  // block number
         ROI broi    = roi;
-        broi.ybegin = ybegin;
-        broi.yend   = yend;
+        broi.ybegin = (int)ybegin;
+        broi.yend   = (int)yend;
         results[b]  = simplePixelHashSHA1(src, "", broi);
     }, nthreads);
     // clang-format on
@@ -1106,7 +1106,7 @@ ImageBufAlgo::histogram_draw(ImageBuf& R,
 {
     pvt::LoggedTimer logtimer("IBA::histogram_draw");
     // Fail if there are no bins to draw.
-    int bins = histogram.size();
+    int bins = (int)histogram.size();
     if (bins == 0) {
         R.errorfmt("There are no bins to draw, the histogram is empty");
         return false;

--- a/src/libOpenImageIO/imagebufalgo_test.cpp
+++ b/src/libOpenImageIO/imagebufalgo_test.cpp
@@ -112,7 +112,7 @@ static ImageBuf
 filled_image(cspan<float> value, int width = 4, int height = 4,
              TypeDesc dtype = TypeDesc::FLOAT)
 {
-    ImageSpec spec(width, height, std::ssize(value), dtype);
+    ImageSpec spec(width, height, (int)std::ssize(value), dtype);
     return filled_image(value, spec);
 }
 

--- a/src/libOpenImageIO/imagebufalgo_yee.cpp
+++ b/src/libOpenImageIO/imagebufalgo_yee.cpp
@@ -333,7 +333,7 @@ ImageBufAlgo::compare_Yee(const ImageBuf& img0, const ImageBuf& img1,
         }
     }
 
-    return result.nfail;
+    return (int)result.nfail;
 }
 
 

--- a/src/libOpenImageIO/imageinput.cpp
+++ b/src/libOpenImageIO/imageinput.cpp
@@ -529,8 +529,8 @@ ImageInput::read_tile(int x, int y, int z, TypeDesc format, void* data,
         return false;
     if (m_spec.channelformats.empty()) {
         // No per-channel formats -- do the conversion in one shot
-        ok = contiguous ? convert_types(m_spec.format, &buf[0], format, data,
-                                        tile_values)
+        ok = contiguous ? convert_pixel_values(m_spec.format, &buf[0], format, data,
+                                        (int)tile_values)
                         : convert_image(m_spec.nchannels, m_spec.tile_width,
                                         m_spec.tile_height, m_spec.tile_depth,
                                         &buf[0], m_spec.format, AutoStride,

--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -498,11 +498,11 @@ getattribute(string_view name, TypeDesc type, void* val)
     if (name == "missingcolor" && type.basetype == TypeDesc::FLOAT
         && oiio_missingcolor.size()) {
         // missingcolor as float array
-        int n  = type.basevalues();
-        int nm = std::min(int(oiio_missingcolor.size()), n);
-        for (int i = 0; i < nm; ++i)
+        size_t n  = type.basevalues();
+        size_t nm = std::min(oiio_missingcolor.size(), n);
+        for (size_t i = 0; i < nm; ++i)
             ((float*)val)[i] = oiio_missingcolor[i];
-        for (int i = nm; i < n; ++i)
+        for (size_t i = nm; i < n; ++i)
             ((float*)val)[i] = 0.0f;
         return true;
     }
@@ -824,7 +824,7 @@ parallel_convert_image(int nchannels, int width, int height, int depth,
 
     int blocksize = std::max(1, height / nthreads);
     parallel_for_chunked(0, height, blocksize, [=](int64_t ybegin, int64_t yend) {
-        convert_image(nchannels, width, yend - ybegin, depth,
+        convert_image(nchannels, width, (int)(yend - ybegin), depth,
                       (const char*)src + src_ystride * ybegin, src_type,
                       src_xstride, src_ystride, src_zstride,
                       (char*)dst + dst_ystride * ybegin, dst_type, dst_xstride,

--- a/src/libOpenImageIO/kissfft.hh
+++ b/src/libOpenImageIO/kissfft.hh
@@ -139,7 +139,7 @@ class kissfft
         void kf_bfly2( cpx_type * Fout, const size_t fstride, int m)
         {
             for (int k=0;k<m;++k) {
-                cpx_type t = Fout[m+k] * _traits.twiddle(k*fstride);
+                cpx_type t = Fout[m+k] * _traits.twiddle(k * (int)fstride);
                 Fout[m+k] = Fout[k] - t;
                 Fout[k] += t;
             }
@@ -149,10 +149,10 @@ class kissfft
         {
             cpx_type scratch[7];
             int negative_if_inverse = _inverse * -2 +1;
-            for (size_t k=0;k<m;++k) {
-                scratch[0] = Fout[k+m] * _traits.twiddle(k*fstride);
-                scratch[1] = Fout[k+2*m] * _traits.twiddle(k*fstride*2);
-                scratch[2] = Fout[k+3*m] * _traits.twiddle(k*fstride*3);
+            for (size_t k=0; k < m; ++k) {
+                scratch[0] = Fout[k+m] * _traits.twiddle((int)(k*fstride));
+                scratch[1] = Fout[k+2*m] * _traits.twiddle((int)(k*fstride*2));
+                scratch[2] = Fout[k+3*m] * _traits.twiddle((int)(k*fstride*3));
                 scratch[5] = Fout[k] - scratch[1];
 
                 Fout[k] += scratch[1];

--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -1232,7 +1232,7 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
         std::vector<imagesize_t> hist;
 
         for (int i = 0; i < channels; i++) {
-            hist = ImageBufAlgo::histogram(*src, i, bins, 0.0f, 1.0f);
+            hist = ImageBufAlgo::histogram(*src, i, (int)bins, 0.0f, 1.0f);
 
             // Turn the histogram into a non-normalized CDF
             for (uint64_t j = 1; j < bins; j++) {
@@ -1255,7 +1255,7 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
                 invCDF[j] = std::min(1.0f, std::max(0.0f, g));
             }
             configspec.attribute("invCDF_" + std::to_string(i),
-                                 TypeDesc(TypeDesc::FLOAT, bins),
+                                 TypeDesc(TypeDesc::FLOAT, int(bins)),
                                  invCDF.data());
 
             // Store the forward CDF as a lookup table to transform back to
@@ -1268,7 +1268,7 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
             }
 
             configspec.attribute("CDF_" + std::to_string(i),
-                                 TypeDesc(TypeDesc::FLOAT, bins), CDF.data());
+                                 TypeDesc(TypeDesc::FLOAT, int(bins)), CDF.data());
         }
 
         configspec["CDF_bits"] = cdf_bits;

--- a/src/libOpenImageIO/xmp.cpp
+++ b/src/libOpenImageIO/xmp.cpp
@@ -376,7 +376,7 @@ add_attrib(ImageSpec& spec, string_view xmlname, string_view xmlvalue,
             vals.push_back(Strutil::stoi(xmlvalue));
         TypeDesc t = oiiotype;
         if (vals.size() > 1)
-            t.arraylen = vals.size();
+            t.arraylen = int(vals.size());
         spec.attribute(oiioname, t, vals.data());
         return vals.size() * sizeof(int);
     } else if (oiiotype == TypeDesc::UINT) {
@@ -390,7 +390,7 @@ add_attrib(ImageSpec& spec, string_view xmlname, string_view xmlvalue,
         vals.push_back(Strutil::stof(xmlvalue));
         TypeDesc t = oiiotype;
         if (vals.size() > 1)
-            t.arraylen = vals.size();
+            t.arraylen = int(vals.size());
         spec.attribute(oiioname, t, vals.data());
         return vals.size() * sizeof(float);
     }

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -395,7 +395,7 @@ ImageCacheFile::SubimageInfo::init(ImageCacheFile& icfile,
             /* future expansion:  || spec.format == AnotherFormat ... */)
             datatype = spec.format;
     }
-    channelsize = datatype.size();
+    channelsize = (unsigned int)datatype.size();
     pixelsize   = channelsize * spec.nchannels;
 
     // See if there's a constant color tag
@@ -1508,7 +1508,7 @@ ImageCacheTile::ImageCacheTile(const TileID& id, const void* pels,
 {
     ImageCacheFile& file(m_id.file());
     const ImageSpec& spec(file.spec(id.subimage(), id.miplevel()));
-    m_channelsize = file.datatype(id.subimage()).size();
+    m_channelsize = (int)file.datatype(id.subimage()).size();
     m_pixelsize   = id.nchannels() * m_channelsize;
     m_tile_width  = spec.tile_width;
     if (copy) {
@@ -1564,7 +1564,7 @@ bool
 ImageCacheTile::read(ImageCachePerThreadInfo* thread_info)
 {
     ImageCacheFile& file(m_id.file());
-    m_channelsize = file.datatype(id().subimage()).size();
+    m_channelsize = (int)file.datatype(id().subimage()).size();
     m_pixelsize   = m_id.nchannels() * m_channelsize;
     size_t size   = memsize_needed();
     OIIO_ASSERT(memsize() == 0 && size > OIIO_SIMD_MAX_SIZE_BYTES);
@@ -1991,7 +1991,7 @@ ImageCacheImpl::getstats(int level) const
                 print(out, "  {:76}{}\n", "BROKEN", file->filename());
                 continue;
             }
-            print(out, "{}\n", onefile_stat_line(file, i + 1));
+            print(out, "{}\n", onefile_stat_line(file, (int)i + 1));
         }
         print(out, "\n  Tot:  {:4}  {:7}   {:8.1f}   ({:5} {:6.1f}) {:9}\n",
               total_opens, total_tiles, total_bytes / 1024.0 / 1024.0,
@@ -2425,7 +2425,7 @@ ImageCacheImpl::getattribute(string_view name, TypeDesc type, void* val) const
     if (name == "all_filenames" && type.basetype == TypeDesc::STRING
         && type.is_sized_array()) {
         ustring* names = (ustring*)val;
-        int n          = type.arraylen;
+        size_t n          = type.arraylen;
         for (FilenameMap::iterator f = m_files.begin();
              f != m_files.end() && n-- > 0; ++f) {
             *names++ = f->second->filename();
@@ -2918,7 +2918,7 @@ ImageCacheImpl::get_image_info(ImageCacheFile* file,
         return true;
     }
     if (dataname == s_averagecolor && datatype.basetype == TypeDesc::FLOAT) {
-        int datalen = datatype.numelements() * datatype.aggregate;
+        int datalen = (int)datatype.numelements() * datatype.aggregate;
         return file->get_average_color((float*)data, subimage, 0, datalen);
     }
     if (dataname == s_averagealpha && datatype == TypeDesc::FLOAT
@@ -2929,7 +2929,7 @@ ImageCacheImpl::get_image_info(ImageCacheFile* file,
     }
     if (dataname == s_constantcolor && datatype.basetype == TypeDesc::FLOAT) {
         if (file->subimageinfo(subimage).is_constant_image) {
-            int datalen = datatype.numelements() * datatype.aggregate;
+            int datalen = (int)datatype.numelements() * datatype.aggregate;
             return file->get_average_color((float*)data, subimage, 0, datalen);
         }
         return false;  // Fail if it's not a constant image
@@ -3289,8 +3289,8 @@ ImageCacheImpl::get_pixels(ImageCacheFile* file,
                 if (xcontig) {
                     // Special case for a contiguous span within one tile
                     int spanend   = std::min(tx + spec.tile_width, xend);
-                    stride_t span = spanend - x;
-                    convert_types(cachetype, data, format, xptr,
+                    int span = spanend - x;
+                    convert_pixel_values(cachetype, data, format, xptr,
                                   result_nchans * span);
                     x += (span - 1);
                     xptr += xstride * (span - 1);

--- a/src/libtexture/texturesys.cpp
+++ b/src/libtexture/texturesys.cpp
@@ -2634,7 +2634,7 @@ TextureSystemImpl::sample_bicubic(
     }
     TileID id(texturefile, options.subimage, miplevel, 0, 0, 0, tile_chbegin,
               tile_chend, options.colortransformid);
-    int pixelsize                         = channelsize * id.nchannels();
+    int pixelsize                         = (int)channelsize * id.nchannels();
     imagesize_t firstchannel_offset_bytes = channelsize
                                             * (firstchannel - id.chbegin());
     vfloat4 accum, daccumds, daccumdt;
@@ -2766,7 +2766,7 @@ TextureSystemImpl::sample_bicubic(
             tile_s_edge = stex - tile_s;
             tile_t_edge = ttex - tile_t;
             simd::vint4 column_offset_bytes = tile_s * pixelsize
-                                              + firstchannel_offset_bytes;
+                                              + (uint32_t)firstchannel_offset_bytes;
             for (int j = 0; j < 4; ++j) {
                 if (!tvalid[j]) {
                     for (int i = 0; i < 4; ++i)

--- a/src/libutil/farmhash.cpp
+++ b/src/libutil/farmhash.cpp
@@ -42,7 +42,7 @@
 // Hash function for a byte array.  See also Hash(), below.
 // May change from time to time, may differ on different platforms, may differ
 // depending on NDEBUG.
-uint32_t Hash32(const char* s, size_t len) {
+uint32_t Hash32(const char* s, uint32_t len) {
   return farmhash::inlined::Hash32(s, len);
 }
 
@@ -50,7 +50,7 @@ uint32_t Hash32(const char* s, size_t len) {
 // hashed into the result.
 // May change from time to time, may differ on different platforms, may differ
 // depending on NDEBUG.
-uint32_t Hash32WithSeed(const char* s, size_t len, uint32_t seed) {
+uint32_t Hash32WithSeed(const char* s, uint32_t len, uint32_t seed) {
   return farmhash::inlined::Hash32WithSeed(s, len, seed);
 }
 
@@ -105,7 +105,7 @@ uint128_t Hash128WithSeed(const char* s, size_t len, uint128_t seed) {
 // FINGERPRINTING (i.e., good, portable, forever-fixed hash functions)
 
 // Fingerprint function for a byte array.  Most useful in 32-bit binaries.
-uint32_t Fingerprint32(const char* s, size_t len) {
+uint32_t Fingerprint32(const char* s, uint32_t len) {
   return farmhash::inlined::Fingerprint32(s, len);
 }
 

--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -1016,7 +1016,7 @@ Filesystem::scan_for_matching_filenames(const std::string& pattern,
                                                  view_filenames))
                     continue;
 
-                for (int j = 0, f = view_numbers.size(); j < f; ++j) {
+                for (size_t j = 0, f = view_numbers.size(); j < f; ++j) {
                     matches.push_back(
                         std::make_pair(std::make_pair(view_numbers[j], view),
                                        view_filenames[j]));

--- a/src/libutil/paramlist.cpp
+++ b/src/libutil/paramlist.cpp
@@ -128,11 +128,11 @@ parse_elements(string_view value, ParamValue& p)
 {
     using namespace Strutil;
     TypeDesc type = p.type();
-    int num_items = type.numelements() * type.aggregate;
+    size_t num_items = type.numelements() * type.aggregate;
     T* data       = (T*)p.data();
     // Erase any leading whitespace
     value.remove_prefix(value.find_first_not_of(" \t"));
-    for (int i = 0; i < num_items; ++i) {
+    for (size_t i = 0; i < num_items; ++i) {
         // Make a temporary copy so we for sure have a 0-terminated string.
         std::string temp = value;
         // Grab the first value from it

--- a/src/libutil/paramlist_test.cpp
+++ b/src/libutil/paramlist_test.cpp
@@ -21,7 +21,7 @@ static std::string
 test_numeric(T* data, int num_elements, TypeDesc type)
 {
     ParamValue p("name", type, num_elements, data);
-    int n = type.numelements() * num_elements;
+    int n = (int)type.numelements() * num_elements;
     for (int i = 0; i < n; ++i)
         OIIO_CHECK_EQUAL(p.get<T>(i), ((const T*)data)[i]);
     if (std::numeric_limits<T>::is_integer) {

--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -220,7 +220,7 @@ Strutil::vsprintf(const char* fmt, va_list ap)
         apsave = ap;
 #endif
 
-        int needed = oiio_stbsp_vsnprintf(buf, size, fmt, ap);
+        int needed = oiio_stbsp_vsnprintf(buf, (int)size, fmt, ap);
         va_end(ap);
 
         // NB. C99 says vsnprintf returns -1 on an encoding error. Otherwise
@@ -484,8 +484,8 @@ strncasecmp(const char* a, const char* b, size_t size)
 bool
 Strutil::iequals(string_view a, string_view b)
 {
-    int asize = a.size();
-    int bsize = b.size();
+    size_t asize = a.size();
+    size_t bsize = b.size();
     if (asize != bsize)
         return false;
     return Strutil::strncasecmp(a.data(), b.data(), bsize) == 0;

--- a/src/libutil/sysutil.cpp
+++ b/src/libutil/sysutil.cpp
@@ -254,10 +254,10 @@ Sysutil::this_program_path()
     char filename[10240] = "";
 
 #if defined(__linux__)
-    unsigned int size = sizeof(filename);
-    int r             = readlink("/proc/self/exe", filename, size);
+    size_t size = sizeof(filename);
+    ssize_t r = readlink("/proc/self/exe", filename, size);
     // user won't get the right answer if the filename is too long to store
-    OIIO_ASSERT(r < int(size));
+    OIIO_ASSERT(r < ssize_t(size));
     if (r > 0)
         filename[r] = 0;  // readlink does not fill in the 0 byte
 #elif defined(__APPLE__)

--- a/src/libutil/sysutil.cpp
+++ b/src/libutil/sysutil.cpp
@@ -325,7 +325,7 @@ Sysutil::usleep(unsigned long useconds)
 #ifdef _WIN32
     Sleep(useconds / 1000);  // Win32 Sleep() is milliseconds, not micro
 #else
-    ::usleep(useconds);  // *nix usleep() is in microseconds
+    ::usleep((useconds_t)useconds);  // *nix usleep() is in microseconds
 #endif
 }
 

--- a/src/libutil/thread.cpp
+++ b/src/libutil/thread.cpp
@@ -707,7 +707,7 @@ parallel_for_impl(Index begin, Index end, function_view<void(Index)> task,
     parallel_for_chunked_id(
         int64_t(begin), int64_t(end), 0,
         [&task](int /*id*/, int64_t b, int64_t e) {
-            for (Index i(b), end(e); i != end; ++i)
+            for (Index i = Index(b), end = Index(e); i != end; ++i)
                 task(i);
         },
         opt);

--- a/src/libutil/typedesc.cpp
+++ b/src/libutil/typedesc.cpp
@@ -176,7 +176,7 @@ TypeDesc::c_str() const
         return ustring("keycode").c_str();
     }
 
-    int alen = arraylen;
+    size_t alen = arraylen;
     std::string result;
     if (aggregate == SCALAR)
         result = basetype_name[basetype];
@@ -783,8 +783,8 @@ convert_type(TypeDesc srctype, const void* src, TypeDesc dsttype, void* dst,
 {
     if (n > 1) {
         // Handle multiple values by turning into or expanding array length
-        srctype.arraylen = srctype.numelements() * n;
-        dsttype.arraylen = dsttype.numelements() * n;
+        srctype.arraylen = (int)srctype.numelements() * n;
+        dsttype.arraylen = (int)dsttype.numelements() * n;
     }
 
     if (srctype.basetype == dsttype.basetype

--- a/src/null.imageio/nullimageio.cpp
+++ b/src/null.imageio/nullimageio.cpp
@@ -195,10 +195,10 @@ parse_param(string_view paramname, string_view val, ImageSpec& spec)
     }
 
     // Read the values and set the attribute
-    int n = type.numelements() * type.aggregate;
+    size_t n = type.numelements() * type.aggregate;
     if (type.basetype == TypeDesc::INT) {
         std::vector<int> values(n);
-        for (int i = 0; i < n; ++i) {
+        for (size_t i = 0; i < n; ++i) {
             Strutil::parse_int(val, values[i]);
             Strutil::parse_char(val, ',');  // optional
         }
@@ -207,7 +207,7 @@ parse_param(string_view paramname, string_view val, ImageSpec& spec)
     }
     if (type.basetype == TypeDesc::FLOAT) {
         std::vector<float> values(n);
-        for (int i = 0; i < n; ++i) {
+        for (size_t i = 0; i < n; ++i) {
             Strutil::parse_float(val, values[i]);
             Strutil::parse_char(val, ',');  // optional
         }
@@ -215,7 +215,7 @@ parse_param(string_view paramname, string_view val, ImageSpec& spec)
             spec.attribute(paramname, type, &values[0]);
     } else if (type.basetype == TypeDesc::STRING) {
         std::vector<ustring> values(n);
-        for (int i = 0; i < n; ++i) {
+        for (size_t i = 0; i < n; ++i) {
             string_view v;
             Strutil::parse_string(val, v);
             Strutil::parse_char(val, ',');  // optional

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -1697,7 +1697,7 @@ void
 Oiiotool::express_error(const string_view expr, const string_view s,
                         string_view explanation)
 {
-    int offset = expr.rfind(s) + 1;
+    size_t offset = expr.rfind(s) + 1;
     errorfmt("expression", "{} at char {} of '{}'", explanation, offset, expr);
 }
 
@@ -2643,7 +2643,7 @@ icc_read(Oiiotool& ot, cspan<const char*> argv)
     int subimages = allsubimages ? A->subimages() : 1;
     for (int s = 0; s < subimages; ++s) {
         (*A)(s).specmod().attribute("ICCProfile",
-                                    TypeDesc(TypeDesc::UINT8, len), icc.get());
+                                    TypeDesc(TypeDesc::UINT8, int(len)), icc.get());
         A->update_spec_from_imagebuf(s);
     }
     A->metadata_modified(true);

--- a/src/oiiotool/printinfo.cpp
+++ b/src/oiiotool/printinfo.cpp
@@ -400,7 +400,7 @@ print_info_subimage(std::ostream& out, Oiiotool& ot, int current_subimage,
             if (input)
                 input->seek_subimage(i, 0, spec);
             int bits = spec.get_int_attribute("oiio:BitsPerSample",
-                                              spec.format.size() * 8);
+                                              (int)spec.format.size() * 8);
             if (i)
                 s += ", ";
             if (spec.depth > 1)

--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -392,10 +392,10 @@ OpenEXRInput::open(const std::string& name, ImageSpec& newspec,
                 m->get_string());
         } else {
             // missingcolor as numeric array
-            int n = m->type().basevalues();
+            size_t n = m->type().basevalues();
             m_missingcolor.clear();
             m_missingcolor.reserve(n);
-            for (int i = 0; i < n; ++i)
+            for (size_t i = 0; i < n; ++i)
                 m_missingcolor[i] = m->get_float(i);
         }
     } else {
@@ -665,7 +665,7 @@ OpenEXRInput::PartInfo::parse_header(OpenEXRInput* in,
             std::vector<ustring> ustrvec(strvec.size());
             for (size_t i = 0, e = strvec.size(); i < e; ++i)
                 ustrvec[i] = strvec[i];
-            TypeDesc sv(TypeDesc::STRING, ustrvec.size());
+            TypeDesc sv(TypeDesc::STRING, int(ustrvec.size()));
             spec.attribute(oname, sv, &ustrvec[0]);
 #if OPENEXR_HAS_FLOATVECTOR
 
@@ -674,7 +674,7 @@ OpenEXRInput::PartInfo::parse_header(OpenEXRInput* in,
                        = header->findTypedAttribute<Imf::FloatVectorAttribute>(
                            name))) {
             std::vector<float> fvec = fvattr->value();
-            TypeDesc fv(TypeDesc::FLOAT, fvec.size());
+            TypeDesc fv(TypeDesc::FLOAT, int(fvec.size()));
             spec.attribute(oname, fv, &fvec[0]);
 #endif
         } else if (type == "double"
@@ -976,7 +976,7 @@ OpenEXRInput::PartInfo::query_channels(OpenEXRInput* in,
         spec.channelformats.push_back(cnh[c].datatype);
         spec.format = TypeDesc::basetype_merge(spec.format, cnh[c].datatype);
         pixeltype.push_back(cnh[c].exr_data_type);
-        chanbytes.push_back(cnh[c].datatype.size());
+        chanbytes.push_back((int)cnh[c].datatype.size());
         all_one_format &= (cnh[c].datatype == cnh[0].datatype);
         if (spec.alpha_channel < 0
             && (Strutil::iequals(cnh[c].suffix, "A")
@@ -1603,9 +1603,9 @@ OpenEXRInput::read_native_deep_tiles(int subimage, int miplevel, int xbegin,
         }
         m_deep_tiled_input_part->setFrameBuffer(frameBuffer);
 
-        int xtiles = round_to_multiple(width, m_spec.tile_width)
+        int xtiles = (int)round_to_multiple(width, m_spec.tile_width)
                      / m_spec.tile_width;
-        int ytiles = round_to_multiple(height, m_spec.tile_height)
+        int ytiles = (int)round_to_multiple(height, m_spec.tile_height)
                      / m_spec.tile_height;
 
         int firstxtile = (xbegin - m_spec.x) / m_spec.tile_width;

--- a/src/png.imageio/png_pvt.h
+++ b/src/png.imageio/png_pvt.h
@@ -579,7 +579,7 @@ write_info(png_structp& sp, png_infop& ip, int& color_type, ImageSpec& spec,
 
     if (setjmp(png_jmpbuf(sp)))  // NOLINT(cert-err52-cpp)
         return "Could not set PNG IHDR chunk";
-    png_set_IHDR(sp, ip, spec.width, spec.height, spec.format.size() * 8,
+    png_set_IHDR(sp, ip, spec.width, spec.height, (uint32_t)spec.format.size() * 8,
                  color_type, PNG_INTERLACE_NONE, PNG_COMPRESSION_TYPE_DEFAULT,
                  PNG_FILTER_TYPE_DEFAULT);
 
@@ -616,7 +616,7 @@ write_info(png_structp& sp, png_infop& ip, int& color_type, ImageSpec& spec,
     const ParamValue* icc_profile_parameter = spec.find_attribute(
         ICC_PROFILE_ATTR);
     if (icc_profile_parameter != NULL) {
-        unsigned int length = icc_profile_parameter->type().size();
+        uint32_t length = (uint32_t)icc_profile_parameter->type().size();
         if (setjmp(png_jmpbuf(sp)))  // NOLINT(cert-err52-cpp)
             return "Could not set PNG iCCP chunk";
 #if OIIO_LIBPNG_VERSION > 10500 /* PNG function signatures changed */
@@ -698,7 +698,7 @@ write_info(png_structp& sp, png_infop& ip, int& color_type, ImageSpec& spec,
                       spec.extra_attribs[p].data(), text);
 
     if (text.size())
-        png_set_text(sp, ip, &text[0], text.size());
+        png_set_text(sp, ip, &text[0], (int)text.size());
 
     png_write_info(sp, ip);
     png_set_packing(sp);  // Pack 1, 2, 4 bit into bytes

--- a/src/pnm.imageio/pnminput.cpp
+++ b/src/pnm.imageio/pnminput.cpp
@@ -215,7 +215,7 @@ PNMInput::read_file_scanline(void* data, int y)
             else if (m_pnm_type == PF || m_pnm_type == Pf)
                 numbytes = m_spec.nchannels * 4 * m_spec.width;
             else
-                numbytes = m_spec.scanline_bytes();
+                numbytes = (int)m_spec.scanline_bytes();
             if (size_t(numbytes) > m_remaining.size())
                 return false;
             buf.assign(m_remaining.begin(), m_remaining.begin() + numbytes);

--- a/src/pnm.imageio/pnmoutput.cpp
+++ b/src/pnm.imageio/pnmoutput.cpp
@@ -97,7 +97,7 @@ PNMOutput::write_ascii(const T* data, const stride_t stride,
 {
     int nc = m_spec.nchannels;
     for (int x = 0; x < m_spec.width; x++) {
-        unsigned int pixel = x * stride;
+        size_t pixel = x * stride;
         for (int c = 0; c < nc; c++) {
             unsigned int val = data[pixel + c];
             val              = val * max_val / std::numeric_limits<T>::max();
@@ -116,7 +116,7 @@ PNMOutput::write_raw(const T* data, const stride_t stride, unsigned int max_val)
 {
     int nc = m_spec.nchannels;
     for (int x = 0; x < m_spec.width; x++) {
-        unsigned int pixel = x * stride;
+        size_t pixel = x * stride;
         for (int c = 0; c < nc; c++) {
             unsigned int val = data[pixel + c];
             val              = val * max_val / std::numeric_limits<T>::max();

--- a/src/psd.imageio/psdinput.cpp
+++ b/src/psd.imageio/psdinput.cpp
@@ -590,7 +590,7 @@ PSDInput::open(const std::string& name, ImageSpec& newspec)
     }
 
     // Layer count + 1 for merged composite (Image Data Section)
-    m_subimage_count = m_layers.size() + 1;
+    m_subimage_count = (int)m_layers.size() + 1;
     // Set m_type_desc to the appropriate TypeDesc
     set_type_desc();
     // Setup ImageSpecs and m_channels

--- a/src/python/py_imagebuf.cpp
+++ b/src/python/py_imagebuf.cpp
@@ -35,20 +35,20 @@ ImageBuf_from_buffer(const py::buffer& buffer)
 
     if (info.ndim == 3) {
         // Assume [y][x][c]
-        ImageSpec spec(info.shape[1], info.shape[0], info.shape[2], format);
+        ImageSpec spec((int)info.shape[1], (int)info.shape[0], (int)info.shape[2], format);
         ib.reset(spec, InitializePixels::No);
         ib.set_pixels(get_roi(spec), format, info.ptr, info.strides[1],
                       info.strides[0]);
     } else if (info.ndim == 2) {
         // Assume [y][x], single channel
-        ImageSpec spec(info.shape[1], info.shape[0], 1, format);
+        ImageSpec spec((int)info.shape[1], (int)info.shape[0], 1, format);
         ib.reset(spec, InitializePixels::No);
         ib.set_pixels(get_roi(spec), format, info.ptr, info.strides[1],
                       info.strides[0]);
     } else if (info.ndim == 4) {
         // Assume volume [z][y][x][c]
-        ImageSpec spec(info.shape[2], info.shape[1], info.shape[3], format);
-        spec.depth      = info.shape[0];
+        ImageSpec spec((int)info.shape[2], (int)info.shape[1], (int)info.shape[3], format);
+        spec.depth      = (int)info.shape[0];
         spec.full_depth = spec.depth;
         ib.reset(spec, InitializePixels::No);
         ib.set_pixels(get_roi(spec), format, info.ptr, info.strides[2],

--- a/src/python/py_oiio.cpp
+++ b/src/python/py_oiio.cpp
@@ -74,7 +74,7 @@ oiio_bufinfo::oiio_bufinfo(const py::buffer_info& pybuf)
         data    = pybuf.ptr;
         xstride = format.size();
         size    = 1;
-        for (int i = pybuf.ndim - 1; i >= 0; --i) {
+        for (ssize_t i = pybuf.ndim - 1; i >= 0; --i) {
             if (pybuf.strides[i] != py::ssize_t(size * xstride)) {
                 // Just can't handle non-contiguous strides
                 format = TypeUnknown;
@@ -221,7 +221,7 @@ make_pyobject(const void* data, TypeDesc type, int nvalues,
         // Array of uint8 bytes
         // Have to make a copy of the data, because make_numpy_array will
         // take possession of it.
-        int n = type.arraylen * nvalues;
+        size_t n = type.arraylen * nvalues;
         if (n <= 0)
             return defaultvalue;
         uint8_t* ucdata(new uint8_t[n]);

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -165,7 +165,7 @@ private:
              bool force = true, int ignval = 0)
     {
         if (force || !allval(data, ignval)) {
-            int size = data.size() > 1 ? data.size() : 0;
+            int size = data.size() > 1 ? int(data.size()) : 0;
             m_spec.attribute(prefixedname(prefix, name),
                              TypeDesc(TypeDesc::INT, size), data.data());
         }
@@ -174,7 +174,7 @@ private:
              bool force = true, short ignval = 0)
     {
         if (force || !allval(data, ignval)) {
-            int size = data.size() > 1 ? data.size() : 0;
+            int size = data.size() > 1 ? int(data.size()) : 0;
             m_spec.attribute(prefixedname(prefix, name),
                              TypeDesc(TypeDesc::INT16, size), data.data());
         }
@@ -183,7 +183,7 @@ private:
              bool force = true, unsigned short ignval = 0)
     {
         if (force || !allval(data, ignval)) {
-            int size = data.size() > 1 ? data.size() : 0;
+            int size = data.size() > 1 ? int(data.size()) : 0;
             m_spec.attribute(prefixedname(prefix, name),
                              TypeDesc(TypeDesc::UINT16, size), data.data());
         }
@@ -192,7 +192,7 @@ private:
              bool force = true, unsigned char ignval = 0)
     {
         if (force || !allval(data, ignval)) {
-            int size = data.size() > 1 ? data.size() : 0;
+            int size = data.size() > 1 ? int(data.size()) : 0;
             m_spec.attribute(prefixedname(prefix, name),
                              TypeDesc(TypeDesc::UINT8, size), data.data());
         }
@@ -201,7 +201,7 @@ private:
              bool force = true, float ignval = 0)
     {
         if (force || !allval(data, ignval)) {
-            int size = data.size() > 1 ? data.size() : 0;
+            int size = data.size() > 1 ? int(data.size()) : 0;
             m_spec.attribute(prefixedname(prefix, name),
                              TypeDesc(TypeDesc::FLOAT, size), data.data());
         }
@@ -638,7 +638,7 @@ RawInput::open_raw(bool unpack, const std::string& name,
                 "Mixed", "LMMSE", "AMaZE", "DHT", "AAHD",
                 // Future demosaicing algorithms should go here
                 NULL };
-        size_t d;
+        int d;
         for (d = 0; demosaic_algs[d]; d++)
             if (Strutil::iequals(demosaic, demosaic_algs[d]))
                 break;

--- a/src/rla.imageio/rlainput.cpp
+++ b/src/rla.imageio/rlainput.cpp
@@ -512,9 +512,9 @@ RLAInput::decode_channel_group(int first_channel, short num_channels,
                                short num_bits, int y)
 {
     // Some preliminaries -- figure out various sizes and offsets
-    int chsize;         // size of the channels in this group, in bytes
-    int offset;         // buffer offset to first channel
-    int pixelsize;      // spacing between pixels (in bytes) in the output
+    size_t chsize;         // size of the channels in this group, in bytes
+    size_t offset;         // buffer offset to first channel
+    size_t pixelsize;      // spacing between pixels (in bytes) in the output
     TypeDesc chantype;  // data type for the channel
     if (!m_spec.channelformats.size()) {
         // No per-channel formats, they are all the same, so it's easy
@@ -571,9 +571,9 @@ RLAInput::decode_channel_group(int first_channel, short num_channels,
         // which we re-interleave properly by passing the right offsets
         // and strides to decode_rle_span.
         size_t eoffset = 0;
-        for (int bytes = 0; bytes < chsize && length > 0; ++bytes) {
+        for (size_t bytes = 0; bytes < chsize && length > 0; ++bytes) {
             size_t e = decode_rle_span(&m_buf[offset + c * chsize + bytes],
-                                       m_spec.width, pixelsize,
+                                       m_spec.width, (int)pixelsize,
                                        &encoded[eoffset], length);
             if (!e)
                 return false;

--- a/src/sgi.imageio/sgiinput.cpp
+++ b/src/sgi.imageio/sgiinput.cpp
@@ -192,8 +192,8 @@ SgiInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
         for (int c = 0; c < m_spec.nchannels; ++c) {
             // offset for this scanline/channel
             ptrdiff_t off             = y + c * m_spec.height;
-            ptrdiff_t scanline_offset = start_tab[off];
-            ptrdiff_t scanline_length = length_tab[off];
+            uint32_t scanline_offset = start_tab[off];
+            uint32_t scanline_length = length_tab[off];
             channeldata[c].resize(m_spec.width * bpc);
             uncompress_rle_channel(scanline_offset, scanline_length,
                                    &(channeldata[c][0]));

--- a/src/targa.imageio/targainput.cpp
+++ b/src/targa.imageio/targainput.cpp
@@ -552,7 +552,7 @@ TGAInput::get_thumbnail(ImageBuf& thumb, int subimage)
         // load pixel data
         unsigned char pixel[4];
         unsigned char in[4];
-        for (int64_t y = thumbspec.height - 1; y >= 0; y--) {
+        for (int y = thumbspec.height - 1; y >= 0; y--) {
             char* img = (char*)thumb.pixeladdr(0, y);
             for (int64_t x = 0; x < thumbspec.width;
                  x++, img += m_spec.nchannels) {

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -289,7 +289,7 @@ private:
         // Strutil::printf(" tgsf %s tag %d datatype %d passcount %d readcount %d\n",
         //                 name, tag, int(tiffdatatype), passcount, readcount);
         char* s        = nullptr;
-        uint32_t count = 0;
+        size_t   count = 0;
         bool ok        = false;
         if (tiffdatatype == TIFF_ASCII && passcount
             && readcount == TIFF_VARIABLE) {
@@ -1522,10 +1522,10 @@ TIFFInput::separate_to_contig(int nplanes, int nvals,
                               const unsigned char* separate,
                               unsigned char* contig)
 {
-    int channelbytes = m_spec.channel_bytes();
+    size_t channelbytes = m_spec.channel_bytes();
     for (int p = 0; p < nvals; ++p)                 // loop over pixels
         for (int c = 0; c < nplanes; ++c)           // loop over channels
-            for (int i = 0; i < channelbytes; ++i)  // loop over data bytes
+            for (size_t i = 0; i < channelbytes; ++i)  // loop over data bytes
                 contig[(p * nplanes + c) * channelbytes + i]
                     = separate[(c * nvals + p) * channelbytes + i];
 }
@@ -1539,7 +1539,7 @@ TIFFInput::palette_to_rgb(int n, const unsigned char* palettepels,
 {
     size_t vals_per_byte = 8 / m_bitspersample;
     size_t entries       = 1 << m_bitspersample;
-    int highest          = entries - 1;
+    size_t highest       = entries - 1;
     OIIO_DASSERT(m_spec.nchannels == 3);
     OIIO_DASSERT(m_colormap.size() == 3 * entries);
     for (int x = 0; x < n; ++x) {
@@ -2084,8 +2084,8 @@ TIFFInput::read_native_tile(int subimage, int miplevel, int x, int y, int z,
         return true;
     }
 
-    imagesize_t tile_pixels = m_spec.tile_pixels();
-    imagesize_t nvals       = tile_pixels * m_inputchannels;
+    int tile_pixels = (int)m_spec.tile_pixels();
+    int nvals       = tile_pixels * m_inputchannels;
     if (m_photometric == PHOTOMETRIC_PALETTE && m_bitspersample > 8)
         m_scratch.resize(nvals * 2);  // special case for 16 bit palette
     else
@@ -2229,7 +2229,7 @@ TIFFInput::read_native_tiles(int subimage, int miplevel, int xbegin, int xend,
     stride_t ystride       = (xend - xbegin) * pixel_bytes;
     stride_t zstride       = (yend - ybegin) * ystride;
     imagesize_t tile_bytes = m_spec.tile_bytes(true);
-    int tilevals           = m_spec.tile_pixels() * m_spec.nchannels;
+    int tilevals           = (int)m_spec.tile_pixels() * m_spec.nchannels;
     size_t cbound          = compressBound((uLong)tile_bytes);
     std::unique_ptr<char[]> compressed_scratch(new char[cbound * ntiles]);
     std::unique_ptr<char[]> scratch(new char[tile_bytes * ntiles]);

--- a/src/tiff.imageio/tiffoutput.cpp
+++ b/src/tiff.imageio/tiffoutput.cpp
@@ -859,7 +859,7 @@ TIFFOutput::open(const std::string& name, const ImageSpec& userspec,
     if (icc_profile_parameter != NULL) {
         unsigned char* icc_profile
             = (unsigned char*)icc_profile_parameter->data();
-        uint32_t length = icc_profile_parameter->type().size();
+        size_t length = icc_profile_parameter->type().size();
         if (icc_profile && length)
             TIFFSetField(m_tif, TIFFTAG_ICCPROFILE, length, icc_profile);
     }
@@ -1178,10 +1178,10 @@ void
 TIFFOutput::contig_to_separate(int n, int nchans, const char* contig,
                                char* separate)
 {
-    int channelbytes = m_spec.channel_bytes();
+    size_t channelbytes = m_spec.channel_bytes();
     for (int p = 0; p < n; ++p)                     // loop over pixels
         for (int c = 0; c < nchans; ++c)            // loop over channels
-            for (int i = 0; i < channelbytes; ++i)  // loop over data bytes
+            for (size_t i = 0; i < channelbytes; ++i)  // loop over data bytes
                 separate[(c * n + p) * channelbytes + i]
                     = contig[(p * nchans + c) * channelbytes + i];
 }
@@ -1243,7 +1243,7 @@ TIFFOutput::write_scanline(int y, int z, TypeDesc format, const void* data,
     std::vector<unsigned char> cmyk;
     if (m_photometric == PHOTOMETRIC_SEPARATED && m_convert_rgb_to_cmyk)
         data = convert_to_cmyk(spec().width, data, cmyk);
-    size_t scanline_vals = size_t(spec().width) * m_outputchans;
+    int scanline_vals = spec().width * m_outputchans;
 
     // Handle weird bit depths
     if (spec().format.size() * 8 != m_bitspersample) {
@@ -1254,7 +1254,7 @@ TIFFOutput::write_scanline(int y, int z, TypeDesc format, const void* data,
     y -= m_spec.y;
     if (m_planarconfig == PLANARCONFIG_SEPARATE && m_spec.nchannels > 1) {
         // Convert from contiguous (RGBRGBRGB) to separate (RRRGGGBBB)
-        int plane_bytes = m_spec.width * m_spec.format.size();
+        size_t plane_bytes = m_spec.width * m_spec.format.size();
 
         char* separate;
         OIIO_ALLOCATE_STACK_OR_HEAP(separate, char, plane_bytes* m_outputchans);
@@ -1491,7 +1491,7 @@ TIFFOutput::write_tile(int x, int y, int z, TypeDesc format, const void* data,
     // Handle weird photometric/color spaces
     std::vector<unsigned char> cmyk;
     if (m_photometric == PHOTOMETRIC_SEPARATED && m_convert_rgb_to_cmyk)
-        data = convert_to_cmyk(spec().tile_pixels(), data, cmyk);
+        data = convert_to_cmyk((int)spec().tile_pixels(), data, cmyk);
 
     // Handle weird bit depths
     if (spec().format.size() * 8 != m_bitspersample) {
@@ -1507,7 +1507,7 @@ TIFFOutput::write_tile(int x, int y, int z, TypeDesc format, const void* data,
 
         char* separate;
         OIIO_ALLOCATE_STACK_OR_HEAP(separate, char, plane_bytes* m_outputchans);
-        contig_to_separate(tile_pixels, m_outputchans, (const char*)data,
+        contig_to_separate((int)tile_pixels, m_outputchans, (const char*)data,
                            separate);
         for (int c = 0; c < m_outputchans; ++c) {
             if (TIFFWriteTile(m_tif, (tdata_t)&separate[plane_bytes * c], x, y,

--- a/src/webp.imageio/webpinput.cpp
+++ b/src/webp.imageio/webpinput.cpp
@@ -298,14 +298,14 @@ WebpInput::read_current_subimage()
                                       m_iter.fragment.size,
                                       m_decoded_image.get() + offset,
                                       m_spec.image_bytes() - offset,
-                                      m_spec.scanline_bytes());
+                                      (int)m_spec.scanline_bytes());
         } else {
             OIIO_DASSERT(m_spec.nchannels == 4);
             okptr = WebPDecodeRGBAInto(m_iter.fragment.bytes,
                                        m_iter.fragment.size,
                                        m_decoded_image.get() + offset,
                                        m_spec.image_bytes() - offset,
-                                       m_spec.scanline_bytes());
+                                       (int)m_spec.scanline_bytes());
             // WebP requires unassociated alpha, and it's sRGB.
             // Handle this all by wrapping an IB around it.
             ImageBuf fullbuf(m_spec, m_decoded_image.get());
@@ -323,7 +323,7 @@ WebpInput::read_current_subimage()
         okptr = WebPDecodeRGBAInto(m_iter.fragment.bytes, m_iter.fragment.size,
                                    (uint8_t*)fragbuf.localpixels(),
                                    fragspec.image_bytes(),
-                                   fragspec.scanline_bytes());
+                                   (int)fragspec.scanline_bytes());
         // WebP requires unassociated alpha, and it's sRGB.
         // Handle this all by wrapping an IB around it.
         ImageBufAlgo::premult(fragbuf, fragbuf);

--- a/src/webp.imageio/webpoutput.cpp
+++ b/src/webp.imageio/webpoutput.cpp
@@ -145,10 +145,10 @@ WebpOutput::write_scanline(int y, int z, TypeDesc format, const void* data,
             ImageBufAlgo::unpremult(bufwrap, bufwrap);
             ImageBufAlgo::pow(bufwrap, bufwrap, 1.0f / 2.2f, rgbroi);
             WebPPictureImportRGBA(&m_webp_picture, &m_uncompressed_image[0],
-                                  m_scanline_size);
+                                  (int)m_scanline_size);
         } else {
             WebPPictureImportRGB(&m_webp_picture, &m_uncompressed_image[0],
-                                 m_scanline_size);
+                                 (int)m_scanline_size);
         }
         if (!WebPEncode(&m_webp_config, &m_webp_picture)) {
             errorfmt("Failed to encode {} as WebP image", m_filename);


### PR DESCRIPTION

## Description

Enabling the implicit 64 to 32 bit conversion warnings shows several hundreds of them. This is my attempt to fix them all.

## Tests

I have built the code on an Apple silicon Mac (both command line and Xcode), and an x64 linux machine, and have run the tests. I have not tested on Windows, or any 32-bit hardware. 

I'm not familiar with the project enough to say that my testing was adequate. Any help would be appreciated.

## Checklist:

- [x] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
