### PR TITLE
Prevent infinite loop in bit_range_convert

### DIFF
--- a/src/include/OpenImageIO/fmath.h
+++ b/src/include/OpenImageIO/fmath.h
@@ -1229,6 +1229,7 @@ convert_type (const S &src)
 /// shifted fully to the right.
 template<unsigned int FROM_BITS, unsigned int TO_BITS>
 inline OIIO_HOSTDEVICE unsigned int bit_range_convert(unsigned int in) {
+    static_assert(FROM_BITS > 0, "FROM_BITS cannot be 0");
     unsigned int out = 0;
     int shift = TO_BITS - FROM_BITS;
     for (; shift > 0; shift -= FROM_BITS)
@@ -1244,10 +1245,12 @@ inline OIIO_HOSTDEVICE unsigned int
 bit_range_convert(unsigned int in, unsigned int FROM_BITS, unsigned int TO_BITS)
 {
     unsigned int out = 0;
-    int shift = TO_BITS - FROM_BITS;
-    for (; shift > 0; shift -= FROM_BITS)
-        out |= in << shift;
-    out |= in >> -shift;
+    if (FROM_BITS) {
+        int shift = TO_BITS - FROM_BITS;
+        for (; shift > 0; shift -= FROM_BITS)
+            out |= in << shift;
+        out |= in >> -shift;
+    }
     return out;
 }
 


### PR DESCRIPTION
## Description

It was possible for `bit_range_convert` to be called with a 0 for the `FROM_BITS` parameter leading to an infinite loop in its processing.

Fixes #3993 

## Tests

The test image from the above bug is now able to be read correctly.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
