### PR TITLE
build(win): Fix windows.h pre-definitions

### DIFF
--- a/src/include/OpenImageIO/platform.h
+++ b/src/include/OpenImageIO/platform.h
@@ -42,9 +42,11 @@
 #    include <intrin.h>
 #endif
 
-//Avoid min and max being defined
-#if defined(_WIN32)
-#define NOMINMAX
+// Avoid min and max being defined for any subsequent include of windows.h
+#ifdef _WIN32
+#    ifndef NOMINMAX
+#        define NOMINMAX
+#    endif
 #endif
 
 #include <OpenImageIO/oiioversion.h>

--- a/src/libutil/CMakeLists.txt
+++ b/src/libutil/CMakeLists.txt
@@ -35,6 +35,7 @@ if (NOT OIIO_USING_FMT_LOCAL)
 endif ()
 
 if (WIN32)
+    add_definitions(-DWIN32_LEAN_AND_MEAN -DNOMINMAX -DNOGDI -DVC_EXTRALEAN)
     target_link_libraries (OpenImageIO_Util PRIVATE psapi)
 endif()
 

--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -21,9 +21,6 @@
 #include <OpenImageIO/ustring.h>
 
 #ifdef _WIN32
-#    define WIN32_LEAN_AND_MEAN
-#    define VC_EXTRALEAN
-#    define NOMINMAX
 #    include <windows.h>
 
 #    include <direct.h>

--- a/src/libutil/plugin.cpp
+++ b/src/libutil/plugin.cpp
@@ -8,9 +8,6 @@
 #include <OpenImageIO/platform.h>
 
 #ifdef _WIN32
-#    define WIN32_LEAN_AND_MEAN
-#    define VC_EXTRALEAN
-#    define NOMINMAX
 #    include <windows.h>
 #else
 #    include <dlfcn.h>

--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -32,12 +32,8 @@
 #include <OpenImageIO/ustring.h>
 
 #ifdef _WIN32
-#    define WIN32_LEAN_AND_MEAN
-#    define VC_EXTRALEAN
-#    define NOMINMAX
-#    include <windows.h>
-
 #    include <shellapi.h>
+#    include <windows.h>
 #endif
 
 

--- a/src/libutil/sysutil.cpp
+++ b/src/libutil/sysutil.cpp
@@ -45,11 +45,7 @@
 #include <OpenImageIO/platform.h>
 
 #ifdef _WIN32
-#    define WIN32_LEAN_AND_MEAN
-#    define VC_EXTRALEAN
-#    define NOMINMAX
 #    include <windows.h>
-
 #    define DEFINE_CONSOLEV2_PROPERTIES
 #    include <cstdio>
 #    include <io.h>

--- a/src/libutil/thread.cpp
+++ b/src/libutil/thread.cpp
@@ -36,9 +36,6 @@
 #include <boost/container/flat_map.hpp>
 
 #ifdef _WIN32
-#    define WIN32_LEAN_AND_MEAN
-#    define VC_EXTRALEAN
-#    define NOMINMAX
 #    include <windows.h>
 #endif
 

--- a/src/libutil/timer.cpp
+++ b/src/libutil/timer.cpp
@@ -8,9 +8,6 @@
 #include <OpenImageIO/timer.h>
 
 #ifdef _WIN32
-#    define WIN32_LEAN_AND_MEAN
-#    define VC_EXTRALEAN
-#    define NOMINMAX
 #    include <windows.h>
 #endif
 


### PR DESCRIPTION
* Avoid possible double define of NOMINMAX in platform.h
* Move other Windows symbol definitions into the cmake file instead of
  repeating them in certain .cpp files.

Fixes #3964
