### PR TITLE
ci: unbreak CI by adjusting Ubuntu installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -502,7 +502,7 @@ jobs:
             # Ensure we are testing all the deps we think we are. We would
             # like this test to have minimal missing dependencies.
             required_deps: all
-            optional_deps: 'CUDAToolkit;DCMTK;JXL;Nuke;OpenCV;OpenGL;OpenVDB;R3DSDK'
+            optional_deps: 'CUDAToolkit;DCMTK;JXL;libuhdr;Nuke;OpenCV;OpenGL;openjph;R3DSDK;'
           - desc: all local builds gcc12 C++17 avx2 exr3.2 ocio2.3
             nametag: linux-local-builds
             runner: ubuntu-22.04
@@ -517,18 +517,19 @@ jobs:
                             PTEX_VERSION=v2.4.2
                             PUGIXML_VERSION=v1.14
                             WEBP_VERSION=v1.4.0
-          - desc: clang15 C++17 avx2 exr3.1 ocio2.3
-            nametag: linux-clang15
-            runner: ubuntu-22.04
-            cxx_compiler: clang++-15
-            cc_compiler: clang-15
+          - desc: clang18 C++17 avx2 exr3.1 ocio2.3
+            nametag: linux-clang18
+            runner: ubuntu-24.04
+            cxx_compiler: clang++
+            cc_compiler: clang
             cxx_std: 17
             fmt_ver: 10.1.1
             opencolorio_ver: v2.3.0
             openexr_ver: v3.1.13
             pybind11_ver: v2.12.0
-            python_ver: "3.10"
+            python_ver: "3.12"
             simd: avx2,f16c
+            setenvs: export USE_OPENVDB=0
           - desc: Linux ARM latest releases gcc14 C++20 py3.12 exr3.4 ocio2.4
             nametag: linux-arm-latest-releases
             runner: ubuntu-24.04-arm

--- a/src/build-scripts/gh-installdeps.bash
+++ b/src/build-scripts/gh-installdeps.bash
@@ -96,14 +96,17 @@ else
     if [[ "${SKIP_SYSTEM_DEPS_INSTALL}" != "1" ]] ; then
         time sudo apt-get -q install -y --fix-missing \
             git cmake ninja-build ccache g++ \
-            libilmbase-dev libopenexr-dev \
-            libtiff-dev libgif-dev libpng-dev \
+            libtiff-dev libgif-dev libpng-dev libjpeg-dev \
             libraw-dev libwebp-dev \
             libavcodec-dev libavformat-dev libswscale-dev libavutil-dev \
             dcmtk libopenvdb-dev \
             libfreetype6-dev \
             libopencolorio-dev \
-            libtbb-dev || true
+            libtbb-dev \
+            libdeflate-dev bzip2
+        # Iffy ones get the "|| true" treatment so failure is ok
+        time sudo apt-get -q install -y --fix-missing \
+            libjxl-dev || true
     fi
     if [[ "${USE_OPENCV}" != "0" ]] && [[ "${INSTALL_OPENCV}" != "0" ]] ; then
         sudo apt-get -q install -y --fix-missing libopencv-dev || true
@@ -131,6 +134,10 @@ else
        time sudo apt-get -q install -y libheif-plugin-aomdec \
             libheif-plugin-aomenc libheif-plugin-libde265 \
             libheif-plugin-x265 libheif-dev || true
+    fi
+
+    if [[ "${USE_FFMPEG}" != "0" ]] ; then
+        time sudo apt-get -q install -y ffmpeg || true
     fi
 
     export CMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu:$CMAKE_PREFIX_PATH


### PR DESCRIPTION
The default Ubuntu images keep shifing around. Last week, some packages that used to be installed disappeared. Need to adjust what we install in gh-installdeps.bash, and slightly adjust the optional deps in ci.yml to allow some things that seem to be only on some runners to be missing. Also bump the clang test to clang18 on an ubuntu-24 runner (from clang 15 on ubuntu 22).

Gets us back to all-passing CI after a week of all sorts of failures in tests that used to work.
