### PR TITLE
testing: Set up placeholders for docs-examples-are-tests

### DIFF
--- a/testsuite/docs-examples-cpp/CMakeLists.txt
+++ b/testsuite/docs-examples-cpp/CMakeLists.txt
@@ -27,19 +27,12 @@ if (DEFINED ENV{SANITIZE})
     add_link_options (-fsanitize=$ENV{SANITIZE})
 endif()
 
-add_executable(docs-examples-imageoutput src/docs-examples-imageoutput.cpp)
-target_link_libraries (docs-examples-imageoutput
-                       PRIVATE OpenImageIO::OpenImageIO)
-
-# Chapters we haven't done yet:
-# add_executable(docs-imageinput src/docs-examples-imageinput.cpp)
-# target_link_libraries (docs-examples-imageinput
-#                        PRIVATE OpenImageIO::OpenImageIO)
-# 
-# add_executable(docs-imagebuf src/docs-examples-imagebuf.cpp)
-# target_link_libraries (docs-examples-imagebuf
-#                        PRIVATE OpenImageIO::OpenImageIO)
-# 
-# add_executable(docs-imagebufalgo src/docs-examples-imagebufalgo.cpp)
-# target_link_libraries (docs-examples-imagebufalgo
-#                        PRIVATE OpenImageIO::OpenImageIO)
+###########################################################################
+# For each chapter example file, build an executable.
+set (chapters imageioapi imageoutput imageinput writingplugins
+             imagecache texturesys imagebuf imagebufalgo)
+foreach (chapter ${chapters})
+    add_executable(docs-examples-${chapter} src/docs-examples-${chapter}.cpp)
+    target_link_libraries (docs-examples-${chapter}
+                           PRIVATE OpenImageIO::OpenImageIO)
+endforeach ()

--- a/testsuite/docs-examples-cpp/run.py
+++ b/testsuite/docs-examples-cpp/run.py
@@ -5,13 +5,28 @@
 # https://github.com/OpenImageIO/oiio
 
 
+if platform.system() == 'Windows' :
+    prefix = "Release\\"
+else :
+    prefix = "./"
+
 # command += "echo test_source_dir=" + test_source_dir + " >> build.txt ;"
 command += run_app("cmake " + test_source_dir + " -DCMAKE_BUILD_TYPE=Release >> build.txt 2>&1", silent=True)
 command += run_app("cmake --build . --config Release >> build.txt 2>&1", silent=True)
-if platform.system() == 'Windows' :
-    command += run_app("Release\\docs-examples-imageoutput")
-else :
-    command += run_app("./docs-examples-imageoutput")
 
-outputs = [ "simple.tif", "scanlines.tif",
-            "out.txt" ]
+# Run the examples for each chapter
+for chapter in [ "imageioapi", "imageoutput", "imageinput", "writingplugins",
+                 "imagecache", "texturesys", "imagebuf", "imagebufalgo" ] :
+    command += run_app(prefix + "docs-examples-" + chapter)
+
+outputs = [
+    # Outputs from the ImageOutput chapter:
+    "simple.tif", "scanlines.tif",
+    # Outputs from the ImageInput chapter:
+
+    # ... etc ... other chapters ...
+
+    # Last, we have the out.txt that captures console output of the test
+    # programs.
+    "out.txt"
+    ]

--- a/testsuite/docs-examples-cpp/src/docs-examples-imagebuf.cpp
+++ b/testsuite/docs-examples-cpp/src/docs-examples-imagebuf.cpp
@@ -1,0 +1,41 @@
+// Copyright Contributors to the OpenImageIO project.
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/OpenImageIO/oiio
+
+
+///////////////////////////////////////////////////////////////////////////
+// This file contains code examples from the ImageBuf chapter of the
+// main OpenImageIO documentation.
+//
+// To add an additional test, replicate the section below. Change
+// "example1" to a helpful short name that identifies the example.
+
+// BEGIN-imagebuf-example1
+#include <OpenImageIO/imageio.h>
+using namespace OIIO;
+
+void example1()
+{
+    //
+    // Example code fragment from the docs goes here.
+    //
+    // It probably should generate either some text output (which will show up
+    // in "out.txt" that captures each test's output), or it should produce a
+    // (small) image file that can be compared against a reference image that
+    // goes in the ref/ subdirectory of this test.
+    //
+}
+// END-imagebuf-example1
+
+//
+///////////////////////////////////////////////////////////////////////////
+
+
+
+int main(int /*argc*/, char** /*argv*/)
+{
+    // Each example function needs to get called here, or it won't execute
+    // as part of the test.
+    example1();
+    return 0;
+}

