### PR TITLE
ci: Test freetype 2.14 and document that it works

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -431,7 +431,7 @@ jobs:
                             PTEX_VERSION=v2.4.3
                             PUGIXML_VERSION=v1.15
                             WEBP_VERSION=v1.6.0
-                            FREETYPE_VERSION=VER-2-13-3
+                            FREETYPE_VERSION=VER-2-14-0
                             USE_OPENVDB=0
           - desc: bleeding edge gcc14 C++23 py3.12 OCIO/libtiff/exr-main avx2
             nametag: linux-bleeding-edge
@@ -529,7 +529,7 @@ jobs:
                             PTEX_VERSION=v2.4.3
                             PUGIXML_VERSION=v1.15
                             WEBP_VERSION=v1.6.0
-                            FREETYPE_VERSION=VER-2-13-3
+                            FREETYPE_VERSION=VER-2-14-0
                             USE_OPENVDB=0
           - desc: Linux ARM latest releases clang18 C++20 py3.12 exr3.4 ocio2.4
             nametag: linux-arm-latest-releases-clang
@@ -549,7 +549,7 @@ jobs:
                             PTEX_VERSION=v2.4.3
                             PUGIXML_VERSION=v1.15
                             WEBP_VERSION=v1.6.0
-                            FREETYPE_VERSION=VER-2-13-3
+                            FREETYPE_VERSION=VER-2-14-0
                             USE_OPENVDB=0
 
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -73,7 +73,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
  * If you want support for Ptex:
      * Ptex >= 2.3.1 (probably works for older; tested through 2.4.3)
  * If you want to be able to do font rendering into images:
-     * Freetype >= 2.10.0 (tested through 2.13)
+     * Freetype >= 2.10.0 (tested through 2.14)
  * If you want to be able to read "ultra-HDR" embedded in JPEG files:
      * libultrahdr >= 1.3 (tested through 1.4)
  * If you want support for JPEG XL images:


### PR DESCRIPTION
Freetype 2.14 was recently released and just became the default for homebrew.

It seems that no changes are needed on our end and no output references even need to change!
