### PR TITLE
build: Fix broken libheif < 1.13

### DIFF
--- a/src/heif.imageio/heifinput.cpp
+++ b/src/heif.imageio/heifinput.cpp
@@ -62,7 +62,7 @@ private:
 void
 oiio_heif_init()
 {
-#if LIBHEIF_HAVE_VERSION(1, 6, 0)
+#if LIBHEIF_HAVE_VERSION(1, 16, 0)
     static std::once_flag flag;
     std::call_once(flag, []() { heif_init(nullptr); });
 #endif


### PR DESCRIPTION
Typo introduced in #3894 broke our ability to build against libheif < 1.13. A conditional compilation that should have kicked in for >=1.16 was mistakenly written as 1.6.