--- a/testsuite/docs-examples-cpp/src/docs-examples-imagebufalgo.cpp
+++ b/testsuite/docs-examples-cpp/src/docs-examples-imagebufalgo.cpp
@@ -1,0 +1,41 @@
+// Copyright Contributors to the OpenImageIO project.
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/OpenImageIO/oiio
+
+
+///////////////////////////////////////////////////////////////////////////
+// This file contains code examples from the ImageBufAlgo chapter of the
+// main OpenImageIO documentation.
+//
+// To add an additional test, replicate the section below. Change
+// "example1" to a helpful short name that identifies the example.
+
+// BEGIN-imagebufalgo-example1
+#include <OpenImageIO/imageio.h>
+using namespace OIIO;
+
+void example1()
+{
+    //
+    // Example code fragment from the docs goes here.
+    //
+    // It probably should generate either some text output (which will show up
+    // in "out.txt" that captures each test's output), or it should produce a
+    // (small) image file that can be compared against a reference image that
+    // goes in the ref/ subdirectory of this test.
+    //
+}
+// END-imagebufalgo-example1
+
+//
+///////////////////////////////////////////////////////////////////////////
+
+
+
+int main(int /*argc*/, char** /*argv*/)
+{
+    // Each example function needs to get called here, or it won't execute
+    // as part of the test.
+    example1();
+    return 0;
+}

--- a/testsuite/docs-examples-cpp/src/docs-examples-imagecache.cpp
+++ b/testsuite/docs-examples-cpp/src/docs-examples-imagecache.cpp
@@ -1,0 +1,41 @@
+// Copyright Contributors to the OpenImageIO project.
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/OpenImageIO/oiio
+
+
+///////////////////////////////////////////////////////////////////////////
+// This file contains code examples from the ImageCache chapter of the
+// main OpenImageIO documentation.
+//
+// To add an additional test, replicate the section below. Change
+// "example1" to a helpful short name that identifies the example.
+
+// BEGIN-imagecache-example1
+#include <OpenImageIO/imageio.h>
+using namespace OIIO;
+
+void example1()
+{
+    //
+    // Example code fragment from the docs goes here.
+    //
+    // It probably should generate either some text output (which will show up
+    // in "out.txt" that captures each test's output), or it should produce a
+    // (small) image file that can be compared against a reference image that
+    // goes in the ref/ subdirectory of this test.
+    //
+}
+// END-imagecache-example1
+
+//
+///////////////////////////////////////////////////////////////////////////
+
+
+
+int main(int /*argc*/, char** /*argv*/)
+{
+    // Each example function needs to get called here, or it won't execute
+    // as part of the test.
+    example1();
+    return 0;
+}

--- a/testsuite/docs-examples-cpp/src/docs-examples-imageinput.cpp
+++ b/testsuite/docs-examples-cpp/src/docs-examples-imageinput.cpp
@@ -1,0 +1,41 @@
+// Copyright Contributors to the OpenImageIO project.
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/OpenImageIO/oiio
+
+
+///////////////////////////////////////////////////////////////////////////
+// This file contains code examples from the ImageInput chapter of the
+// main OpenImageIO documentation.
+//
+// To add an additional test, replicate the section below. Change
+// "example1" to a helpful short name that identifies the example.
+
+// BEGIN-imageinput-example1
+#include <OpenImageIO/imageio.h>
+using namespace OIIO;
+
+void example1()
+{
+    //
+    // Example code fragment from the docs goes here.
+    //
+    // It probably should generate either some text output (which will show up
+    // in "out.txt" that captures each test's output), or it should produce a
+    // (small) image file that can be compared against a reference image that
+    // goes in the ref/ subdirectory of this test.
+    //
+}
+// END-imageinput-example1
+
+//
+///////////////////////////////////////////////////////////////////////////
+
+
+
+int main(int /*argc*/, char** /*argv*/)
+{
+    // Each example function needs to get called here, or it won't execute
+    // as part of the test.
+    example1();
+    return 0;
+}

