### PR TITLE
fix(idiff): Fail comparison when images have different dimensions

### DIFF
--- a/src/libOpenImageIO/imagebufalgo_yee.cpp
+++ b/src/libOpenImageIO/imagebufalgo_yee.cpp
@@ -52,7 +52,7 @@ public:
         if (lev >= PYRAMID_MAX_LEVELS)
             return 0.0f;
         else
-            return level[lev].getchannel(x, y, 0, 1);
+            return level[lev].getchannel(x, y, 0, 0);
     }
 
 #if 0 /* unused */
@@ -65,7 +65,7 @@ public:
     float operator()(int x, int y, int lev) const
     {
         OIIO_DASSERT(lev < PYRAMID_MAX_LEVELS);
-        return level[lev].getchannel(x, y, 0, 1);
+        return level[lev].getchannel(x, y, 0, 0);
     }
 #endif
 

--- a/testsuite/diff/ref/out-fmt6.txt
+++ b/testsuite/diff/ref/out-fmt6.txt
@@ -16,7 +16,7 @@ Computing diff of "img1.exr" vs "img2.exr"
   121 pixels (2.95%) over 1e-06
 FAILURE
 Computing perceptual diff of "img1.exr" vs "img2.exr"
-  Max error  = 1.0 @ (5, 17, R)  values are 0.1, 0.1, 0.1 vs 0.1, 0.6, 0.1
+  Max error  = 10.0 @ (5, 17, R)  values are 0.1, 0.1, 0.1 vs 0.1, 0.6, 0.1
   121 pixels (2.95%) failed the perceptual test
 FAILURE
 Computing perceptual diff of "img1.exr" vs "img1.exr"
@@ -26,7 +26,7 @@ Comparing "img1.exr" and "img2.exr"
   Mean error = 0
   RMS error = 0
   Peak SNR = 0
-  Max error  = 1 @ (5, 17, R)  values are 0.1, 0.1, 0.1 vs 0.1, 0.6, 0.1
+  Max error  = 10 @ (5, 17, R)  values are 0.1, 0.1, 0.1 vs 0.1, 0.6, 0.1
   0 pixels (0%) over 0.008
   121 pixels (2.95%) over 0.004
   121 pixels (2.9541%) failed the perceptual test
@@ -38,7 +38,7 @@ Comparing "img1.exr" and "img2.exr"
   Mean error = 0
   RMS error = 0
   Peak SNR = 0
-  Max error  = 1 @ (5, 17, R)  values are 0.1, 0.1, 0.1 vs 0.1, 0.6, 0.1
+  Max error  = 10 @ (5, 17, R)  values are 0.1, 0.1, 0.1 vs 0.1, 0.6, 0.1
   0 pixels (0%) over 0.008
   121 pixels (2.95%) over 1.0
   121 pixels (2.9541%) failed the perceptual test

--- a/testsuite/diff/ref/out.txt
+++ b/testsuite/diff/ref/out.txt
@@ -16,7 +16,7 @@ Computing diff of "img1.exr" vs "img2.exr"
   121 pixels (2.95%) over 1e-06
 FAILURE
 Computing perceptual diff of "img1.exr" vs "img2.exr"
-  Max error  = 1 @ (5, 17, R)  values are 0.1, 0.1, 0.1 vs 0.1, 0.6, 0.1
+  Max error  = 10 @ (5, 17, R)  values are 0.1, 0.1, 0.1 vs 0.1, 0.6, 0.1
   121 pixels (2.95%) failed the perceptual test
 FAILURE
 Computing perceptual diff of "img1.exr" vs "img1.exr"
@@ -26,7 +26,7 @@ Comparing "img1.exr" and "img2.exr"
   Mean error = 0
   RMS error = 0
   Peak SNR = 0
-  Max error  = 1 @ (5, 17, R)  values are 0.1, 0.1, 0.1 vs 0.1, 0.6, 0.1
+  Max error  = 10 @ (5, 17, R)  values are 0.1, 0.1, 0.1 vs 0.1, 0.6, 0.1
   0 pixels (0%) over 0.008
   121 pixels (2.95%) over 0.004
   121 pixels (2.9541%) failed the perceptual test
@@ -38,7 +38,7 @@ Comparing "img1.exr" and "img2.exr"
   Mean error = 0
   RMS error = 0
   Peak SNR = 0
-  Max error  = 1 @ (5, 17, R)  values are 0.1, 0.1, 0.1 vs 0.1, 0.6, 0.1
+  Max error  = 10 @ (5, 17, R)  values are 0.1, 0.1, 0.1 vs 0.1, 0.6, 0.1
   0 pixels (0%) over 0.008
   121 pixels (2.95%) over 1
   121 pixels (2.9541%) failed the perceptual test


### PR DESCRIPTION
Previously, idiff would not explicitly fail when comparing images with different dimensions. Both numeric and perceptual comparisons use roi_union which silently handles dimension differences by comparing against black pixels for non-overlapping regions.

This fix adds an explicit dimension check before any comparison to ensure images with different sizes or channel counts fail with ErrDifferentSize (exit code 3) and print a clear error message.

Fixes #4948

<!-- This is just a guideline and set of reminders about what constitutes -->
<!-- a good PR. Feel free to delete all this matter and replace it with   -->
<!-- your own detailed message about the PR, assuming you hit all the     -->
<!-- important points made below.                                         -->


## Description

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
