### PR TITLE
feat(JXL): CICP read and write support for JPEG XL

### DIFF
--- a/src/jpegxl.imageio/jxloutput.cpp
+++ b/src/jpegxl.imageio/jxloutput.cpp
@@ -6,6 +6,7 @@
 #include <cstdio>
 #include <vector>
 
+#include <OpenImageIO/color.h>
 #include <OpenImageIO/filesystem.h>
 #include <OpenImageIO/fmath.h>
 #include <OpenImageIO/imageio.h>
@@ -538,6 +539,8 @@ JxlOutput::save_image(const void* data)
         return false;
     }
 
+    bool wrote_colorspace = false;
+
     // Write the ICC profile, if available
     const ParamValue* icc_profile_parameter = m_spec.find_attribute(
         "ICCProfile");
@@ -550,6 +553,59 @@ JxlOutput::save_image(const void* data)
                 != JxlEncoderSetICCProfile(m_encoder.get(), icc_profile,
                                            length)) {
                 errorfmt("JxlEncoderSetICCProfile failed\n");
+            }
+            wrote_colorspace = true;
+        }
+    }
+
+    // Write CICP
+    const ColorConfig& colorconfig(ColorConfig::default_colorconfig());
+    const ParamValue* p    = m_spec.find_attribute("CICP",
+                                                   TypeDesc(TypeDesc::INT, 4));
+    string_view colorspace = m_spec.get_string_attribute("oiio:ColorSpace");
+    cspan<int> cicp        = (p) ? p->as_cspan<int>()
+                             : (!wrote_colorspace) ? colorconfig.get_cicp(colorspace)
+                                                   : cspan<int>();
+    if (!cicp.empty()) {
+        // JXL only has a subset of CICP, only write if supported. Custom
+        // primaries and white point are not currently used but could help
+        // support more CICP codes.
+        JxlColorEncoding color_encoding {};
+        color_encoding.primaries         = JxlPrimaries(cicp[0]);
+        color_encoding.transfer_function = JxlTransferFunction(cicp[1]);
+        color_encoding.color_space       = JXL_COLOR_SPACE_RGB;
+
+        bool supported_primaries = false;
+        bool supported_transfer  = false;
+
+        switch (color_encoding.primaries) {
+        case JXL_PRIMARIES_SRGB:
+        case JXL_PRIMARIES_2100:
+        case JXL_PRIMARIES_P3:
+            supported_primaries        = true;
+            color_encoding.white_point = JXL_WHITE_POINT_D65;
+            break;
+        case JXL_PRIMARIES_CUSTOM:  // Not an actual CICP code in JXL
+            break;
+        }
+
+        switch (color_encoding.transfer_function) {
+        case JXL_TRANSFER_FUNCTION_709:
+        case JXL_TRANSFER_FUNCTION_UNKNOWN:
+        case JXL_TRANSFER_FUNCTION_LINEAR:
+        case JXL_TRANSFER_FUNCTION_SRGB:
+        case JXL_TRANSFER_FUNCTION_PQ:
+        case JXL_TRANSFER_FUNCTION_DCI:
+        case JXL_TRANSFER_FUNCTION_HLG: supported_transfer = true; break;
+        case JXL_TRANSFER_FUNCTION_GAMMA:  // Not an actual CICP code
+            break;
+        }
+
+        if (supported_primaries && supported_transfer) {
+            if (JXL_ENC_SUCCESS
+                != JxlEncoderSetColorEncoding(m_encoder.get(),
+                                              &color_encoding)) {
+                errorfmt("JxlEncoderSetColorEncoding failed\n");
             }
         }
     }

--- a/testsuite/jxl/ref/out.txt
+++ b/testsuite/jxl/ref/out.txt
@@ -19,3 +19,26 @@ tahoe-icc.jxl        :  128 x   96, 3 channel, uint8 jpegxl
     ICCProfile:profile_size: 560
     ICCProfile:profile_version: "2.1.0"
     ICCProfile:rendering_intent: "Perceptual"
+Reading tahoe-cicp-pq.jxl
+tahoe-cicp-pq.jxl    :  128 x   96, 3 channel, uint8 jpegxl
+    SHA-1: 069F1A3E5567349C2D34E535B29913029EF1B09C
+    channel list: R, G, B
+    CICP: 9, 16, 0, 1
+    ICCProfile: 0, 0, 16, 248, 106, 120, 108, 32, 4, 64, 0, 0, 109, 110, 116, 114, ... [4344 x uint8]
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1786276896
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "CC0"
+    ICCProfile:creation_date: "2019:12:01 00:00:00"
+    ICCProfile:creator_signature: "6a786c20"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "0"
+    ICCProfile:model: "0"
+    ICCProfile:platform_signature: "Apple Computer, Inc."
+    ICCProfile:profile_connection_space: "CIELAB"
+    ICCProfile:profile_description: "RGB_D65_202_Per_PeQ"
+    ICCProfile:profile_size: 4344
+    ICCProfile:profile_version: "4.4.0"
+    ICCProfile:rendering_intent: "Perceptual"
+    oiio:ColorSpace: "pq_rec2020_display"

--- a/testsuite/jxl/run.py
+++ b/testsuite/jxl/run.py
@@ -10,6 +10,9 @@ command += oiiotool ("../common/tahoe-tiny.tif --iccread ref/test-jxl.icc -o tah
 command += info_command ("tahoe-icc.jxl", safematch=True)
 command += oiiotool ("tahoe-icc.jxl --iccwrite test-jxl.icc")
 
+command += oiiotool ("../common/tahoe-tiny.tif --cicp \"9,16,9,1\" -o tahoe-cicp-pq.jxl")
+command += info_command ("tahoe-cicp-pq.jxl", safematch=True)
+
 outputs = [
             "test-jxl.icc",
             "out.txt"


### PR DESCRIPTION
## Description

The JPEG XL color encoding metadata only supports a subset of CICP. So for
example `srgb_p3d65_display` and `pq_rec2020_display` are supported, but
`g26_xyzd65_display` is not.

Custom primaries, custom white point and arbitrary gamma could be used to
support more, but I didn't implement that.

## Tests

Tests for read and write were added.

## Checklist:

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.