--- a/testsuite/docs-examples-cpp/src/docs-examples-imageioapi.cpp
+++ b/testsuite/docs-examples-cpp/src/docs-examples-imageioapi.cpp
@@ -1,0 +1,41 @@
+// Copyright Contributors to the OpenImageIO project.
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/OpenImageIO/oiio
+
+
+///////////////////////////////////////////////////////////////////////////
+// This file contains code examples from the ImageIO API chapter of the
+// main OpenImageIO documentation.
+//
+// To add an additional test, replicate the section below. Change
+// "example1" to a helpful short name that identifies the example.
+
+// BEGIN-imageioapi-example1
+#include <OpenImageIO/imageio.h>
+using namespace OIIO;
+
+void example1()
+{
+    //
+    // Example code fragment from the docs goes here.
+    //
+    // It probably should generate either some text output (which will show up
+    // in "out.txt" that captures each test's output), or it should produce a
+    // (small) image file that can be compared against a reference image that
+    // goes in the ref/ subdirectory of this test.
+    //
+}
+// END-imageioapi-example1
+
+//
+///////////////////////////////////////////////////////////////////////////
+
+
+
+int main(int /*argc*/, char** /*argv*/)
+{
+    // Each example function needs to get called here, or it won't execute
+    // as part of the test.
+    example1();
+    return 0;
+}

--- a/testsuite/docs-examples-cpp/src/docs-examples-imageoutput.cpp
+++ b/testsuite/docs-examples-cpp/src/docs-examples-imageoutput.cpp
@@ -1,3 +1,37 @@
+// Copyright Contributors to the OpenImageIO project.
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/OpenImageIO/oiio
+
+
+///////////////////////////////////////////////////////////////////////////
+// This file contains code examples from the ImageOutput chapter of the
+// main OpenImageIO documentation.
+//
+// To add an additional test, replicate the section below. Change
+// "example1" to a helpful short name that identifies the example.
+
+// BEGIN-imageoutput-example1
+#include <OpenImageIO/imageio.h>
+using namespace OIIO;
+
+void example1()
+{
+    //
+    // Example code fragment from the docs goes here.
+    //
+    // It probably should generate either some text output (which will show up
+    // in "out.txt" that captures each test's output), or it should produce a
+    // (small) image file that can be compared against a reference image that
+    // goes in the ref/ subdirectory of this test.
+    //
+}
+// END-imageoutput-example1
+
+//
+///////////////////////////////////////////////////////////////////////////
+
+
+
 // BEGIN-imageoutput-simple
 #include <OpenImageIO/imageio.h>
 using namespace OIIO;

--- a/testsuite/docs-examples-cpp/src/docs-examples-texturesys.cpp
+++ b/testsuite/docs-examples-cpp/src/docs-examples-texturesys.cpp
@@ -1,0 +1,41 @@
+// Copyright Contributors to the OpenImageIO project.
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/OpenImageIO/oiio
+
+
+///////////////////////////////////////////////////////////////////////////
+// This file contains code examples from the TextureSystem chapter of the
+// main OpenImageIO documentation.
+//
+// To add an additional test, replicate the section below. Change
+// "example1" to a helpful short name that identifies the example.
+
+// BEGIN-texturesys-example1
+#include <OpenImageIO/imageio.h>
+using namespace OIIO;
+
+void example1()
+{
+    //
+    // Example code fragment from the docs goes here.
+    //
+    // It probably should generate either some text output (which will show up
+    // in "out.txt" that captures each test's output), or it should produce a
+    // (small) image file that can be compared against a reference image that
+    // goes in the ref/ subdirectory of this test.
+    //
+}
+// END-texturesys-example1
+
+//
+///////////////////////////////////////////////////////////////////////////
+
+
+
+int main(int /*argc*/, char** /*argv*/)
+{
+    // Each example function needs to get called here, or it won't execute
+    // as part of the test.
+    example1();
+    return 0;
+}

