### PR TITLE
admin: Update some license notices

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1152,3 +1152,7 @@ For older release notes, see:
 * [CHANGES-2.x](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/CHANGES-2.x.md).
 * [CHANGES-1.x](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/CHANGES-1.x.md).
 * [CHANGES-0.x](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/CHANGES-0.x.md).
+
+
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Copyright Contributors to the OpenImageIO Project. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -5,3 +5,7 @@ you can read in full [here](https://lfprojects.org/policies/code-of-conduct).
 
 To report incidents or to appeal reports of incidents, send email to
 the Manager of LF Projects at manager@lfprojects.org.
+
+
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Copyright Contributors to the OpenImageIO Project. -->

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -255,3 +255,7 @@ lg@openimageio.org
 * Zach Lewis
 * Ziad Khouri
 * zomgrolf
+
+
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Copyright Contributors to the OpenImageIO Project. -->

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -449,3 +449,7 @@ You do not need any of these packages in order to build or use
 OpenImageIO. But if you are going to contribute to OpenImageIO
 development, you probably want them, since it is required for executing
 OpenImageIO's test suite (when you run "make test").
+
+
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Copyright Contributors to the OpenImageIO Project. -->

--- a/RELICENSING.md
+++ b/RELICENSING.md
@@ -1,3 +1,6 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Copyright Contributors to the OpenImageIO Project. -->
+
 New code entering the OpenImageIO repository from July 1 2023 onward is
 subject to the [Apache 2.0 license](LICENSE.md).
 

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,3 +1,7 @@
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/AcademySoftwareFoundation/OpenImageIO
+
 [requires]
 zlib/1.2.11
 libtiff/4.0.9

--- a/docs/CHANGES-0.x.md
+++ b/docs/CHANGES-0.x.md
@@ -679,3 +679,7 @@ Initial developer release 0.1 (1 Sep 2008):
 * maketx
 * API docs for ImageInput, ImageOutput, writing plugins
 * Linux and OSX
+
+
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Copyright Contributors to the OpenImageIO Project. -->

--- a/docs/CHANGES-1.x.md
+++ b/docs/CHANGES-1.x.md
@@ -4039,3 +4039,7 @@ Developer goodies:
 
 For older release notes, see:
 * [CHANGES-0.x](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/CHANGES-0.x.md).
+
+
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Copyright Contributors to the OpenImageIO Project. -->

--- a/docs/QuickStart.md
+++ b/docs/QuickStart.md
@@ -92,3 +92,7 @@ output.write_image(pixels)
 This is just a simple example to give you a flavor of the different major
 interfaces. For more advanced usage, you may want to explore the
 [documentation](https://docs.openimageio.org).
+
+
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Copyright Contributors to the OpenImageIO Project. -->

--- a/docs/dev/Architecture.md
+++ b/docs/dev/Architecture.md
@@ -197,3 +197,7 @@ image- and file-oriented classes described above. The most important ones are:
   sequence point to the same character memory. In addition to saving memory,
   this makes string assignment and equality comparison as inexpensive as
   integer operations.
+
+
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Copyright Contributors to the OpenImageIO Project. -->

--- a/src/include/OpenImageIO/argparse.h
+++ b/src/include/OpenImageIO/argparse.h
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/AcademySoftwareFoundation/OpenImageIO
 
 

--- a/src/include/OpenImageIO/detail/detail-README.txt
+++ b/src/include/OpenImageIO/detail/detail-README.txt
@@ -9,3 +9,7 @@ anything in those headers or in the pvt or detail namespaces.
 Therefore, anything in this directory may be changed arbitrarily as part of
 a minor version release (but not part of a patch version release, since
 changes here may well change the ABI/linkage).
+
+
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Copyright Contributors to the OpenImageIO Project. -->

--- a/src/include/OpenImageIO/vecparam.h
+++ b/src/include/OpenImageIO/vecparam.h
@@ -13,11 +13,6 @@
 
 OIIO_NAMESPACE_3_1_BEGIN
 
-// NOTE: These interoperable type templates were copied from the
-// [Imath project](http://github.com/AcademySoftwareFoundation/imath),
-// licensed under the same BSD-3-clause license as OpenImageIO.
-
-
 /// @{
 /// @name Detecting interoperable linear algebra types.
 ///

--- a/src/include/OpenImageIO/version.h
+++ b/src/include/OpenImageIO/version.h
@@ -1,3 +1,8 @@
+// Copyright Contributors to the OpenImageIO project.
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/AcademySoftwareFoundation/OpenImageIO
+
+
 // DEPRECATED header OpenImageIO/version.h
 // For back compatibility, just include the new name, oiioversion.h.
 

--- a/src/libutil/strutil.cpp
+++ b/src/libutil/strutil.cpp
@@ -1515,6 +1515,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 IN THE SOFTWARE.
 */
+// SPDX-License-Identifier: MIT
 
 #define UTF8_ACCEPT 0
 #define UTF8_REJECT 12
@@ -1592,6 +1593,7 @@ Strutil::utf8_to_unicode(string_view str, std::vector<uint32_t>& uvec)
 
    René Nyffenegger rene.nyffenegger@adp-gmbh.ch
 */
+// SPDX-License-Identifier: Zlib
 std::string
 Strutil::base64_encode(string_view str)
 {

--- a/src/oiiotool/expressions.cpp
+++ b/src/oiiotool/expressions.cpp
@@ -1,5 +1,5 @@
 // Copyright Contributors to the OpenImageIO project.
-// SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // https://github.com/AcademySoftwareFoundation/OpenImageIO
 
 

--- a/src/python/stubs/CMakeLists.txt
+++ b/src/python/stubs/CMakeLists.txt
@@ -1,3 +1,7 @@
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/AcademySoftwareFoundation/OpenImageIO
+
 
 # Setup the pystub target, which is not built by default.
 

--- a/src/python/stubs/generate_stubs.py
+++ b/src/python/stubs/generate_stubs.py
@@ -1,3 +1,7 @@
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/AcademySoftwareFoundation/OpenImageIO
+
 """
 Script to generate pyi stubs by patching and calling mypy's stubgen tool.
 

--- a/src/rla.imageio/CMakeLists.txt
+++ b/src/rla.imageio/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/AcademySoftwareFoundation/OpenImageIO
 
 add_oiio_plugin (rlainput.cpp rlaoutput.cpp)

--- a/src/sgi.imageio/CMakeLists.txt
+++ b/src/sgi.imageio/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright Contributors to the OpenImageIO project.
-# SPDX-License-Identifier: BSD-3-Clause and Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # https://github.com/AcademySoftwareFoundation/OpenImageIO
 
 add_oiio_plugin (sgiinput.cpp sgioutput.cpp)


### PR DESCRIPTION
Result of our annual license scan.

* Add license notices some places we had missed (mostly documentation).
* Double check some of the code files that are still marked as a mix of Apache 2.0 + BSD, see if there are any remaining lines that are from authors that hadn't relicensed their contributions -- there were a few that had none of those old lines left, so they can be changed to advertise that they are purely Apache 2.0.
