### PR TITLE
feat(heif): Add IOProxy for input and output

### DIFF
--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -806,6 +806,10 @@ attributes are supported:
        having Orientation 1). If zero, then libheif will not reorient the
        image and the Orientation metadata will be set to reflect the camera
        orientation.
+   * - ``oiio:ioproxy``
+     - ptr
+     - Pointer to a ``Filesystem::IOProxy`` that will handle the I/O, for
+       example by reading from memory rather than the file system.
 
 **Configuration settings for HEIF output**
 
@@ -824,6 +828,10 @@ control aspects of the writing itself:
      - If supplied, can be ``"heic"`` or ``"avif"``, but may optionally have a
        quality value appended, like ``"heic:90"``. Quality can be 1-100, with
        100 meaning lossless. The default is 75.
+   * - ``oiio:ioproxy``
+     - ptr
+     - Pointer to a ``Filesystem::IOProxy`` that will handle the I/O, for
+       example by writing to memory rather than the file system.
 
 
 


### PR DESCRIPTION
### Description

Add IOProxy support similar to other file formats.

MyHeifWriter was renamed for consistency with other code.

### Tests

All input and output now goes through the proxy, so this is covered by
existing tests.

### Checklist:

- [x] **I have read the guidelines** on [contributions](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md) and [code review procedures](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/CodeReview.md).
- [x] **I have updated the documentation** if my PR adds features or changes
  behavior.
- [x] **I am sure that this PR's changes are tested somewhere in the
  testsuite**.
- [x] **I have run and passed the testsuite in CI** *before* submitting the
  PR, by pushing the changes to my fork and seeing that the automated CI
  passed there. (Exceptions: If most tests pass and you can't figure out why
  the remaining ones fail, it's ok to submit the PR and ask for help. Or if
  any failures seem entirely unrelated to your change; sometimes things break
  on the GitHub runners.)
- [x] **My code follows the prevailing code style of this project** and I
  fixed any problems reported by the clang-format CI test.
- [x] If I added or modified a public C++ API call, I have also amended the
  corresponding Python bindings. If altering ImageBufAlgo functions, I also
  exposed the new functionality as oiiotool options.
