### PR TITLE
ci: unbreak icc/icx CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,30 +251,29 @@ jobs:
             fmt_ver: 7.1.3
             # icc MUST use this older FMT version
             pybind11_ver: v2.9.0
-            setenvs: export USE_ICC=1 USE_OPENVDB=0
+            setenvs: export USE_ICC=1 USE_OPENVDB=0 USE_OPENCV=0
                             OIIO_EXTRA_CPP_ARGS="-fp-model=precise"
                             FREETYPE_VERSION=VER-2-13-0
                             DISABLE_libuhdr=1
             # For icc, use fp-model precise to eliminate needless LSB errors
             # that make test results differ from other platforms.
             optional_deps_append: "LibRaw;Ptex;Qt6"
-          - desc: VFX2023 icx/C++17 py3.10 exr3.1 ocio2.3 qt5.15
+          - desc: VFX2025 icx/C++17 py3.11 exr3.3 ocio2.4 qt5.15
             nametag: linux-vfx2023.icx
             runner: ubuntu-latest
-            container: aswf/ci-osl:2023
+            container: aswf/ci-oiio:2025
             cc_compiler: icx
             cxx_compiler: icpx
-            opencolorio_ver: v2.3.0
-            python_ver: "3.10"
-            pybind11_ver: v2.10.0
+            fmt_ver: 11.2.0
+            python_ver: "3.11"
+            pybind11_ver: v2.13.6
             simd: "avx2,f16c"
             benchmark: 1
-            setenvs: export USE_OPENVDB=0
+            setenvs: export USE_OPENVDB=0 USE_OPENCV=0
                             UHDR_CMAKE_C_COMPILER=gcc
                             UHDR_CMAKE_CXX_COMPILER=g++
             # Building libuhdr with icx results in test failures
-            # so we force using gcc/g++.
-            optional_deps_append: "LibRaw;Ptex;Qt6"
+            optional_deps_append: "LibRaw;Ptex;openjph;Qt6"
           - desc: VFX2024 gcc11/C++17 py3.11 exr3.2 ocio2.3
             nametag: linux-vfx2024
             runner: ubuntu-latest

--- a/src/build-scripts/gh-installdeps.bash
+++ b/src/build-scripts/gh-installdeps.bash
@@ -7,6 +7,7 @@
 
 
 set -ex
+df -h
 
 
 #
@@ -17,8 +18,22 @@ if [[ "$ASWF_ORG" != ""  ]] ; then
 
     #ls /etc/yum.repos.d
 
+    # This will show how much space is taken by each installed package, sorted
+    # by size in KB.
+    # rpm -qa --queryformat '%10{size} - %-25{name} \t %{version}\n' | sort -n
+
+    # I would like this to free space by removing packages we don't need.
+    # BUT IT DOESN'T, because uninstalling a package just ends is visibility
+    # to the runtime, it doesn't remove it from the static container image
+    # that's taking up the disk space. So this is pointless. But leaving it
+    # here to remind myself not to waste time trying it again.
+    # time sudo yum remove -y nsight-compute-2022.3.0 libcublas-devel-11-8 libcublas-11-8 libcusparse-devel-11-8 libnpp-devel-11-8 libnpp-11-8 libcurand-devel-11-8 libcurand-11-8 || true
+    # time sudo yum remove -y nsight-compute-2024.3.1 libcublas-devel-12-6 libcublas-12-6 libcusparse-devel-12-6 libnpp-devel-12-6 libnpp-12-6 libcurand-devel-12-6 libcurand-12-6 || true
+
     # time sudo dnf upgrade --refresh || true
-    time sudo dnf install --nogpgcheck https://mirrors.rpmfusion.org/free/el/rpmfusion-free-release-$(rpm -E %rhel).noarch.rpm -y || true
+    if [[ "${DO_RPMFUSION_REPO:-0}" != "0" ]] ; then
+        time sudo dnf install --nogpgcheck https://mirrors.rpmfusion.org/free/el/rpmfusion-free-release-$(rpm -E %rhel).noarch.rpm -y || true
+    fi
 
     if [[ "$ASWF_VFXPLATFORM_VERSION" == "2022" ]] ; then
         # CentOS 7 based containers need the now-nonexistent centos repo to be
