### PR TITLE
fix(ustring): fix Cuda warnings

### DIFF
--- a/src/include/OpenImageIO/ustring.h
+++ b/src/include/OpenImageIO/ustring.h
@@ -816,41 +816,41 @@ public:
 
     /// Construct a ustringhash from a null-terminated C string (char *).
     OIIO_DEVICE_CONSTEXPR explicit ustringhash(const char* str)
-    {
 #ifdef __CUDA_ARCH__
         // GPU: just compute the hash. This can be constexpr!
-        m_hash = Strutil::strhash(str);
+        : m_hash(Strutil::strhash(str))
 #else
         // CPU: make ustring, get its hash. Note that ustring ctr can't be
         // constexpr because it has to modify the internal ustring table.
-        m_hash = ustring(str).hash();
+        : m_hash(ustring(str).hash())
 #endif
+    {
     }
 
     OIIO_DEVICE_CONSTEXPR explicit ustringhash(const char* str, size_t len)
-    {
 #ifdef __CUDA_ARCH__
         // GPU: just compute the hash. This can be constexpr!
-        m_hash = Strutil::strhash(len, str);
+        : m_hash(Strutil::strhash(len, str))
 #else
         // CPU: make ustring, get its hash. Note that ustring ctr can't be
         // constexpr because it has to modify the internal ustring table.
-        m_hash = ustring(str, len).hash();
+        : m_hash(ustring(str, len).hash())
 #endif
+    {
     }
 
     /// Construct a ustringhash from a string_view, which can be
     /// auto-converted from either a std::string.
     OIIO_DEVICE_CONSTEXPR explicit ustringhash(string_view str)
-    {
 #ifdef __CUDA_ARCH__
         // GPU: just compute the hash. This can be constexpr!
-        m_hash = Strutil::strhash(str);
+        : m_hash(Strutil::strhash(str))
 #else
         // CPU: make ustring, get its hash. Note that ustring ctr can't be
         // constexpr because it has to modify the internal ustring table.
-        m_hash = ustring(str).hash();
+        : m_hash(ustring(str).hash())
 #endif
+    {
     }
 
     /// Construct from a raw hash value. Beware: results are undefined if it's


### PR DESCRIPTION
To my eyes, these two constructors look like they should be treated as doing exactly the same thing:

    MyType()
        : mymember(...)
    { }

and

    MyType()
    {
       mymember = ...;
    }

But nvcc in Cuda mode says no, if the constructor is constexpr, the former is okey dokey, but latter gives a warning. Fine, Cuda, whatver you say.
