### PR TITLE
perf: IBA::resample improvements to speed up 20x or more

### DIFF
--- a/src/libOpenImageIO/imagebufalgo_test.cpp
+++ b/src/libOpenImageIO/imagebufalgo_test.cpp
@@ -641,6 +641,41 @@ test_zover()
 
 
 
+// Test ImageBuf::resample
+void
+test_resample()
+{
+    std::cout << "test resample\n";
+
+    // Timing
+    Benchmarker bench;
+    bench.units(Benchmarker::Unit::ms);
+
+    ImageSpec spec_hd_rgba_f(1920, 1080, 4, TypeFloat);
+    ImageSpec spec_hd_rgba_u8(1920, 1080, 4, TypeUInt8);
+    ImageBuf buf_hd_rgba_f(spec_hd_rgba_f);
+    ImageBuf buf_hd_rgba_u8(spec_hd_rgba_u8);
+    float red_rgba[] = { 1.0, 0.0, 0.0, 1.0 };
+    ImageBufAlgo::fill(buf_hd_rgba_f, red_rgba);
+    ImageBufAlgo::fill(buf_hd_rgba_u8, red_rgba);
+    ImageBuf smallf(ImageSpec(1024, 512, 4, TypeFloat));
+    ImageBuf smallu8(ImageSpec(1024, 512, 4, TypeUInt8));
+    bench("  IBA::resample HD->1024x512 rgba f->f    interp   ",
+          [&]() { ImageBufAlgo::resample(smallf, buf_hd_rgba_f, true); });
+    bench("  IBA::resample HD->1024x512 rgba f->u8   interp   ",
+          [&]() { ImageBufAlgo::resample(smallu8, buf_hd_rgba_f, true); });
+    bench("  IBA::resample HD->1024x512 rgba u8->u8  interp   ",
+          [&]() { ImageBufAlgo::resample(smallu8, buf_hd_rgba_u8, true); });
+    bench("  IBA::resample HD->1024x512 rgba f->f   no interp ",
+          [&]() { ImageBufAlgo::resample(smallf, buf_hd_rgba_f, false); });
+    bench("  IBA::resample HD->1024x512 rgba f->u8  no interp ",
+          [&]() { ImageBufAlgo::resample(smallu8, buf_hd_rgba_f, false); });
+    bench("  IBA::resample HD->1024x512 rgba u8->u8 no interp ",
+          [&]() { ImageBufAlgo::resample(smallu8, buf_hd_rgba_u8, false); });
+}
+
+
+
 // Tests ImageBufAlgo::compare
 void
 test_compare()
@@ -1581,6 +1616,7 @@ main(int argc, char** argv)
     test_over(TypeFloat);
     test_over(TypeHalf);
     test_zover();
+    test_resample();
     test_compare();
     test_isConstantColor();
     test_isConstantChannel();


### PR DESCRIPTION
For IBA::resample() when bilinear interpolation is used, almost all of the expense was due to its relying on ImageBuf::interppixel which is simple but constructs a new ImageBuf::ConstIterator EVERY TIME, which is very expensive.

Reimplement in a way that reuses a single iterator. This speeds up IBA::resample by 20x or more typicaly.

Also refactor resample to pull the handling of deep images into a separate helper function and out of the main inner loop. And add some benchmarking.
