### PR TITLE
fix(webp): Missing oiio:UnassociatedAlpha on input

### DIFF
--- a/src/webp.imageio/webpinput.cpp
+++ b/src/webp.imageio/webpinput.cpp
@@ -214,8 +214,11 @@ WebpInput::open(const std::string& name, ImageSpec& spec,
     // Make space for the decoded image
     m_decoded_image.reset(new uint8_t[m_spec.image_bytes()]);
 
-    if (config.get_int_attribute("oiio:UnassociatedAlpha", 0) == 1)
+    if (config.get_int_attribute("oiio:UnassociatedAlpha", 0) == 1) {
         m_keep_unassociated_alpha = true;
+        if (m_spec.alpha_channel != -1)
+            m_spec.attribute("oiio:UnassociatedAlpha", 1);
+    }
 
     seek_subimage(0, 0);
     spec = m_spec;

--- a/testsuite/webp/ref/out-webp1.1.txt
+++ b/testsuite/webp/ref/out-webp1.1.txt
@@ -18,3 +18,9 @@ Reading ../oiio-images/webp/4.webp
     SHA-1: 8F42E3DCCE6FE15146BA06C440C15B7831F60572
     channel list: R, G, B
     oiio:ColorSpace: "srgb_rec709_scene"
+Reading rgba.webp
+rgba.webp            :   64 x   64, 4 channel, uint8 webp
+    SHA-1: 897256B6709E1A4DA9DABA92B6BDE39CCFCCD8C1
+    channel list: R, G, B, A
+    oiio:ColorSpace: "srgb_rec709_scene"
+    oiio:UnassociatedAlpha: 1

--- a/testsuite/webp/run.py
+++ b/testsuite/webp/run.py
@@ -11,3 +11,6 @@ for f in files:
     # a lossy format and is not stable under the round trip
     # command += rw_command (OIIO_TESTSUITE_IMAGEDIR, f,
     #                        extraargs='-attrib compression lossless')
+
+command += oiiotool ("--create 64x64 4 -o rgba.webp")
+command += info_command ("rgba.webp", "--iconfig oiio:UnassociatedAlpha 1", safematch=True)


### PR DESCRIPTION
### Description

Like other file formats, the returned ImageSpec should indicate if the image contains unassociated alpha.

This was an oversight in #4770.

### Tests

Test added.

### Checklist:

- [x] **I have read the guidelines** on [contributions](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md) and [code review procedures](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/CodeReview.md).
- [x] **I have updated the documentation** if my PR adds features or changes
  behavior.
- [x] **I am sure that this PR's changes are tested somewhere in the
  testsuite**.
- [x] **I have run and passed the testsuite in CI** *before* submitting the
  PR, by pushing the changes to my fork and seeing that the automated CI
  passed there. (Exceptions: If most tests pass and you can't figure out why
  the remaining ones fail, it's ok to submit the PR and ask for help. Or if
  any failures seem entirely unrelated to your change; sometimes things break
  on the GitHub runners.)
- [x] **My code follows the prevailing code style of this project** and I
  fixed any problems reported by the clang-format CI test.
- [x] If I added or modified a public C++ API call, I have also amended the
  corresponding Python bindings. If altering ImageBufAlgo functions, I also
  exposed the new functionality as oiiotool options.
