### PR TITLE
test: Add new ref image for jpeg test

### DIFF
--- a/testsuite/jpeg/ref/out-jpeg9.4.txt
+++ b/testsuite/jpeg/ref/out-jpeg9.4.txt
@@ -1,0 +1,9 @@
+Reading src/YCbCrK.jpg
+src/YCbCrK.jpg       :   52 x   52, 3 channel, uint8 jpeg
+    SHA-1: B54FAE77E27EFCEACF27BA796A48DCE6DF262F26
+    channel list: R, G, B
+    jpeg:ColorSpace: "YCbCrK"
+    jpeg:subsampling: "4:4:4"
+    oiio:ColorSpace: "srgb_rec709_scene"
+Comparing "rgb-from-YCbCrK.tif" and "ref/rgb-from-YCbCrK.tif"
+PASS


### PR DESCRIPTION
Needed for some systems after the changes of #4963.

Ever so slightly different LSB somewhere makes the hashes not match, but it's a correct visual result.
