### PR TITLE
fix(api/docs): Fix IBA::set_pixels declaration and docs

### DIFF
--- a/src/doc/imagebuf.rst
+++ b/src/doc/imagebuf.rst
@@ -182,7 +182,7 @@ Getting and setting pixel values
 .. doxygenfunction:: OIIO::ImageBuf::get_pixels(ROI, const image_span<T>&) const
 .. doxygenfunction:: OIIO::ImageBuf::get_pixels(ROI, TypeDesc, const image_span<std::byte>&) const
 .. doxygenfunction:: OIIO::ImageBuf::set_pixels(ROI, const image_span<T>&)
-.. doxygenfunction:: OIIO::ImageBuf::set_pixels(ROI, TypeDesc, const image_span<std::byte>&)
+.. doxygenfunction:: OIIO::ImageBuf::set_pixels(ROI, TypeDesc, const image_span<const std::byte>&)
 
 |
 

--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -1094,7 +1094,7 @@ public:
     ///             Return true if the operation could be completed,
     ///             otherwise return false.
     ///
-    template<typename T> bool set_pixels(ROI roi, const image_span<T> buffer)
+    template<typename T> bool set_pixels(ROI roi, const image_span<T>& buffer)
     {
         return set_pixels(roi, TypeDescFromC<T>::value(),
                           as_image_span_bytes(buffer));


### PR DESCRIPTION
Two places where the docs and header for ImageBuf::set_pixels did not match.

In one case, the docs were right, the declaration was supposed to have a parameter that was a `const image_span<T>&` but the `&` was left out.  Now, if this was an actual linkable function, we wouldn't be able to fix it until a compatibility-breaking boundary. But because it's a template and inline, I believe it is actually safe to fix it in situ without breaking ABI compatibility (and it seems to pass our ABI check in CI).

In the second case, the header was correct but the docs used the wrong declaration (leaving out a `const`) and made the docs fail to pull in the right explanation.

Fixes #4923