--- a/testsuite/docs-examples-cpp/src/docs-examples-writingplugins.cpp
+++ b/testsuite/docs-examples-cpp/src/docs-examples-writingplugins.cpp
@@ -1,0 +1,41 @@
+// Copyright Contributors to the OpenImageIO project.
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/OpenImageIO/oiio
+
+
+///////////////////////////////////////////////////////////////////////////
+// This file contains code examples from the Writing Plugins chapter of the
+// main OpenImageIO documentation.
+//
+// To add an additional test, replicate the section below. Change
+// "example1" to a helpful short name that identifies the example.
+
+// BEGIN-writingplugins-example1
+#include <OpenImageIO/imageio.h>
+using namespace OIIO;
+
+void example1()
+{
+    //
+    // Example code fragment from the docs goes here.
+    //
+    // It probably should generate either some text output (which will show up
+    // in "out.txt" that captures each test's output), or it should produce a
+    // (small) image file that can be compared against a reference image that
+    // goes in the ref/ subdirectory of this test.
+    //
+}
+// END-writingplugins-example1
+
+//
+///////////////////////////////////////////////////////////////////////////
+
+
+
+int main(int /*argc*/, char** /*argv*/)
+{
+    // Each example function needs to get called here, or it won't execute
+    // as part of the test.
+    example1();
+    return 0;
+}

--- a/testsuite/docs-examples-python/run.py
+++ b/testsuite/docs-examples-python/run.py
@@ -5,8 +5,20 @@
 # https://github.com/OpenImageIO/oiio
 
 
-# Run the script 
-command += pythonbin + " src/docs-examples-imageoutput.py >> out.txt ;"
+# Run the examples for each chapter
+for chapter in [ "imageioapi", "imageoutput", "imageinput", "writingplugins",
+                 "imagecache", "texturesys", "imagebuf", "imagebufalgo" ] :
+    command += pythonbin + " src/docs-examples-" + chapter + ".py >> out.txt ;"
 
-outputs = [ "simple.tif", "scanlines.tif", "out.txt" ]
+outputs = [
+    # Outputs from the ImageOutput chapter:
+    "simple.tif", "scanlines.tif",
+    # Outputs from the ImageInput chapter:
+
+    # ... etc ... other chapters ...
+
+    # Last, we have the out.txt that captures console output of the test
+    # programs.
+    "out.txt"
+    ]
 

--- a/testsuite/docs-examples-python/src/docs-examples-imagebuf.py
+++ b/testsuite/docs-examples-python/src/docs-examples-imagebuf.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+from __future__ import print_function
+from __future__ import absolute_import
+
+
+############################################################################
+# This file contains code examples from the ImageInput chapter of the
+# main OpenImageIO documentation.
+#
+# To add an additional test, replicate the section below. Change
+# "example1" to a helpful short name that identifies the example.
+
+
+# BEGIN-imageinput-example1
+import OpenImageIO as oiio
+import numpy as np
+
+def example1() :
+    #
+    # Example code fragment from the docs goes here.
+    #
+    # It probably should generate either some text output (which will show up
+    # in "out.txt" that captures each test's output), or it should produce a
+    # (small) image file that can be compared against a reference image that
+    # goes in the ref/ subdirectory of this test.
+    #
+    return
+
+# END-imageinput-example1
+
+#
+############################################################################
+
+
+
+
+
+if __name__ == '__main__':
+    # Each example function needs to get called here, or it won't execute
+    # as part of the test.
+    example1()

--- a/testsuite/docs-examples-python/src/docs-examples-imagebuf.py
+++ b/testsuite/docs-examples-python/src/docs-examples-imagebuf.py
@@ -9,14 +9,14 @@ from __future__ import absolute_import
 
 
 ############################################################################
-# This file contains code examples from the ImageInput chapter of the
+# This file contains code examples from the ImageBuf chapter of the
 # main OpenImageIO documentation.
 #
 # To add an additional test, replicate the section below. Change
 # "example1" to a helpful short name that identifies the example.
 
 
-# BEGIN-imageinput-example1
+# BEGIN-imagebuf-example1
 import OpenImageIO as oiio
 import numpy as np
 
@@ -31,7 +31,7 @@ def example1() :
     #
     return
 
