### PR TITLE
fix: conform certain attrib names "exif:*" to our "Exif:*" convention

### DIFF
--- a/src/jpeg.imageio/jpegoutput.cpp
+++ b/src/jpeg.imageio/jpegoutput.cpp
@@ -370,9 +370,9 @@ void
 JpgOutput::resmeta_to_density()
 {
     // Clear cruft from Exif that might confuse us
-    m_spec.erase_attribute("exif:XResolution");
-    m_spec.erase_attribute("exif:YResolution");
-    m_spec.erase_attribute("exif:ResolutionUnit");
+    m_spec.erase_attribute("Exif:XResolution");
+    m_spec.erase_attribute("Exif:YResolution");
+    m_spec.erase_attribute("Exif:ResolutionUnit");
 
     string_view resunit = m_spec.get_string_attribute("ResolutionUnit");
     if (Strutil::iequals(resunit, "none"))

--- a/src/libOpenImageIO/xmp.cpp
+++ b/src/libOpenImageIO/xmp.cpp
@@ -98,8 +98,8 @@ static XMPtag xmptag[] = {
     { "tiff:Software", "Software", TypeDesc::STRING, TiffRedundant },
 
     { "exif:ColorSpace", "Exif:ColorSpace", TypeDesc::INT, ExifRedundant },
-    { "exif:PixelXDimension", "", TypeDesc::INT, ExifRedundant|TiffRedundant},
-    { "exif:PixelYDimension", "", TypeDesc::INT, ExifRedundant|TiffRedundant },
+    { "exif:PixelXDimension", "Exif:PixelXDimension", TypeDesc::INT, ExifRedundant|TiffRedundant},
+    { "exif:PixelYDimension", "Exif:PixelYDimension", TypeDesc::INT, ExifRedundant|TiffRedundant },
     { "exifEX:PhotographicSensitivity", "Exif:ISOSpeedRatings", TypeDesc::INT, ExifRedundant },
 
     { "xmp:CreateDate", "DateTime", TypeDesc::STRING, DateConversion|TiffRedundant },


### PR DESCRIPTION
I think it was basically harmless, since we do all the metadata name comparisons using case-insensitive comparisons. But we use "Exif:" as our prefix for Exif data throughout OIIO by convention, and there was this tiny handful of places where we said "exif:".
