### PR TITLE
testing: Adjust test comparision thresholds for Mac ARM

### DIFF
--- a/testsuite/texture-crop/run.py
+++ b/testsuite/texture-crop/run.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/AcademySoftwareFoundation/OpenImageIO
 
+hardfail = 0.02
 
 command += oiiotool("../common/grid.tif --crop 512x512+200+100 -o grid-crop.tif")
 command += maketx_command ("grid-crop.tif", "grid-crop.tx")

--- a/testsuite/texture-interp-bilinear/run.py
+++ b/testsuite/texture-interp-bilinear/run.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/AcademySoftwareFoundation/OpenImageIO
 
+hardfail = 0.02
 
 command = testtex_command ("../common/textures/grid.tx",
                            extraargs = "-interpmode 1  -d uint8 -o out.tif")

--- a/testsuite/texture-skinny/run.py
+++ b/testsuite/texture-skinny/run.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/AcademySoftwareFoundation/OpenImageIO
 
+hardfail = 0.013
 
 command = testtex_command ("src/vertgrid.tx", " --scalest 4 1 ")
 outputs = [ "out.exr" ]

--- a/testsuite/texture-uint8/run.py
+++ b/testsuite/texture-uint8/run.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/AcademySoftwareFoundation/OpenImageIO
 
+hardfail = 0.021
 
 command = testtex_command ("../common/textures/grid.tx")
 outputs = [ "out.exr" ]


### PR DESCRIPTION
Even though we have CI testing on Mac with ARM CPU that were passing, after getting a new laptop, I saw some test failures that were due to just a few pixels on a few tests needing a higher comparision threshold.  Results are correct, just different due to the math. I guess this machine (CPU? build flags? specific compiler or library versions?) is ever so slightly different than the CI Macs, so I caught a few more instances that needed to be adjusted.

I tried to increase the thresholds as little as possible to fix the problem.
