### PR TITLE
ci: Various ccache save/restore improvements for CI runs

### DIFF
--- a/.github/workflows/build-steps.yml
+++ b/.github/workflows/build-steps.yml
@@ -106,25 +106,23 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Prepare ccache timestamp
-        id: ccache_cache_keys
-        shell: bash
-        run: echo "date=`date -u +'%Y-%m-%dT%H:%M:%SZ'`" >> $GITHUB_OUTPUT
-      - name: ccache
-        id: ccache
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
-        with:
-          path: ./ccache
-          key: ${{github.job}}-${{inputs.nametag}}-${{steps.ccache_cache_keys.outputs.date}}
-          restore-keys: ${{github.job}}-
-      - name: Setup Nuget.exe (Windows only)
-        if: runner.os == 'Windows'
-        uses: nuget/setup-nuget@a21f25cd3998bf370fde17e3f1b4c12c175172f9 # v2.0.0
       - name: Build setup
         shell: bash
         run: |
             ${{inputs.setenvs}}
             src/build-scripts/ci-startup.bash
+      - name: Prepare ccache timestamp
+        id: ccache_cache_keys
+        shell: bash
+        run: echo "date=`date -u +'%Y-%m-%dT%H:%M:%SZ'`" >> $GITHUB_OUTPUT
+      - name: ccache-restore
+        id: ccache-restore
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          # path: ./ccache
+          key: ${{inputs.nametag}}-${{steps.ccache_cache_keys.outputs.date}}
+          restore-keys: ${{inputs.nametag}}
       - name: Dependencies
         shell: bash
         run: |
@@ -143,6 +141,26 @@ jobs:
         if: inputs.skip_build != '1'
         shell: bash
         run: src/build-scripts/ci-build.bash
+      - name: Check out ABI standard
+        if: inputs.abi_check != ''
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{inputs.abi_check}}
+          path: abi_standard
+      - name: Build ABI standard
+        if: inputs.abi_check != ''
+        shell: bash
+        run: |
+            mkdir -p abi_standard/build
+            pushd abi_standard
+            src/build-scripts/ci-build.bash
+            popd
+      - name: ccache-save
+        id: ccache-save
+        uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ${{inputs.nametag}}-${{steps.ccache_cache_keys.outputs.date}}
       - name: Testsuite
         if: inputs.skip_tests != '1'
         shell: bash
@@ -171,20 +189,6 @@ jobs:
             # sonar-scanner --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}"
             time sonar-scanner --define sonar.host.url="${{ env.SONAR_SERVER_URL }}" --define sonar.cfamily.build-wrapper-output="$BUILD_WRAPPER_OUT_DIR" --define sonar.cfamily.gcov.reportsPath="_coverage" --define sonar.cfamily.threads="$PARALLEL"
         # Consult https://docs.sonarcloud.io/advanced-setup/ci-based-analysis/sonarscanner-cli/ for more information and options
-      - name: Check out ABI standard
-        if: inputs.abi_check != ''
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: ${{inputs.abi_check}}
-          path: abi_standard
-      - name: Build ABI standard
-        if: inputs.abi_check != ''
-        shell: bash
-        run: |
-            mkdir -p abi_standard/build
-            pushd abi_standard
-            src/build-scripts/ci-build.bash
-            popd
       - name: Check ABI
         if: inputs.abi_check != ''
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,11 @@ on:
 
 permissions: read-all
 
+# Allow subsequent pushes to the same PR or REF to cancel any previous jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 
 jobs:
 
@@ -176,20 +181,22 @@ jobs:
       #     egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
       - name: Checkout repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Prepare ccache timestamp
-        id: ccache_cache_keys
-        run: echo "date=`date -u +'%Y-%m-%dT%H:%M:%SZ'`" >> $GITHUB_OUTPUT
-      - name: ccache
-        id: ccache
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
-        with:
-          path: /tmp/ccache
-          key: ${{github.job}}-${{matrix.nametag}}-${{steps.ccache_cache_keys.outputs.date}}
-          restore-keys: ${{github.job}}-
       - name: Build setup
         run: |
             ${{matrix.setenvs}}
             src/build-scripts/ci-startup.bash
