### PR TITLE
ci: build_Ptex.bash should build Ptex using C++17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -463,7 +463,7 @@ jobs:
                             LIBRAW_VERSION=0.21.4
                             LIBTIFF_VERSION=v4.7.1
                             OPENJPEG_VERSION=v2.5.4
-                            PTEX_VERSION=v2.4.3
+                            PTEX_VERSION=v2.5.0
                             PUGIXML_VERSION=v1.15
                             WEBP_VERSION=v1.6.0
                             FREETYPE_VERSION=VER-2-14-0

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -71,7 +71,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
  * If you want support for WebP images:
      * WebP >= 1.1 (tested through 1.6)
  * If you want support for Ptex:
-     * Ptex >= 2.3.1 (probably works for older; tested through 2.4.3)
+     * Ptex >= 2.3.1 (probably works for older; tested through 2.5)
  * If you want to be able to do font rendering into images:
      * Freetype >= 2.10.0 (tested through 2.14)
  * If you want to be able to read "ultra-HDR" embedded in JPEG files:

--- a/src/build-scripts/build_Ptex.bash
+++ b/src/build-scripts/build_Ptex.bash
@@ -33,6 +33,7 @@ git checkout ${PTEX_VERSION} --force
 
 time cmake -S . -B ${PTEX_BUILD_DIR} -DCMAKE_BUILD_TYPE=Release \
            -DCMAKE_INSTALL_PREFIX=${PTEX_INSTALL_DIR} \
+           -DCMAKE_CXX_STANDARD=17 \
            ${PTEX_CONFIG_OPTS}
 time cmake --build ${PTEX_BUILD_DIR} --config Release --target install
 


### PR DESCRIPTION
If we don't specify anything, it seems that Ptex will think it's using C++98, which it is in fact not capable of doing.

Meanwhile, since OIIO's own minimum requirement is C++17, it certainly meand that any compiler we're using can support 17 as a minimum when building Ptex as well.
