### PR TITLE
perf(exr): Speed up OpenEXR non-core header read time

### DIFF
--- a/src/openexr.imageio/exr_pvt.h
+++ b/src/openexr.imageio/exr_pvt.h
@@ -77,13 +77,38 @@ public:
             throw Iex::IoExc("Unexpected end of file.");
         return n;
     }
-    uint64_t tellg() override { return m_io->tell(); }
+
+    uint64_t tellg() override
+    {
+        OIIO_DASSERT(m_io);
+        return m_io->tell();
+    }
+
     void seekg(uint64_t pos) override
     {
+        OIIO_DASSERT(m_io);
         if (!m_io->seek(pos))
             throw Iex::IoExc("File input failed.");
     }
+
     void clear() override {}
+
+#if OPENEXR_CODED_VERSION >= 30300
+    int64_t size() override
+    {
+        OIIO_DASSERT(m_io);
+        return static_cast<int64_t>(m_io->size());
+    }
+
+    bool isStatelessRead() const override { return true; }
+
+    int64_t read(void* buf, uint64_t sz, uint64_t offset) override
+    {
+        OIIO_DASSERT(m_io);
+        return static_cast<int64_t>(
+            m_io->pread(buf, sz, static_cast<int64_t>(offset)));
+    }
+#endif
 
 private:
     Filesystem::IOProxy* m_io = nullptr;


### PR DESCRIPTION
Recent OpenEXR internals changes make header reads via the C++ library dramatically slower if a Imf::IStream subclass does not implement the size() and stateless-read method.

See https://github.com/AcademySoftwareFoundation/openexr/issues/1984

On my laptop, when forcing OIIO to avoid the "core" library and use the C++ API to OpenEXR, this speeds up the reading of small exr files by about 6x.

These changes were introduced with OpenEXR 3.3 and we never changed our side.

(Also opportunistically added a couple DASSERT's to the existing functions.)
