### PR TITLE
ci: Speed up macos15 intel variant by not installing Qt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -626,7 +626,7 @@ jobs:
             python_ver: "3.13"
             simd: sse4.2,avx2
             ctest_test_timeout: 1200
-            setenvs: export MACOSX_DEPLOYMENT_TARGET=12.0
+            setenvs: export MACOSX_DEPLOYMENT_TARGET=12.0 INSTALL_QT=0
             benchmark: 1
           - desc: MacOS-14-ARM aclang15/C++20/py3.13
             runner: macos-14


### PR DESCRIPTION
The Intel MacOS 15 CI testing is getting dicier... lots of times, Homebrew doesn't have cached versions of updated packages, so it tries to build from source, which takes forever. The big culprit today is Qt. So, basically, just on this one CI job variant, don't ask it to install Qt. If it's there, it's there. If not, just skip it. It's tested plenty in other variants.
