### PR TITLE
build(ocio): bump build ver to 2.5.1

### DIFF
--- a/src/cmake/build_OpenColorIO.cmake
+++ b/src/cmake/build_OpenColorIO.cmake
@@ -6,7 +6,7 @@
 # OpenColorIO by hand!
 ######################################################################
 
-set_cache (OpenColorIO_BUILD_VERSION 2.4.2 "OpenColorIO version for local builds")
+set_cache (OpenColorIO_BUILD_VERSION 2.5.1 "OpenColorIO version for local builds")
 set (OpenColorIO_GIT_REPOSITORY "https://github.com/AcademySoftwareFoundation/OpenColorIO")
 set (OpenColorIO_GIT_TAG "v${OpenColorIO_BUILD_VERSION}")
 set_cache (OpenColorIO_BUILD_SHARED_LIBS  OFF


### PR DESCRIPTION
Makes OpenColorIO 2.5.1 the default version when building OCIO locally. This will cause the released python wheels to build against the currently-latest version of OCIO.