-# END-imageinput-example1
+# END-imagebuf-example1
 
 #
 ############################################################################

--- a/testsuite/docs-examples-python/src/docs-examples-imagebufalgo.py
+++ b/testsuite/docs-examples-python/src/docs-examples-imagebufalgo.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+from __future__ import print_function
+from __future__ import absolute_import
+
+
+############################################################################
+# This file contains code examples from the ImageBufAlgo chapter of the
+# main OpenImageIO documentation.
+#
+# To add an additional test, replicate the section below. Change
+# "example1" to a helpful short name that identifies the example.
+
+
+# BEGIN-imagebufalgo-example1
+import OpenImageIO as oiio
+import numpy as np
+
+def example1() :
+    #
+    # Example code fragment from the docs goes here.
+    #
+    # It probably should generate either some text output (which will show up
+    # in "out.txt" that captures each test's output), or it should produce a
+    # (small) image file that can be compared against a reference image that
+    # goes in the ref/ subdirectory of this test.
+    #
+    return
+
+# END-imagebufalgo-example1
+
+#
+############################################################################
+
+
+
+
+
+if __name__ == '__main__':
+    # Each example function needs to get called here, or it won't execute
+    # as part of the test.
+    example1()

--- a/testsuite/docs-examples-python/src/docs-examples-imagecache.py
+++ b/testsuite/docs-examples-python/src/docs-examples-imagecache.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+from __future__ import print_function
+from __future__ import absolute_import
+
+
+############################################################################
+# This file contains code examples from the ImageCache chapter of the
+# main OpenImageIO documentation.
+#
+# To add an additional test, replicate the section below. Change
+# "example1" to a helpful short name that identifies the example.
+
+
+# BEGIN-imagecache-example1
+import OpenImageIO as oiio
+import numpy as np
+
+def example1() :
+    #
+    # Example code fragment from the docs goes here.
+    #
+    # It probably should generate either some text output (which will show up
+    # in "out.txt" that captures each test's output), or it should produce a
+    # (small) image file that can be compared against a reference image that
+    # goes in the ref/ subdirectory of this test.
+    #
+    return
+
+# END-imagecache-example1
+
+#
+############################################################################
+
+
+
+
+
+if __name__ == '__main__':
+    # Each example function needs to get called here, or it won't execute
+    # as part of the test.
+    example1()

--- a/testsuite/docs-examples-python/src/docs-examples-imageinput.py
+++ b/testsuite/docs-examples-python/src/docs-examples-imageinput.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+from __future__ import print_function
+from __future__ import absolute_import
+
+
+############################################################################
+# This file contains code examples from the ImageInput chapter of the
+# main OpenImageIO documentation.
+#
+# To add an additional test, replicate the section below. Change
+# "example1" to a helpful short name that identifies the example.
+
+
+# BEGIN-imageinput-example1
+import OpenImageIO as oiio
+import numpy as np
+
+def example1() :
+    #
+    # Example code fragment from the docs goes here.
+    #
+    # It probably should generate either some text output (which will show up
+    # in "out.txt" that captures each test's output), or it should produce a
+    # (small) image file that can be compared against a reference image that
+    # goes in the ref/ subdirectory of this test.
+    #
+    return
+
+# END-imageinput-example1
+
+#
+############################################################################
+
+
+
+
+
+if __name__ == '__main__':
+    # Each example function needs to get called here, or it won't execute
+    # as part of the test.
+    example1()

--- a/testsuite/docs-examples-python/src/docs-examples-imageioapi.py
+++ b/testsuite/docs-examples-python/src/docs-examples-imageioapi.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+from __future__ import print_function
+from __future__ import absolute_import
+
+
+############################################################################
+# This file contains code examples from the ImageIO API chapter of the
+# main OpenImageIO documentation.
+#
+# To add an additional test, replicate the section below. Change
+# "example1" to a helpful short name that identifies the example.
+
+
+# BEGIN-imageioapi-example1
+import OpenImageIO as oiio
+import numpy as np
+
+def example1() :
+    #
+    # Example code fragment from the docs goes here.
+    #
+    # It probably should generate either some text output (which will show up
+    # in "out.txt" that captures each test's output), or it should produce a
+    # (small) image file that can be compared against a reference image that
+    # goes in the ref/ subdirectory of this test.
+    #
+    return
+
+# END-imageioapi-example1
+
+#
+############################################################################
+
+
+
+
+
+if __name__ == '__main__':
+    # Each example function needs to get called here, or it won't execute
+    # as part of the test.
+    example1()