+      - name: Prepare ccache timestamp
+        id: ccache_cache_keys
+        shell: bash
+        run: echo "date=`date -u +'%Y-%m-%dT%H:%M:%SZ'`" >> $GITHUB_OUTPUT
+      - name: ccache-restore
+        id: ccache-restore
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          # path: ./ccache
+          key: ${{matrix.nametag}}-${{steps.ccache_cache_keys.outputs.date}}
+          restore-keys: ${{matrix.nametag}}
       - name: Dependencies
         run: |
             ${{matrix.depcmds}}
@@ -197,6 +204,12 @@ jobs:
       - name: Build
         if: matrix.skip_build != '1'
         run: src/build-scripts/ci-build.bash
+      - name: ccache-save
+        id: ccache-save
+        uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ${{matrix.nametag}}-${{steps.ccache_cache_keys.outputs.date}}
       - name: Testsuite
         if: matrix.skip_tests != '1'
         run: src/build-scripts/ci-test.bash
@@ -204,23 +217,6 @@ jobs:
         if: matrix.benchmark == '1'
         shell: bash
         run: src/build-scripts/ci-benchmark.bash
-      - name: Check out ABI standard
-        if: matrix.abi_check != ''
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: ${{matrix.abi_check}}
-          path: abi_standard
-      - name: Build ABI standard
-        if: matrix.abi_check != ''
-        run: |
-            mkdir -p abi_standard/build
-            pushd abi_standard
-            src/build-scripts/ci-build.bash
-            popd
-      - name: Check ABI
-        if: matrix.abi_check != ''
-        run: |
-            src/build-scripts/ci-abicheck.bash ./build abi_standard/build libOpenImageIO libOpenImageIO_Util
       - name: Build Docs
         if: matrix.build_docs == '1'
         run: |
@@ -477,7 +473,7 @@ jobs:
                             WEBP_VERSION=v1.4.0
 
           - desc: clang15 C++17 avx2 exr3.1 ocio2.2
-            nametag: linux-clang14
+            nametag: linux-clang15
             runner: ubuntu-22.04
             cxx_compiler: clang++-15
             cc_compiler: clang-15

--- a/src/build-scripts/ci-build.bash
+++ b/src/build-scripts/ci-build.bash
@@ -54,6 +54,7 @@ if [[ "$BUILDTARGET" != "none" ]] ; then
         echo "Using build wrapper '${OIIO_CMAKE_BUILD_WRAPPER}'"
     fi
     time ${OIIO_CMAKE_BUILD_WRAPPER} cmake --build ${OIIO_BUILD_DIR} --target ${BUILDTARGET} --config ${CMAKE_BUILD_TYPE}
+   ccache --show-stats || true
 fi
 # popd
 

--- a/src/build-scripts/ci-startup.bash
+++ b/src/build-scripts/ci-startup.bash
@@ -13,6 +13,13 @@ export PATH=/usr/local/bin/_ccache:/usr/lib/ccache:$PATH
 export USE_CCACHE=${USE_CCACHE:=1}
 export CCACHE_CPP2=
 export CCACHE_DIR=$HOME/.ccache
+export CCACHE_COMPRESSION=yes
+if [[ "$(which ccache)" != "" ]] ; then
+    # Try to coax dependency building into also using ccache
+    export CMAKE_CXX_COMPILER_LAUNCHER="ccache"
+    export CMAKE_C_COMPILER_LAUNCHER="ccache"
+    ccache -z
+fi
 mkdir -p $CCACHE_DIR
 
 export OpenImageIO_ROOT=$PWD/dist

--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -224,9 +224,6 @@ if (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG)
     add_compile_options ("-fno-math-errno")
 endif ()
 
-# We will use this for ccache and timing
-set (MY_RULE_LAUNCH "")
-
 
 ###########################################################################
 # Use ccache if found
@@ -236,12 +233,18 @@ set (MY_RULE_LAUNCH "")
 # logic here makes it work even if the user is unaware of ccache. If it's
 # not found on the system, it will simply be silently not used.
 option (USE_CCACHE "Use ccache if found" ON)
