### PR TITLE
Fix typo in debug output

### DIFF
--- a/src/libOpenImageIO/imageioplugin.cpp
+++ b/src/libOpenImageIO/imageioplugin.cpp
@@ -775,7 +775,7 @@ ImageInput::create(string_view filename, bool do_open, const ImageSpec* config,
                 // it was a valid file, and it's not.  Try the next one.
                 if (pvt::oiio_print_debug > 1)
                     OIIO::debugfmt(
-                        "ImageInput::create: \"{}\" did not open using format \"{}\" {} [valid_file was fals].\n",
+                        "ImageInput::create: \"{}\" did not open using format \"{}\" {} [valid_file was false].\n",
                         filename, plugin->first, in->format_name());
                 in.reset();
                 continue;


### PR DESCRIPTION
## Description

Fixes a typo in the debug output triggered during the image plugin search sequence.

## Checklist:

- [x] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
