### PR TITLE
perf(oiiotool): oiiotool --mosaic improve type conversion

### DIFF
--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -4884,6 +4884,7 @@ action_mosaic(Oiiotool& ot, cspan<const char*> argv)
     }
 
     int widest = 0, highest = 0, nchannels = 0;
+    TypeDesc outtype = TypeUnknown;
     std::vector<ImageRecRef> images(nimages);
     for (int i = nimages - 1; i >= 0; --i) {
         ImageRecRef img = ot.pop();
@@ -4892,6 +4893,7 @@ action_mosaic(Oiiotool& ot, cspan<const char*> argv)
         widest    = std::max(widest, img->spec()->full_width);
         highest   = std::max(highest, img->spec()->full_height);
         nchannels = std::max(nchannels, img->spec()->nchannels);
+        outtype   = TypeDesc::basetype_merge(outtype, img->spec()->format);
     }
 
     auto options = ot.extract_options(command);
@@ -4916,7 +4918,7 @@ action_mosaic(Oiiotool& ot, cspan<const char*> argv)
 
     ImageSpec Rspec(ximages * widest + (ximages - 1) * pad,
                     yimages * highest + (yimages - 1) * pad, nchannels,
-                    TypeDesc::FLOAT);
+                    outtype);
     ImageRecRef R(new ImageRec("mosaic", Rspec, ot.imagecache));
     ot.push(R);
 


### PR DESCRIPTION
`oiiotool --mosaic` was always allocating a `float` buffer for the result.  Instead, make it use the "widest" data type of the input images. So, for example, if you are making a mosaic of uint8 images, the result buffer should be uint8, not have to allocate 4x bigger nor do uint8->float conversions as it pastes the images.
