### PR TITLE
fix(iff): Handle non-zero origin, protect against buffer overflows

### DIFF
--- a/src/iff.imageio/iffinput.cpp
+++ b/src/iff.imageio/iffinput.cpp
@@ -521,6 +521,11 @@ IffInput::read_native_tile(int subimage, int miplevel, int x, int y, int /*z*/,
     x -= m_spec.x;
     y -= m_spec.y;
 
+    if (x < 0 || x >= m_spec.width || y < 0 || y >= m_spec.height) {
+        errorfmt("Tile coordinate is not within the valid pixel data window");
+        return false;
+    }
+
     // tile size that we're reading -- consider if the tile overlaps the image
     // boundary.
     int w  = m_header.width;


### PR DESCRIPTION
IffInput::read_native_tile was simply incorrect for images with nonzero data window origin. Fix!

Also switch the forumulation to use spancpy rather than memcpy, to be a little more careful that we are't overwriting the presumed sizes of the buffers.

And while I'm in there, I realized we can hold the mutex for less time.
