### PR TITLE
ci: Allow special branch names to prune CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ permissions: read-all
 jobs:
 
   aswf-old:
+    if: ${{ ! contains(github.ref, 'windows-only') && ! contains(github.ref, 'macos-only') }}
     name: "(old) ${{matrix.desc}}"
     strategy:
       fail-fast: false
@@ -241,6 +242,7 @@ jobs:
   # Linux Tests
   #
   linux:
+    if: ${{ ! contains(github.ref, 'windows-only') && ! contains(github.ref, 'macos-only') }}
     name: "${{matrix.desc}}"
     uses: ./.github/workflows/build-steps.yml
     with:
@@ -495,6 +497,7 @@ jobs:
   # MacOS Tests
   #
   macos:
+    if: ${{ ! contains(github.ref, 'windows-only') && ! contains(github.ref, 'linux-only') }}
     name: "${{matrix.desc}}"
     uses: ./.github/workflows/build-steps.yml
     with:
@@ -557,6 +560,7 @@ jobs:
   # Windows Tests
   #
   windows:
+    if: ${{ ! contains(github.ref, 'linux-only') && ! contains(github.ref, 'macos-only') }}
     name: "${{matrix.desc}}"
     uses: ./.github/workflows/build-steps.yml
     with:


### PR DESCRIPTION
Quite often I find myself debugging code or CI specific to just one platform.  It makes for much longer iteration for a huge CI job that reruns lots of tests that won't be affected by the changes I'm experimenting with. Sometime I make a commit that places `if: 0` in strategic places to exclude irrelevant batches of tests. But this is a pain to add, and has to be removed again to re-enable the tests prior to turning the experiment into a proper PR.

This PR, then, adds some logic to ci.yml that lets me do the same just with special branch names, rather than needing to edit ci.yml. Any branch you push containing the substring "windows-only" will not run any Linux or MacOS CI tests. And the analogous behavior is added for "macos-only" and "linux-only".

This shouldn't affect any CI jobs in which people are not purposely using those special branch names. You should NOT use these special names for branches from which you submit PRs, since obviously we want every PR to validate on all CI combinations. But it is very helpful for topic branches on your own fork as you are developing and iterating over many CI runs but only need results from one platform.

