### PR TITLE
build: Propagate CMAKE_MSVC_RUNTIME_LIBRARY

### DIFF
--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -655,6 +655,17 @@ endif ()
 
 
 ###########################################################################
+# Windows: which MSVC runtime library should we use (to override default)?
+# Note that all dependencies need the same choice. We leave this as the
+# default, but allow it to be set by the environment if not explicit, which
+# the built-in CMAKE_MSVC_RUNTIME_LIBRARY does not do on its own.
+#
+if (WIN32)
+    set_from_env (CMAKE_MSVC_RUNTIME_LIBRARY)
+endif ()
+
+
+###########################################################################
 # Any extra logic to be run only for CI builds goes here.
 # We expect our own CI runs to define env variable ${PROJECT_NAME}_CI
 #

--- a/src/cmake/dependency_utils.cmake
+++ b/src/cmake/dependency_utils.cmake
@@ -626,6 +626,11 @@ macro (build_dependency_with_cmake pkgname)
         list(APPEND _pkg_CMAKE_ARGS "-DCMAKE_IGNORE_PATH=${CMAKE_IGNORE_PATH_ESCAPED}")
     endif()
 
+    # Pass along any CMAKE_MSVC_RUNTIME_LIBRARY
+    if (WIN32 AND CMAKE_MSVC_RUNTIME_LIBRARY)
+        list (APPEND _pkg_CMAKE_ARGS -DCMAKE_MSVC_RUNTIME_LIBRARY=${CMAKE_MSVC_RUNTIME_LIBRARY})
+    endif ()
+
     execute_process (COMMAND
         ${CMAKE_COMMAND}
             # Put things in our special local build areas


### PR DESCRIPTION
* Allow CMAKE_MSVC_RUNTIME_LIBRARY to be initialized from an environment variable of the same name. (CMake doesn't do that on its own.)

* If set, propagate CMAKE_MSVC_RUNTIME_LIBRARY to any packages we auto-build within our build system.
