### PR TITLE
ci/deps: Freetype adjustments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -466,7 +466,7 @@ jobs:
                             PTEX_VERSION=v2.5.0
                             PUGIXML_VERSION=v1.15
                             WEBP_VERSION=v1.6.0
-                            FREETYPE_VERSION=VER-2-14-0
+                            FREETYPE_VERSION=VER-2-14-1
                             USE_OPENVDB=0
             # Ensure we are testing all the deps we think we are. We would
             # like this test to have minimal missing dependencies.
@@ -549,7 +549,7 @@ jobs:
                             PTEX_VERSION=v2.4.3
                             PUGIXML_VERSION=v1.15
                             WEBP_VERSION=v1.6.0
-                            FREETYPE_VERSION=VER-2-14-0
+                            FREETYPE_VERSION=VER-2-14-1
                             USE_OPENVDB=0
           - desc: Linux ARM latest releases clang18 C++20 py3.12 exr3.4 ocio2.4
             nametag: linux-arm-latest-releases-clang
@@ -570,7 +570,7 @@ jobs:
                             PTEX_VERSION=v2.4.3
                             PUGIXML_VERSION=v1.15
                             WEBP_VERSION=v1.6.0
-                            FREETYPE_VERSION=VER-2-14-0
+                            FREETYPE_VERSION=VER-2-14-1
                             USE_OPENVDB=0
 
 
@@ -683,7 +683,7 @@ jobs:
       # built. But we would like to add more dependencies and reduce this list
       # of exceptions in the future.
       required_deps: ${{ matrix.required_deps || 'all' }}
-      optional_deps: ${{ matrix.optional_deps || 'CUDAToolkit;DCMTK;FFmpeg;GIF;JXL;Libheif;LibRaw;Nuke;OpenCV;OpenGL;OpenJPEG;openjph;OpenCV;OpenVDB;Ptex;pystring;Qt5;Qt6;TBB;R3DSDK;${{matrix.optional_deps_append}}' }}
+      optional_deps: ${{ matrix.optional_deps || 'BZip2;CUDAToolkit;DCMTK;FFmpeg;GIF;JXL;Libheif;LibRaw;Nuke;OpenCV;OpenGL;OpenJPEG;openjph;OpenCV;OpenVDB;Ptex;pystring;Qt5;Qt6;TBB;R3DSDK;${{matrix.optional_deps_append}}' }}
     strategy:
       fail-fast: false
       matrix:

--- a/src/build-scripts/build_Freetype.bash
+++ b/src/build-scripts/build_Freetype.bash
@@ -11,7 +11,7 @@ set -ex
 
 # Repo and branch/tag/commit of Freetype to download if we don't have it yet
 FREETYPE_REPO=${FREETYPE_REPO:=https://github.com/freetype/freetype.git}
-FREETYPE_VERSION=${FREETYPE_VERSION:=VER-2-13-3}
+FREETYPE_VERSION=${FREETYPE_VERSION:=VER-2-14-1}
 
 # Where to put Freetype repo source (default to the ext area)
 LOCAL_DEPS_DIR=${LOCAL_DEPS_DIR:=${PWD}/ext}

--- a/src/cmake/build_Freetype.cmake
+++ b/src/cmake/build_Freetype.cmake
@@ -6,10 +6,10 @@
 # Freetype by hand!
 ######################################################################
 
-set_cache (Freetype_BUILD_VERSION 2.13.2 "Freetype version for local builds")
+set_cache (Freetype_BUILD_VERSION 2.14.1 "Freetype version for local builds")
 set (Freetype_GIT_REPOSITORY "https://github.com/freetype/freetype")
-set (Freetype_GIT_TAG "VER-2-13-2")
-set_cache (Freetype_BUILD_SHARED_LIBS  OFF
+set (Freetype_GIT_TAG "VER-2-14-1")
+set_cache (Freetype_BUILD_SHARED_LIBS ${LOCAL_BUILD_SHARED_LIBS_DEFAULT}
            DOC "Should a local Freetype build, if necessary, build shared libraries" ADVANCED)
 # We would prefer to build a static Freetype, but haven't figured out how to make
 # it all work with the static dependencies, it just makes things complicated

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -200,11 +200,9 @@ checked_find_package (R3DSDK NO_RECORD_NOTFOUND)  # RED camera
 set (NUKE_VERSION "7.0" CACHE STRING "Nuke version to target")
 checked_find_package (Nuke NO_RECORD_NOTFOUND)
 
-if (FFmpeg_FOUND OR FREETYPE_FOUND)
+if ((FFmpeg_FOUND OR FREETYPE_FOUND OR TARGET Freetype::Freetype)
+    AND NOT TARGET BZip2::BZip2)
     checked_find_package (BZip2)   # Used by ffmpeg and freetype
-    if (NOT BZIP2_FOUND)
-        set (BZIP2_LIBRARIES "")  # TODO: why does it break without this?
-    endif ()
 endif()
 
 

--- a/src/ffmpeg.imageio/CMakeLists.txt
+++ b/src/ffmpeg.imageio/CMakeLists.txt
@@ -28,7 +28,7 @@ if (FFmpeg_FOUND)
     add_oiio_plugin (ffmpeginput.cpp
                      INCLUDE_DIRS ${FFMPEG_INCLUDES}
                      LINK_LIBRARIES ${FFMPEG_LIBRARIES}
-                                    ${BZIP2_LIBRARIES}
+                                    $<TARGET_NAME_IF_EXISTS:BZip2::BZip2>
                      DEFINITIONS "USE_FFMPEG"
                                  "-DOIIO_FFMPEG_VERSION=\"${FFMPEG_VERSION}\"")
 else()

--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -163,7 +163,7 @@ target_link_libraries (OpenImageIO
             $<TARGET_NAME_IF_EXISTS:pugixml::pugixml>
             $<TARGET_NAME_IF_EXISTS:TBB::tbb>
             $<TARGET_NAME_IF_EXISTS:Freetype::Freetype>
-            ${BZIP2_LIBRARIES}
+            $<TARGET_NAME_IF_EXISTS:BZip2::BZip2>
             ZLIB::ZLIB
             ${CMAKE_DL_LIBS}
         )


### PR DESCRIPTION
* CI test vs the latest freetype 2.14.1
* Bump the version of freetype that we auto-build to the latest (from 2.13.2)
* Simplify BZip2 finding logic, switch to using targets
