### PR TITLE
ci: lock bleeding edge to pybind11 latest version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -482,7 +482,7 @@ jobs:
             fmt_ver: master
             opencolorio_ver: main
             openexr_ver: main
-            pybind11_ver: master
+            pybind11_ver: v3.0.1
             python_ver: "3.12"
             simd: avx2,f16c
             benchmark: 1


### PR DESCRIPTION
There's something in pybind11 master at the moment that is crashing in its destructors. It's been causing our "bleeding edge" test to fail for over a week now. I'm tired of our test failing, so I'm locking down to the last known working version. Will check back periodically and return to testing against pybind11 master after they have fixed it.
