### PR TITLE
api(ImageBuf): IB::localpixels_as_[writable_]byte_image_span

### DIFF
--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -1377,7 +1377,7 @@ public:
     /// Return an `image_span<std::byte>` giving the extent and layout of
     /// "local" pixel memory, if they are fully in RAM and not backed by an
     /// ImageCache, and it is a writable IB, or an empty span otherwise.
-    image_span<std::byte> localpixels_as_writable_byte_image_span() const;
+    image_span<std::byte> localpixels_as_writable_byte_image_span();
 
     /// Pixel-to-pixel stride within the localpixels memory.
     stride_t pixel_stride() const;

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -2149,7 +2149,7 @@ ImageBuf::localpixels_as_byte_image_span() const
 
 
 image_span<std::byte>
-ImageBuf::localpixels_as_writable_byte_image_span() const
+ImageBuf::localpixels_as_writable_byte_image_span()
 {
     return m_impl->m_readonly ? image_span<std::byte>() : m_impl->m_bufspan;
 }


### PR DESCRIPTION
Utilities to ask the IB for the local pixels as an untyped span of bytes. This is a "safe" alternative to `localpixels()`, which just returned a single pointer, instead returning an image_span that understands the sizes and strides of the buffer.