-find_program (CCACHE_FOUND ccache)
-if (CCACHE_FOUND AND USE_CCACHE)
+find_program (CCACHE_EXE ccache)
+if (CCACHE_EXE AND USE_CCACHE)
     if (CMAKE_COMPILER_IS_CLANG AND USE_QT AND (NOT DEFINED ENV{CCACHE_CPP2}))
         message (STATUS "Ignoring ccache because clang + Qt + env CCACHE_CPP2 is not set")
     else ()
-        set (MY_RULE_LAUNCH ccache)
+        if (NOT ${CXX_COMPILER_LAUNCHER} MATCHES "ccache")
+            set (CXX_COMPILER_LAUNCHER ${CCACHE_EXR} ${CXX_COMPILER_LAUNCHER})
+        endif ()
+        if (NOT ${C_COMPILER_LAUNCHER} MATCHES "ccache")
+            set (C_COMPILER_LAUNCHER ${CCACHE_EXR} ${C_COMPILER_LAUNCHER})
+        endif ()
+        message (STATUS "ccache enabled: ${CCACHE_EXE}")
     endif ()
 endif ()
 
@@ -254,14 +257,8 @@ endif ()
 # set `-j 1` or CMAKE_BUILD_PARALLEL_LEVEL to 1.
 option (TIME_COMMANDS "Time each compile and link command" OFF)
 if (TIME_COMMANDS)
-    set (MY_RULE_LAUNCH "${CMAKE_COMMAND} -E time ${MY_RULE_LAUNCH}")
-endif ()
-
-
-# Note: This must be after any option that alters MY_RULE_LAUNCH
-if (MY_RULE_LAUNCH)
-    set_property (GLOBAL PROPERTY RULE_LAUNCH_COMPILE ${MY_RULE_LAUNCH})
-    set_property (GLOBAL PROPERTY RULE_LAUNCH_LINK ${MY_RULE_LAUNCH})
+    set (CXX_COMPILER_LAUNCHER ${CMAKE_COMMAND} -E time ${CXX_COMPILER_LAUNCHER})
+    set (C_COMPILER_LAUNCHER ${CMAKE_COMMAND} -E time ${C_COMPILER_LAUNCHER})
 endif ()
 
 


### PR DESCRIPTION
Improvements to the way our CI utilizes ccache to speed up build. Ported from OSL:

- Split caching into separate restore/save, and rearrange the step order so we save cache before tests run. This allows us to save the ccache even for jobs with failed tests (where the all-in-one unsplit approach would skip the cache save step for a failed job), or for jobs that we purposely end early (maybe because we see failing tests), not only when all tests finish and succeed. This makes subsequent builds, that we do on the same branch while attempting to fix failures, go faster by using the cache.

- Make subsequent pushes to the same PR or REF to cancel any previous jobs, so if we push updates before the last CI run of the same branch completes, it won't keep those going as useless zombie jobs.

- Change the cache key names we use to remove the github ref to encourage cache reuse across different commits or branches (I think), and to fix a couple errors where we had mis-named things and were sharing caches between jobs when we shouldn't or vice versa.

- Be more careful about the location of the cache, making sure we were for sure telling the GHA cache action to be saving/restoring the same directory location that we told ccache to use as its cache location.

- Use CCACHE_COMPRESSION env var to be extra sure we're using compressed caches to be sure we get the best bang for buck on the limited cache storage we're allowed.

- Set CMAKE_CXX_COMPILER_LAUNCHER and CMAKE_C_COMPILER_LAUNCHER in the shell for CI in the hopes of making more dependencies we build also use ccache.

- Alternate launcher structure -- use LANG_COMPILER_LAUNCHER, not RULE_LAUNCH.

A sampling of typical results:

    test                         build deps     build oiio
    -----------------------      ----------     ----------
    VP 2024 (cold)                N/A            6:22
    VP 2024 (cached)              N/A            0:55 (7x)

    latest rels (cold)            8:29           5:30
    latest rels (cached)          2:24 (3.5x)    0:45 (7.3x)

(The N/A is because that run gets all its dependencies from the container and doesn't have to build any from scratch.)
