### PR TITLE
png: a variety of minor optimizations to the PNG writer

### DIFF
--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -1603,10 +1603,10 @@ control aspects of the writing itself:
 
        **Important**: We have noticed that 8 (PNG_FILTER_NONE) is much
        faster than the default of NO_FILTERS (sometimes 3x or more faster),
-       but also makes larger resulting files that are quite a bit larger
-       (sometimes 2x larger). If you need to optimize PNG write speed and
-       are willing to have larger PNG files on disk, you may want to use
-       that value for this attribute.
+       but it also makes the resulting files quite a bit larger (sometimes
+       2x larger). If you need to optimize PNG write speed and are willing
+       to have larger PNG files on disk, you may want to use that value for
+       this attribute.
 
 **Custom I/O Overrides**
 

--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -1602,11 +1602,11 @@ control aspects of the writing itself:
        (``PNG_FILTER_PAETH``).
 
        **Important**: We have noticed that 8 (PNG_FILTER_NONE) is much
-       faster than the default of NO_FILTERS (someimes 3x or more faster),
-       but also makes larger resutling files are quite a bit larger (sometimes
-       2x larger). If you are need to optimize PNG write speed and are willing
-       to have larger PNG files on disk, you may want to use that value for
-       this attribute.
+       faster than the default of NO_FILTERS (sometimes 3x or more faster),
+       but also makes larger resulting files that are quite a bit larger
+       (sometimes 2x larger). If you need to optimize PNG write speed and
+       are willing to have larger PNG files on disk, you may want to use
+       that value for this attribute.
 
 **Custom I/O Overrides**
 

--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -1601,6 +1601,13 @@ control aspects of the writing itself:
        (``PNG_FILTER_UP``), 64 (``PNG_FILTER_AVG``), or 128
        (``PNG_FILTER_PAETH``).
 
+       **Important**: We have noticed that 8 (PNG_FILTER_NONE) is much
+       faster than the default of NO_FILTERS (someimes 3x or more faster),
+       but also makes larger resutling files are quite a bit larger (sometimes
+       2x larger). If you are need to optimize PNG write speed and are willing
+       to have larger PNG files on disk, you may want to use that value for
+       this attribute.
+
 **Custom I/O Overrides**
 
 PNG input and output both support the "custom I/O" feature via the special

--- a/src/png.imageio/png_pvt.h
+++ b/src/png.imageio/png_pvt.h
@@ -723,6 +723,27 @@ write_row(png_structp& sp, png_byte* data)
 
 
 
+/// Write scanlines
+inline bool
+write_rows(png_structp& sp, png_byte* data, int nrows = 0, stride_t ystride = 0)
+{
+    if (setjmp(png_jmpbuf(sp))) {  // NOLINT(cert-err52-cpp)
+        //error ("PNG library error");
+        return false;
+    }
+    if (nrows == 1) {
+        png_write_row(sp, data);
+    } else {
+        png_byte** ptrs = OIIO_ALLOCA(png_byte*, nrows);
+        for (int i = 0; i < nrows; ++i)
+            ptrs[i] = data + i * ystride;
+        png_write_rows(sp, ptrs, png_uint_32(nrows));
+    }
+    return true;
+}
+
+
+
 /// Helper function - error-catching wrapper for png_write_end
 inline void
 write_end(png_structp& sp, png_infop& ip)

--- a/src/png.imageio/pngoutput.cpp
+++ b/src/png.imageio/pngoutput.cpp
@@ -176,7 +176,6 @@ PNGOutput::open(const std::string& name, const ImageSpec& userspec,
     } else if (Strutil::iequals(compression, "none")) {
         png_set_compression_strategy(m_png, Z_NO_COMPRESSION);
         png_set_compression_level(m_png, 0);
-        print("compression zero\n");
     } else {
         png_set_compression_strategy(m_png, Z_DEFAULT_STRATEGY);
     }

--- a/src/png.imageio/pngoutput.cpp
+++ b/src/png.imageio/pngoutput.cpp
@@ -331,7 +331,7 @@ PNGOutput::write_scanline(int y, int z, TypeDesc format, const void* data,
     }
 
     // PNG is always big endian
-    if (need_swap)
+    if (m_need_swap)
         swap_endian((unsigned short*)data, m_spec.width * m_spec.nchannels);
 
     if (!PNG_pvt::write_row(m_png, (png_byte*)data)) {
@@ -384,7 +384,7 @@ PNGOutput::write_scanlines(int ybegin, int yend, int z, TypeDesc format,
     }
 
     // PNG is always big endian
-    if (need_swap)
+    if (m_need_swap)
         swap_endian((unsigned short*)data, nbytes);
 
     if (!PNG_pvt::write_rows(m_png, (png_byte*)data, yend - ybegin,

--- a/src/png.imageio/pngoutput.cpp
+++ b/src/png.imageio/pngoutput.cpp
@@ -310,12 +310,11 @@ bool
 PNGOutput::write_scanline(int y, int z, TypeDesc format, const void* data,
                           stride_t xstride)
 {
-    bool need_swap = (m_spec.format == TypeDesc::UINT16 && littleendian());
     y -= m_spec.y;
     m_spec.auto_stride(xstride, format, spec().nchannels);
     const void* origdata = data;
     data = to_native_scanline(format, data, xstride, m_scratch, m_dither, y, z);
-    if (data == origdata && (m_convert_alpha || need_swap)) {
+    if (data == origdata && (m_convert_alpha || m_need_swap)) {
         m_scratch.assign((unsigned char*)data,
                          (unsigned char*)data + m_spec.scanline_bytes());
         data = &m_scratch[0];
@@ -369,8 +368,7 @@ PNGOutput::write_scanlines(int ybegin, int yend, int z, TypeDesc format,
     size_t npixels = m_spec.width * (yend - ybegin);
     size_t nvals   = npixels * m_spec.nchannels;
     size_t nbytes  = nvals * m_spec.format.size();
-    bool need_swap = (m_spec.format == TypeDesc::UINT16 && littleendian());
-    if (data == origdata && (m_convert_alpha || need_swap)) {
+    if (data == origdata && (m_convert_alpha || m_need_swap)) {
         m_scratch.assign((unsigned char*)data, (unsigned char*)data + nbytes);
         data = m_scratch.data();
     }


### PR DESCRIPTION
* Implement PNGOutput::write_scanlines, previously we only had write_scanline. Sadly, being able to write multiple scanlines at once reduces overhead by much less than I had hoped. But there's a bit of savings, so I'll keep it.

* Rely on libpng's ability to do endianness byte swapping (for new enough libpng). This means that when we do need byte swapping and it's one of the cases where libpng can do it, we can avoid an extra copy.

* New compression recognized: "pngfast", which translates to the Z_BEST_SPEED setting. I don't particularly recommend this, but it's useful for benchmarking.

* New compression recognized: "none", which turns off compression. Also not recommended, as it makes the files much larger. Mostly done for benchmarking and other comparisons.

* Don't unconditionally copy user's data buffer to m_scratch. It's only necessary if there's a data type conversion, stride shuffling, alpha deassociation, or endian swapping. When none of those are needed, we can avoid the extra allocatin and copy, and so now we do. (Sigh, in real use, we're almost always doing the alpha deassociation, so this rarely is a savings.)

* Better documentation on the custom output attribute hint `"png:filter"` noting that a non-default value can make it write PNG files dramatically faster, but with the tradeoff of having much larger files.
