### PR TITLE
api: first draft for removing nativespec from ImageBuf

### DIFF
--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -1064,11 +1064,10 @@ public:
     /// knowledge of its pixel memory layout.  USE WITH EXTREME CAUTION.
     ImageSpec& specmod();
 
-    /// Return a read-only (const) reference to the "native" image spec
-    /// (that describes the file, which may be slightly different than
-    /// the spec of the ImageBuf, particularly if the IB is backed by an
-    /// ImageCache that is imposing some particular data format or tile
-    /// size).
+    /// Return the "native" channel format that describes the file,
+    /// which may be slightly different than the spec of the ImageBuf,
+    /// particularly if the IB is backed by an ImageCache that is imposing
+    /// some particular data format or tile size.
     ///
     /// This may differ from `spec()` --- for example, if a data format
     /// conversion was requested, if the buffer is backed by an ImageCache
@@ -1076,7 +1075,14 @@ public:
     /// that of the file, or if the file had differing per-channel data
     /// formats (ImageBuf must contain a single data format for all
     /// channels).
-    const ImageSpec& nativespec() const;
+    TypeDesc file_format() const;
+    /// Same as the above for channel specific formats.
+    std::vector<TypeDesc> file_channelformats() const;
+
+    /// DEPRECATED old API. This will now return spec() by default.
+    /// We recommend switching to the new API.
+    /// TODO: uncomment for backwards compatibility once everything else is in place.
+    // const ImageSpec& nativespec() const;
 
     /// Does this ImageBuf have an associated thumbnail?
     bool has_thumbnail() const;

