### PR TITLE
fix: Fix some legacy 'Linear' color references

### DIFF
--- a/src/dpx.imageio/dpxinput.cpp
+++ b/src/dpx.imageio/dpxinput.cpp
@@ -312,9 +312,9 @@ DPXInput::seek_subimage(int subimage, int miplevel)
 
     // image linearity
     switch (m_dpx.header.Transfer(subimage)) {
-    case dpx::kLinear: m_spec.set_colorspace("Linear"); break;
+    case dpx::kLinear: m_spec.set_colorspace("lin_rec709_scene"); break;
     case dpx::kLogarithmic: m_spec.set_colorspace("KodakLog"); break;
-    case dpx::kITUR709: m_spec.set_colorspace("Rec709"); break;
+    case dpx::kITUR709: m_spec.set_colorspace("srgb_rec709_scene"); break;
     case dpx::kUserDefined:
         if (!std::isnan(m_dpx.header.Gamma()) && m_dpx.header.Gamma() != 0) {
             set_colorspace_rec709_gamma(m_spec, float(m_dpx.header.Gamma()));

--- a/testsuite/python-imagebufalgo/src/test_imagebufalgo.py
+++ b/testsuite/python-imagebufalgo/src/test_imagebufalgo.py
@@ -374,9 +374,9 @@ try:
     b.setpixel(0, 1, (.5,.5,.5,1))
     b.setpixel(1, 1, (1,1,1,1))
     dumpimg (b, msg="linear src=")
-    r = test_iba (ImageBufAlgo.colorconvert, b, "Linear", "sRGB")
+    r = test_iba (ImageBufAlgo.colorconvert, b, "lin_rec709", "sRGB")
     dumpimg (r, msg="to srgb =")
-    r = ImageBufAlgo.colorconvert(r, "sRGB", "Linear")
+    r = ImageBufAlgo.colorconvert(r, "sRGB", "lin_rec709")
     dumpimg (r, msg="back to linear =")
     # Just to test, make a matrix that halves red, doubles green,
     # adds 0.1 to blue.


### PR DESCRIPTION
Convert to modern oiio color space nomenclature.
