### PR TITLE
feat(api): ImageInput::open_check

### DIFF
--- a/src/fits.imageio/fits_pvt.h
+++ b/src/fits.imageio/fits_pvt.h
@@ -44,8 +44,10 @@ public:
     int supports(string_view feature) const override
     {
         return (feature == "arbitrary_metadata"
-                || feature == "exif"    // Because of arbitrary_metadata
-                || feature == "iptc");  // Because of arbitrary_metadata
+                || feature == "exif"     // Because of arbitrary_metadata
+                || feature == "iptc"     // Because of arbitrary_metadata
+                || feature == "noimage"  // allow metadata only, no pixels
+        );
     }
     bool valid_file(const std::string& filename) const override;
     bool open(const std::string& name, ImageSpec& spec) override;

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -1003,6 +1003,10 @@ public:
     ///       Does this format reader support retrieving a reduced
     ///       resolution copy of the image via the `thumbnail()` method?
     ///
+    ///  - `"noimage"` :
+    ///        Does this format allow 0x0 sized images, i.e. an image file
+    ///        with metadata only and no pixels?
+    ///
     /// This list of queries may be extended in future releases. Since this
     /// can be done simply by recognizing new query strings, and does not
     /// require any new API entry points, addition of support for new
@@ -1818,6 +1822,55 @@ protected:
     /// Helper: retrieve the current position of the proxy, akin to ftell.
     int64_t iotell() const;
 
+    /// Helper: convenience boilerplate for several checks and operations that
+    /// every implementation of ImageInput::open() will need to do. Failure is
+    /// presumed to indicate a file that is corrupt (or perhaps maliciously
+    /// crafted) and no further reading should be attempted.
+    ///
+    /// @param spec
+    ///     The ImageSpec that we are validating.
+    ///
+    /// @param range
+    ///     An ROI that describes the allowable pixel coordinates and channel
+    ///     indices as half-open intervals.  For example, the default value
+    ///     `{0, 65535, 0, 65535, 0, 1, 0, 4}` means that pixel coordinates
+    ///     must be non-negative and the width and height be representable by
+    ///     a uint16 value, up to 4 channels are allowed, and volumes are not
+    ///     permitted (z coordinate may only be 0). File formats that can
+    ///     handle larger resolutions, or volumes, or >4 channels must
+    ///     override these limits!
+    ///
+    /// @param flags
+    ///     A bitfield flag (bits defined by `enum OpenChecks`) that can
+    ///     indicate additional checks to perform, or checks that should be
+    ///     skipped.
+    ///
+    /// @returns
+    ///     Return `true` if the spec is valid and passes all checks,
+    ///     otherwise return `false` and make appropriate calls to
+    ///     this->errorfmt() to record the errors.
+    ///
+    /// Checks performed include:
+    ///
+    /// * Whether the resolution is within the range implied by the half-open
+    ///   intervals given by `reslimits` `[xbegin, xend]`, `[ybegin, yend]`,
+    ///   `[zbegin, zend]`. The default is at least 1x1 and no more than
+    ///   1M x 1M pixels.
+    /// * Whether the channel count is within `reslimits` `[chbegin, chend)`
+    ///   as well as within the `"limit:channels"` OIIO attribute.
+    /// * The total uncompressed pixel data size is expected to be within the
+    ///   `"limit:imagesize_MB"` OIIO attribute.
+    ///
+    bool check_open (const ImageSpec &spec,
+                     ROI reslimits = ROI(1, 1<<20, 1, 1<<20, 1, 1<<20, 1, 1<<16),
+                     uint64_t flags = 0);
+
+    /// Bit field definitions for the `flags` argument to `check_open()`.
+    enum class OpenChecks : uint64_t {
+        Defaults = 0,
+        // Reserved for future use
+    };
+
     /// @}
 
 private:
@@ -2526,7 +2579,8 @@ protected:
     ///    is the request to write volumetric data but the format writer
     ///    doesn't support it).
     ///
-    /// Returns true if ok, false if the open request can't be satisfied.
+    /// Returns true if ok, false if the open request can't be satisfied (and
+    /// makes appropriate calls to this->errorfmt() to record the errors).
     ///
     /// Having a central helper method for this is beneficial:
     ///
@@ -2561,6 +2615,11 @@ protected:
     ///     A bitfield flag (bits defined by `enum OpenChecks`) that can
     ///     indicate additional checks to perform, or checks that should be
     ///     skipped.
+    ///
+    /// @returns
+    ///     Return `true` if the spec is valid and passes all checks,
+    ///     otherwise return `false` and make appropriate calls to
+    ///     this->errorfmt() to record the errors.
     ///
     /// Checks performed include:
     /// 

--- a/src/libOpenImageIO/imageinput.cpp
+++ b/src/libOpenImageIO/imageinput.cpp
@@ -1286,4 +1286,58 @@ ImageInput::iotell() const
 }
 
 