--- a/src/iv/ivimage.cpp
+++ b/src/iv/ivimage.cpp
@@ -119,7 +119,7 @@ std::string
 IvImage::longinfo() const
 {
     if (m_longinfo.empty()) {
-        const ImageSpec& m_spec(nativespec());
+        const ImageSpec& m_spec(spec());
         m_longinfo += "<table>";
         //        m_longinfo += html_table_row (Strutil::fmt::format("<b>{}</b>", m_name.c_str()).c_str(),
         //                                std::string());

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -1255,6 +1255,7 @@ ImageBufImpl::read(int subimage, int miplevel, int chbegin, int chend,
     m_current_subimage = subimage;
     m_current_miplevel = miplevel;
 
+    //! NOTE: m_imagecache can be null, make sure there is a fallback solution
     const ImageSpec& nativespec = *m_imagecache->imagespec(m_name, m_current_subimage);
     if (chend < 0 || chend > nativespec.nchannels)
         chend = nativespec.nchannels;

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -1255,11 +1255,10 @@ ImageBufImpl::read(int subimage, int miplevel, int chbegin, int chend,
     m_current_subimage = subimage;
     m_current_miplevel = miplevel;
 
-    //! TODO: should we pass the number of channels of nativespec()
-    // or consider chbeing/chend are correctly set ?
-    // if (chend < 0 || chend > nativespec().nchannels)
-    //     chend = nativespec().nchannels;
-    // bool use_channel_subset = (chbegin != 0 || chend != nativespec().nchannels);
+    const ImageSpec& nativespec = *m_imagecache->imagespec(m_name, m_current_subimage);
+    if (chend < 0 || chend > nativespec.nchannels)
+        chend = nativespec.nchannels;
+    bool use_channel_subset = (chbegin != 0 || chend != nativespec.nchannels);
 
     if (m_spec.deep) {
         Timer timer;
@@ -1322,9 +1321,8 @@ ImageBufImpl::read(int subimage, int miplevel, int chbegin, int chend,
         force            = true;
         m_spec.nchannels = chend - chbegin;
         m_spec.channelnames.resize(m_spec.nchannels);
-        /// TODO: what to do here ? if we remove m_nativespec, we won't have the channelnames anymore..
         for (int c = 0; c < m_spec.nchannels; ++c)
-            m_spec.channelnames[c] = m_nativespec.channelnames[c + chbegin];
+            m_spec.channelnames[c] = nativespec.channelnames[c + chbegin];
         const std::vector<TypeDesc>& cformats = file_channelformats();
         if (cformats.size()) {
             m_spec.channelformats.resize(m_spec.nchannels);

--- a/src/libOpenImageIO/imagebuf_test.cpp
+++ b/src/libOpenImageIO/imagebuf_test.cpp
@@ -423,7 +423,6 @@ test_read_channel_subset()
            true /*force*/, TypeDesc::FLOAT);
     std::cout << " After reading channels [2,5), we have:\n";
     print(B);
-    OIIO_CHECK_EQUAL(B.nativespec().nchannels, 6);
     OIIO_CHECK_EQUAL(B.spec().nchannels, 3);
     OIIO_CHECK_EQUAL(B.spec().format, TypeDesc::FLOAT);
     OIIO_CHECK_EQUAL(B.spec().channelnames[0], "B");

--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -1124,8 +1124,8 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
     }
 
     // The cache might mess with the apparent data format, so make sure
-    // it's the nativespec that we consult for data format of the file.
-    TypeDesc out_dataformat = src->nativespec().format;
+    // it's the original file format that we consult.
+    TypeDesc out_dataformat = src->file_format();
 
     if (configspec.format != TypeDesc::UNKNOWN)
         out_dataformat = configspec.format;

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -3143,10 +3143,6 @@ ImageCacheImpl::get_cache_dimensions(ImageCacheFile* file,
                   file->subimages());
         return false;
     }
-
-    //! force mip level to zero for now
-    //! TODO: store nativespec in SubImageInfo, and extra overrides in LevelInfo
-    constexpr int miplevel = 0;
     if (miplevel < 0 || miplevel >= file->miplevels(subimage)) {
         if (file->errors_should_issue())
             error("Unknown mip level {} (out of {})", miplevel,

--- a/src/libtexture/imagecache.cpp
+++ b/src/libtexture/imagecache.cpp
@@ -3143,6 +3143,10 @@ ImageCacheImpl::get_cache_dimensions(ImageCacheFile* file,
                   file->subimages());
         return false;
     }
+
+    //! force mip level to zero for now
+    //! TODO: store nativespec in SubImageInfo, and extra overrides in LevelInfo
+    constexpr int miplevel = 0;
     if (miplevel < 0 || miplevel >= file->miplevels(subimage)) {
         if (file->errors_should_issue())
             error("Unknown mip level {} (out of {})", miplevel,

--- a/src/oiiotool/expressions.cpp
+++ b/src/oiiotool/expressions.cpp
@@ -310,7 +310,7 @@ Oiiotool::express_parse_atom(const string_view expr, string_view& s,
                 // OiioTool::print_stats(out, *this, (*img)());
 
                 std::string err;
-                if (!pvt::print_stats(out, "", (*img)(), (*img)().nativespec(),
+                if (!pvt::print_stats(out, "", (*img)(), (*img)().spec(),
                                       ROI(), err))
                     errorfmt("stats", "unable to compute: {}", err);
 

--- a/src/oiiotool/expressions.cpp
+++ b/src/oiiotool/expressions.cpp
@@ -239,7 +239,7 @@ Oiiotool::express_parse_atom(const string_view expr, string_view& s,
             read(img);
             ParamValue tmpparam;
             if (metadata == "nativeformat") {
-                result = img->nativespec(0, 0)->format.c_str();
+                result = img->nativespec(0)->format.c_str();
             } else if (auto p = img->spec(0, 0)->find_attribute(metadata,
                                                                 tmpparam)) {
                 std::string val = ImageSpec::metadata_val(*p);

--- a/src/oiiotool/imagerec.cpp
+++ b/src/oiiotool/imagerec.cpp
@@ -247,6 +247,19 @@ ImageRec::read_nativespec()
 
 
 
+const ImageSpec*
+ImageRec::nativespec(int subimg) const
+{
+    if (subimg < subimages())
+    {
+        ustring uname(name());
+        return m_imagecache->imagespec(uname, subimg);
+    }
+    return nullptr;
+}
+
+
+
 bool
 ImageRec::read(ReadPolicy readpolicy, string_view channel_set)
 {

--- a/src/oiiotool/imagerec.cpp
+++ b/src/oiiotool/imagerec.cpp
@@ -299,7 +299,8 @@ ImageRec::read(ReadPolicy readpolicy, string_view channel_set)
             int new_z_channel     = -1;
             int chbegin = 0, chend = -1;
             if (channel_set.size()) {
-                decode_channel_set(ib->nativespec(), channel_set,
+                //! TODO: now that nativespec() is deprecated what should we do here ?
+                decode_channel_set(ib->spec(), channel_set,
                                    newchannelnames, channel_set_channels,
                                    channel_set_values, eh);
                 for (size_t c = 0, e = channel_set_channels.size(); c < e;
@@ -332,11 +333,11 @@ ImageRec::read(ReadPolicy readpolicy, string_view channel_set)
             TypeDesc convert = TypeDesc::FLOAT;
             if (m_input_dataformat != TypeDesc::UNKNOWN) {
                 convert = m_input_dataformat;
-                if (m_input_dataformat != ib->nativespec().format)
+                if (m_input_dataformat != ib->file_format())
                     m_subimages[s].m_was_direct_read = false;
                 forceread = true;
             } else if (readpolicy & ReadNative)
-                convert = ib->nativespec().format;
+                convert = ib->file_format();
             if (!forceread && convert != TypeDesc::UINT8
                 && convert != TypeDesc::UINT16 && convert != TypeDesc::HALF
                 && convert != TypeDesc::FLOAT) {
@@ -377,11 +378,13 @@ ImageRec::read(ReadPolicy readpolicy, string_view channel_set)
             m_subimages[s].m_specs[m]     = ib->spec();
             // For ImageRec purposes, we need to restore a few of the
             // native settings.
-            const ImageSpec& nativespec(ib->nativespec());
+
+            //! TODO: now that nativespec() is deprecated what should we do here ?
+            const ImageSpec& spec(ib->spec());
             // m_subimages[s].m_specs[m].format = nativespec.format;
-            m_subimages[s].m_specs[m].tile_width  = nativespec.tile_width;
-            m_subimages[s].m_specs[m].tile_height = nativespec.tile_height;
-            m_subimages[s].m_specs[m].tile_depth  = nativespec.tile_depth;
+            m_subimages[s].m_specs[m].tile_width  = spec.tile_width;
+            m_subimages[s].m_specs[m].tile_height = spec.tile_height;
+            m_subimages[s].m_specs[m].tile_depth  = spec.tile_depth;
         }
     }
 

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -5648,7 +5648,7 @@ output_file(Oiiotool& ot, cspan<const char*> argv)
         for (int s = 0, send = ir->subimages(); s < send; ++s) {
             for (int m = 0, mend = ir->miplevels(s); m < mend && ok; ++m) {
                 ImageSpec spec = *ir->spec(s, m);
-                adjust_output_options(filename, spec, ir->nativespec(s, m), ot,
+                adjust_output_options(filename, spec, ir->nativespec(s), ot,
                                       supports_tiles, fileoptions,
                                       (*ir)[s].was_direct_read());
                 if (s > 0 || m > 0) {  // already opened first subimage/level

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -544,11 +544,7 @@ public:
         return subimg < subimages() ? m_subimages[subimg].spec(mip) : NULL;
     }
 
-    const ImageSpec* nativespec(int subimg = 0, int mip = 0) const
-    {
-        return subimg < subimages() ? &((*this)(subimg, mip).nativespec())
-                                    : nullptr;
-    }
+    const ImageSpec* nativespec(int subimg = 0) const;
 
     bool was_output() const { return m_was_output; }
     void was_output(bool val) { m_was_output = val; }

--- a/src/oiiotool/printinfo.cpp
+++ b/src/oiiotool/printinfo.cpp
@@ -257,7 +257,7 @@ OiioTool::print_stats(std::ostream& out, Oiiotool& ot,
         return;
     }
     std::string err;
-    if (!pvt::print_stats(out, indent, input, input.nativespec(), roi, err))
+    if (!pvt::print_stats(out, indent, input, input.spec(), roi, err))
         ot.errorfmt("stats", "unable to compute: {}", err);
 }
 
@@ -472,7 +472,7 @@ print_info_subimage(std::ostream& out, Oiiotool& ot, int current_subimage,
                 std::string err;
                 if (!pvt::print_stats(out, nmip > 1 ? "      " : "    ",
                                       (*img)(current_subimage, m),
-                                      (*img)(current_subimage, m).nativespec(),
+                                      *img->nativespec(),
                                       opt.roi, err))
                     ot.errorfmt("stats", "unable to compute: {}", err);
             }

--- a/src/python/py_imagebuf.cpp
+++ b/src/python/py_imagebuf.cpp
@@ -361,7 +361,9 @@ declare_imagebuf(py::module& m)
              "height"_a = 0, "depth"_a = 0)
         .def("spec", &ImageBuf::spec,
              py::return_value_policy::reference_internal)
-        .def("nativespec", &ImageBuf::nativespec,
+        .def("file_format", &ImageBuf::file_format,
+             py::return_value_policy::reference_internal)
+        .def("file_channelformats", &ImageBuf::file_channelformats,
              py::return_value_policy::reference_internal)
         .def("specmod", &ImageBuf::specmod,
              py::return_value_policy::reference_internal)


### PR DESCRIPTION
Second half of API changes to remove `nativespec` from `ImageCache` and `ImageBuf` for issue: https://github.com/AcademySoftwareFoundation/OpenImageIO/issues/4436

- it currently does not compile, I'm just opening this on to discuss with @lgritz about the changes required.
- I have removed `nativespec()` from the ImageBuf API but this creates a bunch of problems I have not answers for in `ImageBuf::read`