### PR TITLE
ci: Try to avoid ffmpeg install failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,7 +277,7 @@ jobs:
       # Override required_deps to be 'all' and explicitly list as optional
       # only the ones we are intentionally not testing for those jobs.
       required_deps: ${{ matrix.required_deps || 'all' }}
-      optional_deps: ${{ matrix.optional_deps || 'DCMTK;JXL;Libheif;Nuke;OpenCV;openjph;OpenVDB;Qt5;R3DSDK;'}}${{matrix.optional_deps_append}}
+      optional_deps: ${{ matrix.optional_deps || 'DCMTK;FFmpeg;JXL;Libheif;Nuke;OpenCV;openjph;OpenVDB;Qt5;R3DSDK;'}}${{matrix.optional_deps_append}}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
A small portion of time -- maybe 10%, just enough for many CI workflow runs to have a single job fail -- our attempt to `dnf install ffmpeg` fails.

I thought maybe it was an intermittent, transient failure. But looping to try multiple times with delays in between does not help. A job that fails once either succeeds initially or fails over and over. I'm now leaning toward the belief that rather than a transient failures, there are just a subset of GHA runners that will always fail, and the semi-random nature of our job failures is just random luck of the draw in runner selection.

Anyway, so I'm not going to merge the try-in-a-loop approach. Instead, this PR just makes ffmpeg an optional dependency, so the failures to get the dependency won't fail the OIIO build and therefore the CI.  It seems like most of the time we really do get the dependency, but I'm out of better ideas at the moment.
