### PR TITLE
feat: global attribute to enable/disable formats at runtime

### DIFF
--- a/src/libOpenImageIO/imageio.cpp
+++ b/src/libOpenImageIO/imageio.cpp
@@ -59,11 +59,13 @@ int limit_imagesize_MB(std::min(32 * 1024,
 int imageinput_strict(0);
 ustring font_searchpath(Sysutil::getenv("OPENIMAGEIO_FONTS"));
 ustring plugin_searchpath(OIIO_DEFAULT_PLUGIN_SEARCHPATH);
-std::string format_list;         // comma-separated list of all formats
-std::string input_format_list;   // comma-separated list of readable formats
-std::string output_format_list;  // comma-separated list of writable formats
-std::string extension_list;      // list of all extensions for all formats
-std::string library_list;        // list of all libraries for all formats
+std::string allowed_input_format_list;      // list of input formats to be allowed at runtime 
+std::string allowed_output_format_list;     // list of output formats to be allowed at runtime 
+std::string format_list;                    // comma-separated list of all formats
+std::string input_format_list;              // comma-separated list of readable formats
+std::string output_format_list;             // comma-separated list of writable formats
+std::string extension_list;                 // list of all extensions for all formats
+std::string library_list;                   // list of all libraries for all formats
 int oiio_log_times = Strutil::stoi(Sysutil::getenv("OPENIMAGEIO_LOG_TIMES"));
 std::vector<float> oiio_missingcolor;
 }  // namespace pvt
@@ -439,6 +441,14 @@ attribute(string_view name, TypeDesc type, const void* val)
         oiio_try_all_readers = *(const int*)val;
         return true;
     }
+    if (name == "allowed_input_formats" && type == TypeString) {
+        allowed_input_format_list = std::string(*(const char**)val);
+        return true;
+    }
+    if (name == "allowed_output_formats" && type == TypeString) {
+        allowed_output_format_list = std::string(*(const char**)val);
+        return true;
+    }
 
     return false;
 }
@@ -674,6 +684,20 @@ getattribute(string_view name, TypeDesc type, void* val)
     }
     if (name == "IB_total_image_read_time" && type == TypeFloat) {
         *(float*)val = IB_total_image_read_time;
+        return true;
+    }
+    if (name == "allowed_input_formats" && type == TypeString) {
+        if (allowed_input_format_list.empty()) {
+            return false;
+        }
+        *(std::string*)val = allowed_input_format_list;
+        return true;
+    }
+    if (name == "allowed_output_formats" && type == TypeString) {
+        if (allowed_output_format_list.empty()) {
+            return false;
+        }
+        *(std::string*)val = allowed_output_format_list;
         return true;
     }
     return false;

--- a/src/libOpenImageIO/imageioplugin.cpp
+++ b/src/libOpenImageIO/imageioplugin.cpp
@@ -537,6 +537,25 @@ ImageOutput::create(string_view filename, Filesystem::IOProxy* ioproxy,
         format = filename;
     }
 
+    std::string comma_sep_allowed_output_formats; 
+    if (OIIO::getattribute("allowed_output_formats", TypeString, &comma_sep_allowed_output_formats)) {
+        std::vector<std::string> allowed_output_formats;
+        Strutil::split(comma_sep_allowed_output_formats, allowed_output_formats, ",", -1);
+    
+        bool isValidFormat = 0;
+        for (std::string allowed_format: allowed_output_formats) {
+            if (allowed_format == format) {
+                isValidFormat = 1;
+                break;
+            }
+        }
+    
+        if (!isValidFormat) {
+            OIIO::errorfmt("ImageOutput::create() called: output image format not found in list of allowed formats");
+            return out;
+        }
+    }
+
     ImageOutput::Creator create_function = nullptr;
     {  // scope the lock:
         std::unique_lock<std::recursive_mutex> lock(imageio_mutex);
@@ -629,6 +648,26 @@ ImageInput::create(string_view filename, bool do_open, const ImageSpec* config,
         // If the file had no extension, maybe it was itself the format name
         format = filename;
     }
+
+    std::string comma_sep_allowed_input_formats; 
+    if (OIIO::getattribute("allowed_input_formats", TypeString, &comma_sep_allowed_input_formats)) {
+        std::vector<std::string> allowed_input_formats;
+        Strutil::split(comma_sep_allowed_input_formats, allowed_input_formats, ",", -1);
+    
+        bool isValidFormat = 0;
+        for (std::string allowed_format: allowed_input_formats) {
+            if (allowed_format == format) {
+                isValidFormat = 1;
+                break;
+            }
+        }
+    
+        if (!isValidFormat) {
+            OIIO::errorfmt("ImageInput::create() called: input image format not found in list of allowed formats");
+            return in;
+        }
+    }
+
 
     ImageInput::Creator create_function = nullptr;
     {  // scope the lock:


### PR DESCRIPTION
<!-- This is just a guideline and set of reminders about what constitutes -->
<!-- a good PR. Feel free to delete all this matter and replace it with   -->
<!-- your own detailed message about the PR, assuming you hit all the     -->
<!-- important points made below.                                         -->


## Description
A solve for the issue #4759 

Added a OIIO attribute to enable/disable formats at runtime 

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->
- [ ] Proving input image formats can be restricted at runtime 
- [ ]  Proving output image formats can be restricted at runtime 

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
