### PR TITLE
fix: several bug fixes related to internal use of image_span

### DIFF
--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -150,10 +150,11 @@ public:
                      stride_t ystride = AutoStride,
                      stride_t zstride = AutoStride)
     {
-        m_bufspan = image_span(reinterpret_cast<std::byte*>(data),
-                               m_spec.nchannels, m_spec.width, m_spec.height,
-                               m_spec.depth, m_spec.format.size(), xstride,
-                               ystride, zstride);
+        auto formatsize = m_spec.format.size();
+        m_bufspan       = image_span(reinterpret_cast<std::byte*>(data),
+                                     m_spec.nchannels, m_spec.width, m_spec.height,
+                                     m_spec.depth, formatsize, xstride, ystride,
+                                     zstride, formatsize);
     }
 
     bool init_spec(string_view filename, int subimage, int miplevel,


### PR DESCRIPTION
* ImageBuf internal buffer span lacked correct chansize. The internal `m_bufspan` is an `image_span<byte>`, and as such, it needs to remember the size of the original data type. Otherwise, there's a cascade of potential errors when it thinks that the individual values are byte sized.

* In both ImageInput and ImageOutput, several sanity checks of image_span size versus expectations were incorrect. They were only checking if the total byte sizes matched expectations, but they are allowed to disagree when you consider type conversions (in which case, it's the total number of values that need to match, not the total byte sizes.

