### PR TITLE
ci: if dnf install of ffmpeg fails, wait and try again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,7 @@ jobs:
       PYBIND11_VERSION: ${{matrix.pybind11_ver}}
       PYTHON_VERSION: ${{matrix.python_ver}}
       ABI_CHECK: ${{matrix.abi_check}}
+      USE_FFMPEG: 0
     steps:
       # Install nodejs 20 with glibc 2.17, to work around the face that the
       # GHA runners are insisting on a node version that is too new for the

--- a/src/build-scripts/gh-installdeps.bash
+++ b/src/build-scripts/gh-installdeps.bash
@@ -31,8 +31,8 @@ if [[ "$ASWF_ORG" != ""  ]] ; then
     if [[ "${USE_OPENCV}" != "0" ]] ; then
         time sudo yum install -y opencv opencv-devel || true
     fi
-    if [[ "${USE_FFMPEG}" != "0" ]] ; then
-        time sudo dnf install -y ffmpeg ffmpeg-devel || true
+    if [[ "${USE_FFMPEG:-1}" != "0" ]] ; then
+        time sudo dnf install -y ffmpeg ffmpeg-devel || (sleep 10 && echo "try 2" && time sudo dnf install -y ffmpeg ffmpeg-devel)
     fi
     if [[ "${USE_FREETYPE:-1}" != "0" ]] ; then
         time sudo yum install -y freetype freetype-devel || true


### PR DESCRIPTION
Lately, our retrieval of ffmpeg has been failing intermittently. Perhaps 5-10% of the time? Just enough that most CI runs have one job that fails and the others succeed (and sometimes 2 jobs fail, or all pass).

This patch is based on the hypothesis that the problem is truly transient, and that when it fails, maybe we can just pause 10 seconds and then try again, and it will usually succeed, cutting down on the effective failures rate. So far, so good?
