### PR TITLE
Ensure that the tests find the built python module vs an install

### DIFF
--- a/src/cmake/pythonutils.cmake
+++ b/src/cmake/pythonutils.cmake
@@ -133,13 +133,19 @@ macro (setup_python_module)
     # non-python libraries of the same name (which aren't prefixed by "lib"
     # on Windows).
     set_target_properties (${target_name} PROPERTIES
-            LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib/python/site-packages
-            ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib/python/site-packages
+            LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib/python${PYTHON_VERSION}/site-packages/$<CONFIG>/OpenImageIO
+            ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib/python${PYTHON_VERSION}/site-packages/$<CONFIG>/OpenImageIO
             )
 
     install (TARGETS ${target_name}
              RUNTIME DESTINATION ${PYTHON_SITE_DIR} COMPONENT user
              LIBRARY DESTINATION ${PYTHON_SITE_DIR} COMPONENT user)
+
+    add_custom_command (
+        TARGET ${target_name} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy
+                ${CMAKE_CURRENT_SOURCE_DIR}/__init__.py
+                ${CMAKE_BINARY_DIR}/lib/python${PYTHON_VERSION}/site-packages/$<CONFIG>/OpenImageIO/__init__.py)
 
     install(FILES __init__.py DESTINATION ${PYTHON_SITE_DIR})
 

--- a/src/cmake/testing.cmake
+++ b/src/cmake/testing.cmake
@@ -110,8 +110,21 @@ macro (oiio_add_tests)
                              "OIIO_TESTSUITE_ROOT=${_testsuite}"
                              "OIIO_TESTSUITE_SRC=${_testsrcdir}"
                              "OIIO_TESTSUITE_CUR=${_testdir}"
-                             "PYTHONPATH=$<SHELL_PATH:${CMAKE_BINARY_DIR}/lib/python/site-packages;$ENV{PYTHONPATH}>"
                              ${_ats_ENVIRONMENT})
+            if (NOT DEFINED ENV{GITHUB_ACTIONS})
+              # the github actions run all the tests from the dist tree
+              # and do an install prior to running the tests so skip
+              # setting these here
+              if (NOT DEFINED ENV{OpenImageIO_ROOT})
+                # this will ensure the appropriate fonts are found
+                set_property(TEST ${_testname} APPEND PROPERTY ENVIRONMENT
+                  "OpenImageIO_ROOT=${CMAKE_SOURCE_DIR}/src")
+              endif()
+              if (USE_PYTHON)
+                set_property(TEST ${_testname} APPEND PROPERTY ENVIRONMENT
+                  "PYTHONPATH=$<SHELL_PATH:${CMAKE_BINARY_DIR}/lib/python${PYTHON_VERSION}/site-packages/$<CONFIG>;$ENV{PYTHONPATH}>")
+              endif()
+            endif()
             if (NOT ${_ats_testdir} STREQUAL "")
                 set_property(TEST ${_testname} APPEND PROPERTY ENVIRONMENT
                              "OIIO_TESTSUITE_IMAGEDIR=${_ats_testdir}")

--- a/src/cmake/testing.cmake
+++ b/src/cmake/testing.cmake
@@ -110,6 +110,7 @@ macro (oiio_add_tests)
                              "OIIO_TESTSUITE_ROOT=${_testsuite}"
                              "OIIO_TESTSUITE_SRC=${_testsrcdir}"
                              "OIIO_TESTSUITE_CUR=${_testdir}"
+                             "PYTHONPATH=${CMAKE_BINARY_DIR}/lib/python/site-packages:$ENV{PYTHONPATH}"
                              ${_ats_ENVIRONMENT})
             if (NOT ${_ats_testdir} STREQUAL "")
                 set_property(TEST ${_testname} APPEND PROPERTY ENVIRONMENT

--- a/src/cmake/testing.cmake
+++ b/src/cmake/testing.cmake
@@ -110,7 +110,7 @@ macro (oiio_add_tests)
                              "OIIO_TESTSUITE_ROOT=${_testsuite}"
                              "OIIO_TESTSUITE_SRC=${_testsrcdir}"
                              "OIIO_TESTSUITE_CUR=${_testdir}"
-                             "PYTHONPATH=${CMAKE_BINARY_DIR}/lib/python/site-packages:$ENV{PYTHONPATH}"
+                             "PYTHONPATH=$<SHELL_PATH:${CMAKE_BINARY_DIR}/lib/python/site-packages;$ENV{PYTHONPATH}>"
                              ${_ats_ENVIRONMENT})
             if (NOT ${_ats_testdir} STREQUAL "")
                 set_property(TEST ${_testname} APPEND PROPERTY ENVIRONMENT


### PR DESCRIPTION
This may have a slightly messy un-intended consequence of "snap-shotting" pythonpath when configured in a large python env, but eases testing confusion on systems where pythonpath is not yet set, but an (older) copy of OpenImageIO is installed.

This fixes the python tests on my home machine.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