+
+bool
+ImageInput::check_open(const ImageSpec& spec, ROI range, uint64_t /*flags*/)
+{
+    // Check for sensible resolutions, etc.
+    if ((m_spec.width <= 0 || m_spec.height <= 0 || m_spec.depth <= 0
+         || m_spec.nchannels <= 0)
+        && !supports("noimage")) {
+        errorfmt(
+            "{} image resolution must be at least 1x1, but the file specified {}x{}. Possible corrupt input?",
+            format_name(), m_spec.width, m_spec.height);
+        return false;
+    }
+    if (m_spec.width > range.width() || m_spec.height > range.height()) {
+        errorfmt(
+            "{} image resolution may not exceed {}x{}, but the file appears to be {}x{}. Possible corrupt input?",
+            format_name(), range.width(), range.height(), m_spec.width,
+            m_spec.height);
+        return false;
+    }
+    if (spec.depth >= range.depth()) {
+        errorfmt(
+            "{} volumetric slices may not exceed {}, but the file appears to be {}x{}x{}. Possible corrupt input?",
+            format_name(), range.depth(), spec.width, spec.height, spec.depth);
+        return false;
+    }
+    if (spec.nchannels < range.chbegin || spec.nchannels >= range.chend) {
+        errorfmt(
+            "{} does not support {}-channel images. Possible corrupt input?",
+            format_name(), spec.nchannels);
+        return false;
+    }
+    if (pvt::limit_channels && spec.nchannels > pvt::limit_channels) {
+        errorfmt(
+            "{} channels exceeds \"limits:channels\" = {}. Possible corrupt input?\nIf you're sure this is a valid file, raise the OIIO global attribute \"limits:channels\".",
+            spec.nchannels, pvt::limit_channels);
+        return false;
+    }
+    if (pvt::limit_imagesize_MB
+        && spec.image_bytes(true)
+               > pvt::limit_imagesize_MB * imagesize_t(1024 * 1024)) {
+        errorfmt(
+            "Uncompressed image size {:.1f} MB exceeds the {} MB limit.\n"
+            "Image claimed to be {}x{}, {}-channel {}. Possible corrupt input?\n"
+            "If this is a valid file, raise the OIIO attribute \"limits:imagesize_MB\".",
+            float(m_spec.image_bytes(true)) / float(1024 * 1024),
+            pvt::limit_imagesize_MB, m_spec.width, m_spec.height,
+            m_spec.nchannels, m_spec.format);
+        return false;
+    }
+
+    return true;  // all is ok
+}
+
 OIIO_NAMESPACE_END

--- a/src/targa.imageio/targainput.cpp
+++ b/src/targa.imageio/targainput.cpp
@@ -286,18 +286,8 @@ TGAInput::open(const std::string& name, ImageSpec& newspec)
     }
     m_spec.attribute("targa:version", int(m_tga_version));
 
-    if (pvt::limit_imagesize_MB
-        && m_spec.image_bytes(true)
-               > pvt::limit_imagesize_MB * imagesize_t(1024 * 1024)) {
-        errorfmt(
-            "Uncompressed image size {:.1f} MB exceeds the {} MB limit.\n"
-            "Image claimed to be {}x{}, {}-channel {}. Possible corrupt input?\n"
-            "If this is a valid file, raise the OIIO attribute \"limits:imagesize_MB\".",
-            float(m_spec.image_bytes(true)) / float(1024 * 1024),
-            pvt::limit_imagesize_MB, m_spec.width, m_spec.height,
-            m_spec.nchannels, m_spec.format);
+    if (!check_open(m_spec))
         return false;
-    }
 
     if (m_spec.alpha_channel != -1 && m_alpha_type == TGA_ALPHA_USEFUL
         && m_keep_unassociated_alpha)

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -839,24 +839,8 @@ TIFFInput::seek_subimage(int subimage, int miplevel)
             errorfmt("No support for data format of \"{}\"", m_filename);
             return false;
         }
-        if (pvt::limit_channels && m_spec.nchannels > pvt::limit_channels) {
-            errorfmt(
-                "{} channels exceeds \"limits:channels\" = {}. Possible corrupt input?\nIf you're sure this is a valid file, raise the OIIO global attribute \"limits:channels\".",
-                m_spec.nchannels, pvt::limit_channels);
+        if (!check_open(m_spec))
             return false;
-        }
-        if (pvt::limit_imagesize_MB
-            && m_spec.image_bytes(true)
-                   > pvt::limit_imagesize_MB * imagesize_t(1024 * 1024)) {
-            errorfmt(
-                "Uncompressed image size {:.1f} MB exceeds the {} MB limit.\n"
-                "Image claimed to be {}x{}, {}-channel {}. Possible corrupt input?\n"
-                "If this is a valid file, raise the OIIO attribute \"limits:imagesize_MB\".",
-                float(m_spec.image_bytes(true)) / float(1024 * 1024),
-                pvt::limit_imagesize_MB, m_spec.width, m_spec.height,
-                m_spec.nchannels, m_spec.format);
-            return false;
-        }
         return true;
     } else {
         std::string e = oiio_tiff_last_error();


### PR DESCRIPTION
Not unlike the ImageOutput::open_check we added a few months back, this creates an ImageInput utility function that centralizes a number of validation checks. Currently, this is primarily a check on allowed resolution and total size, aimed at making a guess at files that are corrupted or malicious.

Also adds a new `supports("noimage")` query.
