### PR TITLE
Write out proper tiff header version in png EXIF blobs

### DIFF
--- a/src/libOpenImageIO/exif.cpp
+++ b/src/libOpenImageIO/exif.cpp
@@ -1302,6 +1302,8 @@ encode_exif(const ImageSpec& spec, std::vector<char>& blob,
     TIFFHeader head;
     head.tiff_magic   = (endianreq == endian::little) ? 0x4949 : 0x4d4d;
     head.tiff_version = 42;
+    if (endianreq != endian::native)
+         swap_endian(&head.tiff_version);
     // N.B. need to swap_endian head.tiff_diroff  below, once we know the sizes
     append(blob, head);
 

--- a/src/libOpenImageIO/exif.cpp
+++ b/src/libOpenImageIO/exif.cpp
@@ -1303,7 +1303,7 @@ encode_exif(const ImageSpec& spec, std::vector<char>& blob,
     head.tiff_magic   = (endianreq == endian::little) ? 0x4949 : 0x4d4d;
     head.tiff_version = 42;
     if (endianreq != endian::native)
-         swap_endian(&head.tiff_version);
+        swap_endian(&head.tiff_version);
     // N.B. need to swap_endian head.tiff_diroff  below, once we know the sizes
     append(blob, head);
 


### PR DESCRIPTION
## Description

When writing out EXIF headers in PNG files, the `tiff_version` field wasn't handling endianness properly.

This lead to some tools like `exiv2` refusing to process the file at all[1]

[1] https://github.com/Exiv2/exiv2/issues/2745

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [X] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [X] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
