### PR TITLE
fix(exr): ACES container writes colorInteropId instead of colorInteropID

### DIFF
--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -1661,13 +1661,13 @@ control aspects of the writing itself:
      - One of `none` (default), `strict`, or `relaxed`.
        If not `none`, the spec will be checked to see if it is compliant
        with the ACES Container format defined in `ST 2065-4`_. If it is,
-       `chromaticities` will be set to the ACES AP0 ones, `colorInteropId`
+       `chromaticities` will be set to the ACES AP0 ones, `colorInteropID`
        will be set to 'lin_ap0_scene' and the `acesImageContainerFlag`
        attribute will be set to 1.
        In `strict` mode, if the spec is non-compliant, the output will
        throw an error and avoid writing the image.
        While in `relaxed` mode, if the spec is non-compliant, `chromaticities`
-       and `colorInteropId` will be set, but `acesImageContainerFlag`
+       and `colorInteropID` will be set, but `acesImageContainerFlag`
        will NOT.
    * - ``oiio:RawColor``
      - int

--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -299,7 +299,7 @@ static constexpr float ACES_AP0_chromaticities[8] = {
     0.32168f, 0.33767f  // white
 };
 
-static const std::string ACES_AP0_colorInteropId = "lin_ap0_scene";
+static const std::string ACES_AP0_colorInteropID = "lin_ap0_scene";
 
 
 bool
@@ -407,10 +407,10 @@ is_aces_container_compliant(const OIIO::ImageSpec& spec, std::string& reason)
     }
 
     // Check attributes with exact values if they exist
-    if (spec.get_string_attribute("oiio:ColorSpace", ACES_AP0_colorInteropId)
-            != ACES_AP0_colorInteropId
-        || spec.get_string_attribute("colorInteropId", ACES_AP0_colorInteropId)
-               != ACES_AP0_colorInteropId) {
+    if (spec.get_string_attribute("oiio:ColorSpace", ACES_AP0_colorInteropID)
+            != ACES_AP0_colorInteropID
+        || spec.get_string_attribute("colorInteropID", ACES_AP0_colorInteropID)
+               != ACES_AP0_colorInteropID) {
         reason
             = "Color space is not lin_ap0_scene as required for an ACES Container.";
         return false;
@@ -448,7 +448,7 @@ set_aces_container_attributes(OIIO::ImageSpec& spec)
 {
     spec.attribute("chromaticities", OIIO::TypeDesc(OIIO::TypeDesc::FLOAT, 8),
                    ACES_AP0_chromaticities);
-    spec.attribute("colorInteropId", ACES_AP0_colorInteropId);
+    spec.attribute("colorInteropID", ACES_AP0_colorInteropID);
     spec.attribute("acesImageContainerFlag", 1);
 }
 

--- a/testsuite/openexr-suite/ref/out.txt
+++ b/testsuite/openexr-suite/ref/out.txt
@@ -351,7 +351,7 @@ strict-out.exr       :    4 x    4, 3 channel, half openexr
     channel list: R, G, B
     acesImageContainerFlag: 1
     chromaticities: 0.7347, 0.2653, 0, 1, 0.0001, -0.077, 0.32168, 0.33767
-    colorInteropId: "lin_ap0_scene"
+    colorInteropID: "lin_ap0_scene"
     compression: "none"
     PixelAspectRatio: 1
     screenWindowCenter: 0, 0


### PR DESCRIPTION
## Description

The EXR reading code was correct. These attribute names are case sensitive in OpenEXR.

## Tests

Test output was updated.

## Checklist:

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
