### PR TITLE
Look for boost headers for OpenVDBs older than 12

### DIFF
--- a/src/cmake/modules/FindOpenVDB.cmake
+++ b/src/cmake/modules/FindOpenVDB.cmake
@@ -89,6 +89,16 @@ if (OpenVDB_FOUND)
         set_property(TARGET OpenVDB::openvdb APPEND PROPERTY
             IMPORTED_LOCATION "${OPENVDB_LIBRARIES}")
     endif ()
+
+    # Note: OpenVDB older than 12 needs Boost headers.
+    if (OpenVDB_VERSION VERSION_LESS 12)
+        find_package (Boost)
+        if (Boost_FOUND)
+            list(APPEND OPENVDB_INCLUDES ${Boost_INCLUDE_DIRS})
+        else()
+            unset(OpenVDB_FOUND)
+        endif()
+    endif()
 endif ()
 
 MARK_AS_ADVANCED(


### PR DESCRIPTION
<!-- This is just a guideline and set of reminders about what constitutes -->
<!-- a good PR. Feel free to delete all this matter and replace it with   -->
<!-- your own detailed message about the PR, assuming you hit all the     -->
<!-- important points made below.                                         -->


## Description

Look for boost headers for OpenVDBs older than 12. I was getting issues along the lines of this:
```
C:\Users\bober\packages\openvdb\11.0.0\platform-windows\arch-AMD64\python-3.11\include\openvdb\math\Math.h(13,10): error C1083: Cannot open include file: 'boost/numeric/conversio
n/conversion_traits.hpp': No such file or directory [C:\dev\rpks\openimageio\3.0.9.0\build\df31b1486e506952d10f9e8ae1f90b5a2144114d\_OpenImageIO\working\OpenImageIO-3.0.9.0\build
\src\libOpenImageIO\OpenImageIO.vcxproj]
```
Not too sure if my approach is the best but it fixed it for me on Windows MSVC v143/VS2022. I was building against OpenVDB 11 but I didn't test older versions. OpenVDB 12 I did test and it wasn't needed.

## Tests

Not too sure how to make one, it is more or less a compiling bugfix.


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
