### PR TITLE
feat(exr): Write OpenEXR colorInteropID metadata based on oiio:ColorSpace

### DIFF
--- a/src/openexr.imageio/exroutput.cpp
+++ b/src/openexr.imageio/exroutput.cpp
@@ -13,6 +13,7 @@
 #include <numeric>
 
 #include <OpenImageIO/Imath.h>
+#include <OpenImageIO/color.h>
 #include <OpenImageIO/platform.h>
 
 #include <OpenEXR/IlmThreadPool.h>
@@ -1024,6 +1025,15 @@ OpenEXROutput::spec_to_header(ImageSpec& spec, int subimage,
                 non_compliance_reason);
             return false;
         }
+    }
+
+    // Set color interop ID from colorspace
+    if (spec.get_string_attribute("colorInteropID").empty()) {
+        const ColorConfig& colorconfig(ColorConfig::default_colorconfig());
+        string_view colorspace = spec.get_string_attribute("oiio:ColorSpace");
+        string_view interop_id = colorconfig.get_color_interop_id(colorspace);
+        if (!interop_id.empty())
+            spec.attribute("colorInteropID", interop_id);
     }
 
     // Deal with all other params

--- a/testsuite/openexr-suite/ref/out.txt
+++ b/testsuite/openexr-suite/ref/out.txt
@@ -369,3 +369,37 @@ Full command line was:
 oiiotool ERROR: -o : Cannot output non-compliant ACES Container in 'strict' mode. REASON: EXR data type is not 'HALF' as required for an ACES Container.
 Full command line was:
 > oiiotool --create 4x4 3 -d float --compression none -sattrib openexr:ACESContainerPolicy strict -o strict-fail.exr
+Reading color_interop_id_scene_linear.exr
+color_interop_id_scene_linear.exr :    4 x    4, 3 channel, float openexr
+    SHA-1: D7699308C38CD04EEB732577A82D31D04E05A339
+    channel list: R, G, B
+    colorInteropID: "lin_ap1_scene"
+    compression: "zip"
+    PixelAspectRatio: 1
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    oiio:ColorSpace: "lin_ap1_scene"
+    oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
+Reading color_interop_id_linear_adobergb.exr
+color_interop_id_linear_adobergb.exr :    4 x    4, 3 channel, float openexr
+    SHA-1: D7699308C38CD04EEB732577A82D31D04E05A339
+    channel list: R, G, B
+    colorInteropID: "lin_adobergb_scene"
+    compression: "zip"
+    PixelAspectRatio: 1
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    oiio:ColorSpace: "lin_adobergb_scene"
+    oiio:subimages: 1
+    openexr:lineOrder: "increasingY"
+Reading color_interop_id_unknown.exr
+color_interop_id_unknown.exr :    4 x    4, 3 channel, float openexr
+    SHA-1: D7699308C38CD04EEB732577A82D31D04E05A339
+    channel list: R, G, B
+    compression: "zip"
+    PixelAspectRatio: 1
+    screenWindowCenter: 0, 0
+    screenWindowWidth: 1
+    oiio:subimages: 1
+    openexr:lineOrder: "increasingY"

--- a/testsuite/openexr-suite/run.py
+++ b/testsuite/openexr-suite/run.py
@@ -83,3 +83,11 @@ command += oiiotool("--create 4x4 3 -d half --compression zip -sattrib openexr:A
 
 # Invalid data type
 command += oiiotool("--create 4x4 3 -d float --compression none -sattrib openexr:ACESContainerPolicy strict -o strict-fail.exr", failureok=True)
+
+# Check color interop ID output
+command += oiiotool("--create 4x4 3 --attrib oiio:ColorSpace scene_linear -o color_interop_id_scene_linear.exr")
+command += info_command("color_interop_id_scene_linear.exr", safematch=True)
+command += oiiotool("--create 4x4 3 --attrib oiio:ColorSpace lin_adobergb_scene -o color_interop_id_linear_adobergb.exr")
+command += info_command("color_interop_id_linear_adobergb.exr", safematch=True)
+command += oiiotool("--create 4x4 3 --attrib oiio:ColorSpace unknown_interop_id -o color_interop_id_unknown.exr")
+command += info_command("color_interop_id_unknown.exr", safematch=True)


### PR DESCRIPTION
## Description

If the colorspace exists and has an interop ID in an OCIO 2.5 config, use that.
Otherwise check if the colorspace is equivalent to a known color interop ID.

## Tests

Tests were added.

## Checklist:

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.