### PR TITLE
ci:  Automatically push updates to stubs to the current branch

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -147,6 +147,9 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Install Python
         uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
@@ -171,11 +174,24 @@ jobs:
             ./wheelhouse/*.whl
             ./wheelhouse/OpenImageIO/__init__.pyi
         # if stub validation fails we want to upload the stubs for users to review
-        if: success() || failure()
+#         if: success() || failure()
 
-      # Commit all changed files back to the repository
-      - uses: stefanzweifel/git-auto-commit-action@v6
-        commit_message: "Automatic update to python stubs"
+      - name: Copy stubs to repo
+        run: |
+          pwd
+          ls -la .
+          ls -la ./wheelhouse/
+          if [ -f ./wheelhouse/OpenImageIO/__init__.pyi ]; then
+            echo "Copying stubs into repo"
+            cp ./wheelhouse/OpenImageIO/__init__.pyi ./src/python/stubs/OpenImageIO/__init__.pyi
+          fi
+#         if: failure()
+
+      - name: Commit changed stubs back to the repository
+        uses: stefanzweifel/git-auto-commit-action@v6
+        with:
+          commit_message: "Automatic update to python stubs"
+#         if: failure()
 
   # ---------------------------------------------------------------------------
   # Linux ARM Wheels

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -82,6 +82,10 @@ jobs:
     if: |
       github.event_name != 'schedule' ||
       github.repository == 'AcademySoftwareFoundation/OpenImageIO'
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the
+      # added or changed files to the repository.
+      contents: write
     strategy:
       matrix:
         include:
@@ -168,6 +172,10 @@ jobs:
             ./wheelhouse/OpenImageIO/__init__.pyi
         # if stub validation fails we want to upload the stubs for users to review
         if: success() || failure()
+
+      # Commit all changed files back to the repository
+      - uses: stefanzweifel/git-auto-commit-action@v6
+        commit_message: "Automatic update to python stubs"
 
   # ---------------------------------------------------------------------------
   # Linux ARM Wheels

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -9,7 +9,7 @@ name: Wheel
 
 permissions:
   contents: read
-  id-token: write
+  pull-requests: write
 
 on:
   push:
@@ -82,10 +82,6 @@ jobs:
     if: |
       github.event_name != 'schedule' ||
       github.repository == 'AcademySoftwareFoundation/OpenImageIO'
-    permissions:
-      # Give the default GITHUB_TOKEN write permission to commit and push the
-      # added or changed files to the repository.
-      contents: write
     strategy:
       matrix:
         include:
@@ -147,9 +143,9 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
+#         with:
+#           ref: ${{ github.event.pull_request.head.ref }}
+#           repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Install Python
         uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
@@ -179,19 +175,23 @@ jobs:
       - name: Copy stubs to repo
         run: |
           pwd
-          ls -la .
-          ls -la ./wheelhouse/
           if [ -f ./wheelhouse/OpenImageIO/__init__.pyi ]; then
             echo "Copying stubs into repo"
             cp ./wheelhouse/OpenImageIO/__init__.pyi ./src/python/stubs/OpenImageIO/__init__.pyi
+            git diff
           fi
 #         if: failure()
 
-      - name: Commit changed stubs back to the repository
-        uses: stefanzweifel/git-auto-commit-action@v6
+#       - name: Commit changed stubs back to the repository
+#         uses: stefanzweifel/git-auto-commit-action@v6
+#         with:
+#           commit_message: "Automatic update to python stubs"
+# #         if: failure()
+
+      - uses: parkerbxyz/suggest-changes@v2.0.1
         with:
-          commit_message: "Automatic update to python stubs"
-#         if: failure()
+          comment: 'Please commit the suggested changes from the python stub generator.'
+          event: 'REQUEST_CHANGES'
 
   # ---------------------------------------------------------------------------
   # Linux ARM Wheels

--- a/src/python/stubs/generate_stubs.py
+++ b/src/python/stubs/generate_stubs.py
@@ -209,7 +209,7 @@ def main() -> None:
             print(get_colored_diff(old_text, new_text))
             print("Run `make pystubs` locally and commit the results for review.")
             print("The resulting __init__.pyi file will be uploaded as an artifact on this job.")
-            sys.exit(2)
+            # sys.exit(2)
 
 
 if __name__ == "__main__":

--- a/src/python/stubs/generate_stubs.py
+++ b/src/python/stubs/generate_stubs.py
@@ -30,8 +30,8 @@ class OIIOSignatureGenerator(AdvancedSignatureGenerator):
     sig_matcher = AdvancedSigMatcher(
         signature_overrides={
             # signatures for these special methods include many inaccurate overloads
-            "*.__ne__": "(self, other: object) -> bool",
-            "*.__eq__": "(self, other: object) -> bool",
+            # "*.__ne__": "(self, other: object) -> bool",
+            # "*.__eq__": "(self, other: object) -> bool",
         },
         arg_type_overrides={
             # FIXME: Buffer may in fact be more accurate here


### PR DESCRIPTION
<!-- This is just a guideline and set of reminders about what constitutes -->
<!-- a good PR. Feel free to delete all this matter and replace it with   -->
<!-- your own detailed message about the PR, assuming you hit all the     -->
<!-- important points made below.                                         -->


## Description

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

This simplifies developer workflow by automatically pushing freshly built stubs to the current branch for review. 

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
