### PR TITLE
test: image_span_test reduce benchmark load for debug and CI renders

### DIFF
--- a/src/libOpenImageIO/image_span_test.cpp
+++ b/src/libOpenImageIO/image_span_test.cpp
@@ -19,8 +19,7 @@
 using namespace OIIO;
 
 
-static int iterations = 0;  // 1000000;
-static int ntrials    = 5;
+static int ntrials = 5;
 
 
 
@@ -562,9 +561,9 @@ getargs(int argc, char* argv[])
           "image_span_test -- unit test and benchmarks for OpenImageIO/image_span.h\n" OIIO_INTRO_STRING)
         .usage("image_span_test [options]");
 
-    ap.arg("--iterations %d", &iterations)
-        .help(Strutil::fmt::format("Number of iterations (default: {})",
-                                   iterations));
+    // ap.arg("--iterations %d", &iterations)
+    //     .help(Strutil::fmt::format("Number of iterations (default: {})",
+    //                                iterations));
     ap.arg("--trials %d", &ntrials).help("Number of trials");
 
     ap.parse_args(argc, (const char**)argv);
@@ -577,9 +576,8 @@ main(int argc, char* argv[])
 {
 #if !defined(NDEBUG) || defined(OIIO_CI) || defined(OIIO_CODE_COVERAGE)
     // For the sake of test time, reduce the default iterations for DEBUG,
-    // CI, and code coverage builds. Explicit use of --iters or --trials
+    // CI, and code coverage builds. Explicit use of --trials
     // will override this, since it comes before the getargs() call.
-    iterations /= 10;
     ntrials = 1;
 #endif
 

--- a/src/libutil/simd_test.cpp
+++ b/src/libutil/simd_test.cpp
@@ -43,8 +43,10 @@ getargs(int argc, char* argv[])
              OIIO_INTRO_STRING)
       .usage("simd_test [options]");
 
-    ap.arg("--iterations %d", &iterations)
+    ap.arg("--iters %d", &iterations)
       .help(Strutil::fmt::format("Number of iterations (default: {})", iterations));
+    ap.arg("--iterations %d", &iterations)
+      .hidden();  // obsolete synonym for --iters
     ap.arg("--trials %d", &ntrials)
       .help("Number of trials");
 


### PR DESCRIPTION
Almost all the other unit tests do this, just adding it to image_span_test: automatic reduction in test load for CI and debug renders by doing fewer time trials. This cuts down on runtime for CI, but stil exercises the test code. Command line arguments allow you to override, in cases where you need really good timing fidelity even for a debug run.