--- a/testsuite/docs-examples-python/src/docs-examples-imageoutput.py
+++ b/testsuite/docs-examples-python/src/docs-examples-imageoutput.py
@@ -8,6 +8,36 @@ from __future__ import print_function
 from __future__ import absolute_import
 
 
+############################################################################
+# This file contains code examples from the ImageOutput chapter of the
+# main OpenImageIO documentation.
+#
+# To add an additional test, replicate the section below. Change
+# "example1" to a helpful short name that identifies the example.
+
+
+# BEGIN-imageoutput-example1
+import OpenImageIO as oiio
+import numpy as np
+
+def example1() :
+    #
+    # Example code fragment from the docs goes here.
+    #
+    # It probably should generate either some text output (which will show up
+    # in "out.txt" that captures each test's output), or it should produce a
+    # (small) image file that can be compared against a reference image that
+    # goes in the ref/ subdirectory of this test.
+    #
+    return
+
+# END-imageoutput-example1
+
+#
+############################################################################
+
+
+
 # BEGIN-imageoutput-simple
 import OpenImageIO as oiio
 import numpy as np
@@ -54,5 +84,7 @@ def scanlines_write() :
 
 
 if __name__ == '__main__':
+    # Each example function needs to get called here, or it won't execute
+    # as part of the test.
     simple_write()
     scanlines_write()

--- a/testsuite/docs-examples-python/src/docs-examples-texturesys.py
+++ b/testsuite/docs-examples-python/src/docs-examples-texturesys.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+from __future__ import print_function
+from __future__ import absolute_import
+
+
+############################################################################
+# This file contains code examples from the TextureSystem chapter of the
+# main OpenImageIO documentation.
+#
+# To add an additional test, replicate the section below. Change
+# "example1" to a helpful short name that identifies the example.
+
+
+# BEGIN-texturesys-example1
+import OpenImageIO as oiio
+import numpy as np
+
+def example1() :
+    #
+    # Example code fragment from the docs goes here.
+    #
+    # It probably should generate either some text output (which will show up
+    # in "out.txt" that captures each test's output), or it should produce a
+    # (small) image file that can be compared against a reference image that
+    # goes in the ref/ subdirectory of this test.
+    #
+    return
+
+# END-texturesys-example1
+
+#
+############################################################################
+
+
+
+
+
+if __name__ == '__main__':
+    # Each example function needs to get called here, or it won't execute
+    # as part of the test.
+    example1()

--- a/testsuite/docs-examples-python/src/docs-examples-writingplugins.py
+++ b/testsuite/docs-examples-python/src/docs-examples-writingplugins.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/OpenImageIO/oiio
+
+from __future__ import print_function
+from __future__ import absolute_import
+
+
+############################################################################
+# This file contains code examples from the Writing Plugins chapter of the
+# main OpenImageIO documentation.
+#
+# To add an additional test, replicate the section below. Change
+# "example1" to a helpful short name that identifies the example.
+
+
+# BEGIN-writingplugins-example1
+import OpenImageIO as oiio
+import numpy as np
+
+def example1() :
+    #
+    # Example code fragment from the docs goes here.
+    #
+    # It probably should generate either some text output (which will show up
+    # in "out.txt" that captures each test's output), or it should produce a
+    # (small) image file that can be compared against a reference image that
+    # goes in the ref/ subdirectory of this test.
+    #
+    return
+
+# END-writingplugins-example1
+
+#
+############################################################################
+
+
+
+
+
+if __name__ == '__main__':
+    # Each example function needs to get called here, or it won't execute
+    # as part of the test.
+    example1()


### PR DESCRIPTION
I had previously prototyped an instance of this for the ImageOutput chapter.

This patch makes empty placeholders for all of the other API chapters. They don't contain any actual tests or generate any output now, but they do build and run, so people can drop new examples into them without having to worry about how to set up new files for each chapter.