@@ -27,7 +42,7 @@ if [[ "$ASWF_ORG" != ""  ]] ; then
         sed -i 's,^mirrorlist=,#,; s,^#baseurl=http://mirror\.centos\.org/centos/$releasever,baseurl=https://vault.centos.org/7.9.2009,' /etc/yum.repos.d/CentOS-Base.repo
     fi
 
-    time time sudo yum install -y giflib giflib-devel || true
+    # time time sudo yum install -y giflib giflib-devel || true
     if [[ "${USE_OPENCV}" != "0" ]] ; then
         time sudo yum install -y opencv opencv-devel || true
     fi
@@ -47,25 +62,6 @@ if [[ "$ASWF_ORG" != ""  ]] ; then
         time pip3 install ${PIP_INSTALLS} || true
     fi
 
-    if [[ "${CONAN_LLVM_VERSION}" != "" ]] ; then
-        mkdir conan
-        pushd conan
-        # Simple way to conan install just one package:
-        #   conan install clang/${CONAN_LLVM_VERSION}@aswftesting/ci_common1 -g deploy -g virtualenv
-        # But the below method can accommodate multiple requirements:
-        echo "[imports]" >> conanfile.txt
-        echo "., * -> ." >> conanfile.txt
-        echo "[requires]" >> conanfile.txt
-        echo "clang/${CONAN_LLVM_VERSION}@aswftesting/ci_common1" >> conanfile.txt
-        time conan install .
-        echo "--ls--"
-        ls -R .
-        export PATH=$PWD/bin:$PATH
-        export LD_LIBRARY_PATH=$PWD/lib:$LD_LIBRARY_PATH
-        export LLVM_ROOT=$PWD
-        popd
-    fi
-
     if [[ "$CXX" == "icpc" || "$CC" == "icc" || "$USE_ICC" != "" ]] ; then
         # Lock down icc to 2022.1 because newer versions hosted on the Intel
         # repo require a glibc too new for the ASWF CentOS7-based containers
@@ -74,12 +70,10 @@ if [[ "$ASWF_ORG" != ""  ]] ; then
         sudo /usr/bin/yum install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-2022.1.0.x86_64
         set +e; source /opt/intel/oneapi/setvars.sh --config oneapi_2022.1.0.cfg; set -e
     elif [[ "$CXX" == "icpc" || "$CC" == "icc" || "$USE_ICC" != "" || "$CXX" == "icpx" || "$CC" == "icx" || "$USE_ICX" != "" ]] ; then
-        # Lock down icx to 2023.1 because newer versions hosted on the Intel
-        # repo require a libstd++ too new for the ASWF containers we run CI on
-        # because their default install of gcc 9 based toolchain.
         sudo cp src/build-scripts/oneAPI.repo /etc/yum.repos.d
-        sudo yum install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-2023.1.0.x86_64
-        # sudo yum install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
+        sudo yum install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
+        # If we needed to lock down to a particular version, we could:
+        # sudo yum install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-2023.1.0.x86_64
         set +e; source /opt/intel/oneapi/setvars.sh; set -e
         echo "Verifying installation of Intel(r) oneAPI DPC++/C++ Compiler:"
         icpx --version
@@ -224,6 +218,8 @@ if [[ "$USE_ICC" != "" ]] ; then
     export CXX=icpc
     export CC=icc
 fi
+
+df -h
 
 # Save the env for use by other stages
 src/build-scripts/save-env.bash


### PR DESCRIPTION
A few days ago, the icc and icx CI tests started failing, saying they were out of disk space while installing dependencies (specifically, the intel compilers themselves).

Now, the VFX Platform 2023 asf docker image I'm using hasn't changed, and neither has the years-old Intel rpms with the compilers. So maybe the runners themselves just changed again, in a way that adds some pre-installs and leaving us not quite enough disk space for everything else we need?

Asking for a few less things to get installed seems to free up just enough space. And for the icx one, I also swtiched to the 2025 container, which let me use a slightly newer icx version.

Also: Don't try to install giflib needlessly, which speeds up the setup time. And remove some dead code in my dependency setup script.
