### PR TITLE
Speedup to detect the existence of files on Windows

### DIFF
--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -330,8 +330,15 @@ Filesystem::path_is_absolute(string_view path, bool dot_is_absolute)
 bool
 Filesystem::exists(string_view path) noexcept
 {
+#ifdef _WIN32
+    // filesystem::exists is slow on Windows for network paths, so use the
+    // WinAPI directly
+    return INVALID_FILE_ATTRIBUTES
+           != GetFileAttributesW(Strutil::utf8_to_utf16wstring(path).c_str());
+#else
     error_code ec;
     return filesystem::exists(u8path(path), ec);
+#endif
 }
 
 


### PR DESCRIPTION
## Description
On Windows, `Filesystem::exists` forward the call to `std::filesystem::exists`, and finally calls `_std_fs_get_stats` . `_std_fs_get_stats`  is slow if the argument is a netwok path.

## Tests
No, performance related.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
