### PR TITLE
feat(iv): flip, rotate and save image

### DIFF
--- a/src/iv/imageviewer.cpp
+++ b/src/iv/imageviewer.cpp
@@ -520,6 +520,22 @@ ImageViewer::createActions()
     closeupAvgPixelsBox->setToolTip(closeupAvgPixelsTooltip);
     closeupAvgPixelsLabel->setToolTip(closeupAvgPixelsTooltip);
 
+
+    rotateLeftAct = new QAction(tr("&Rotate Left"), this);
+    rotateLeftAct->setShortcut(tr("Ctrl+Shift+L"));
+    connect(rotateLeftAct, SIGNAL(triggered()), this, SLOT(rotateLeft()));
+
+    rotateRightAct = new QAction(tr("&Rotate Right"), this);
+    rotateRightAct->setShortcut(tr("Ctrl+Shift+R"));
+    connect(rotateRightAct, SIGNAL(triggered()), this, SLOT(rotateRight()));
+
+    flipHorizontalAct = new QAction(tr("&Flip Horizontal"), this);
+    connect(flipHorizontalAct, SIGNAL(triggered()), this,
+            SLOT(flipHorizontal()));
+
+    flipVerticalAct = new QAction(tr("&Flip Vertical"), this);
+    connect(flipVerticalAct, SIGNAL(triggered()), this, SLOT(flipVertical()));
+
     // Connect signals to ensure closeupAvgPixelsBox value is always <= closeupPixelsBox value
     connect(closeupPixelsBox, QOverload<int>::of(&QSpinBox::valueChanged),
             [this](int value) {
@@ -780,6 +796,11 @@ ImageViewer::createMenus()
     toolsMenu->addAction(toggleAreaSampleAct);
     toolsMenu->addMenu(slideMenu);
     toolsMenu->addMenu(sortMenu);
+    toolsMenu->addSeparator();
+    toolsMenu->addAction(rotateLeftAct);
+    toolsMenu->addAction(rotateRightAct);
+    toolsMenu->addAction(flipHorizontalAct);
+    toolsMenu->addAction(flipVerticalAct);
 
     // Menus, toolbars, & status
     // Annotate
@@ -2454,4 +2475,83 @@ bool
 ImageViewer::areaSampleMode() const
 {
     return m_areaSampleMode;
+}
+
+
+void
+ImageViewer::rotateLeft()
+{
+    IvImage* img = cur();
+    if (!img)
+        return;
+
+    ImageSpec* spec = curspecmod();
+
+    int curr_orientation = spec->get_int_attribute("Orientation", 1);
+
+    if (curr_orientation >= 1 && curr_orientation <= 8) {
+        static int next_orientation[] = { 0, 8, 5, 6, 7, 4, 1, 2, 3 };
+        curr_orientation              = next_orientation[curr_orientation];
+        spec->attribute("Orientation", curr_orientation);
+    }
+    displayCurrentImage();
+}
+
+
+void
+ImageViewer::rotateRight()
+{
+    IvImage* img = cur();
+    if (!img)
+        return;
+
+    ImageSpec* spec      = curspecmod();
+    int curr_orientation = spec->get_int_attribute("Orientation", 1);
+
+    if (curr_orientation >= 1 && curr_orientation <= 8) {
+        static int next_orientation[] = { 0, 6, 7, 8, 5, 2, 3, 4, 1 };
+        curr_orientation              = next_orientation[curr_orientation];
+        spec->attribute("Orientation", curr_orientation);
+    }
+    displayCurrentImage();
+}
+
+
+void
+ImageViewer::flipHorizontal()
+{
+    IvImage* img = cur();
+    if (!img)
+        return;
+
+    ImageSpec* spec = curspecmod();
+
+    int curr_orientation = spec->get_int_attribute("Orientation", 1);
+
+    if (curr_orientation >= 1 && curr_orientation <= 8) {
+        static int next_orientation[] = { 0, 2, 1, 4, 3, 6, 5, 8, 7 };
+        curr_orientation              = next_orientation[curr_orientation];
+        spec->attribute("Orientation", curr_orientation);
+    }
+    displayCurrentImage();
+}
+
+
+void
+ImageViewer::flipVertical()
+{
+    IvImage* img = cur();
+    if (!img)
+        return;
+
+    ImageSpec* spec = curspecmod();
+
+    int curr_orientation = spec->get_int_attribute("Orientation", 1);
+
+    if (curr_orientation >= 1 && curr_orientation <= 8) {
+        static int next_orientation[] = { 0, 4, 3, 2, 1, 8, 7, 6, 5 };
+        curr_orientation              = next_orientation[curr_orientation];
+        spec->attribute("Orientation", curr_orientation);
+    }
+    displayCurrentImage();
 }

--- a/src/iv/imageviewer.h
+++ b/src/iv/imageviewer.h
@@ -219,6 +219,14 @@ public:
         return img ? &img->spec() : NULL;
     }
 
+    /// Return a modifiable ref to the current image spec, or NULL if there is no
+    /// current image.
+    ImageSpec* curspecmod(void) const
+    {
+        IvImage* img = cur();
+        return img ? &img->specmod() : NULL;
+    }
+
     bool pixelviewOn(void) const
     {
         return showPixelviewWindowAct && showPixelviewWindowAct->isChecked();
@@ -334,6 +342,11 @@ private slots:
     void editPreferences();      ///< Edit viewer preferences
     void toggleAreaSample();     ///< Use area probe
 
+    void rotateLeft();
+    void rotateRight();
+    void flipHorizontal();
+    void flipVertical();
+
     void useOCIOAction(bool checked);
     void ocioColorSpaceAction();
     void ocioDisplayViewAction();
@@ -404,6 +417,8 @@ private:
     QAction* showPixelviewWindowAct;
     QAction* toggleAreaSampleAct;
     QAction* toggleWindowGuidesAct;
+    QAction *rotateLeftAct, *rotateRightAct, *flipHorizontalAct,
+        *flipVerticalAct;
     QMenu *fileMenu, *editMenu, /**imageMenu,*/ *viewMenu, *toolsMenu,
         *helpMenu;
     QMenu* openRecentMenu;


### PR DESCRIPTION
Fixes #4715 

### Description

- Added save functionality
- Added flipping and rotation capabilities via metadata.

Note that the actual pixel data remains unchanged, so only image formats that support the rotation metadata will reflect the changes.

I thought that it made sense for the flip and rotate to be under the tool section, similar to where the macbook Preview app places it. Keyboard shortcuts also follow the shortcuts that Preview uses.

### Tests
Used a .jpeg photo to test:
- saving
- making changes with/without saving and re-opening the image
- flipping and rotation from different initial rotation/mirrored states

Otherwise there doesn't seem to be a test suite for iv? 

### Checklist:
<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [X] **I have read the guidelines** on [contributions](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md) and [code review procedures](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/CodeReview.md).
- [ ] **I have updated the documentation** if my PR adds features or changes
  behavior.
- [ ] **I am sure that this PR's changes are tested somewhere in the
  testsuite**.
- [X] **I have run and passed the testsuite in CI** *before* submitting the
  PR, by pushing the changes to my fork and seeing that the automated CI
  passed there. (Exceptions: If most tests pass and you can't figure out why
  the remaining ones fail, it's ok to submit the PR and ask for help. Or if
  any failures seem entirely unrelated to your change; sometimes things break
  on the GitHub runners.)
- [X] **My code follows the prevailing code style of this project** and I
  fixed any problems reported by the clang-format CI test.
- [X] If I added or modified a public C++ API call, I have also amended the
  corresponding Python bindings. If altering ImageBufAlgo functions, I also
  exposed the new functionality as oiiotool options.
