### PR TITLE
cleanup: remove left over tile emulation code for various formats

### DIFF
--- a/src/hdr.imageio/hdroutput.cpp
+++ b/src/hdr.imageio/hdroutput.cpp
@@ -26,14 +26,10 @@ public:
               OpenMode mode) override;
     bool write_scanline(int y, int z, TypeDesc format, const void* data,
                         stride_t xstride) override;
-    bool write_tile(int x, int y, int z, TypeDesc format, const void* data,
-                    stride_t xstride, stride_t ystride,
-                    stride_t zstride) override;
     bool close() override;
 
 private:
     std::vector<unsigned char> scratch;
-    std::vector<unsigned char> m_tilebuffer;
 
     void init(void) { ioproxy_clear(); }
 
@@ -226,11 +222,6 @@ HdrOutput::open(const std::string& name, const ImageSpec& newspec,
     if (!iowritefmt("-Y {} +X {}\n", m_spec.height, m_spec.width))
         return false;
 
-    // If user asked for tiles -- which this format doesn't support, emulate
-    // it by buffering the whole image.
-    if (m_spec.tile_width && m_spec.tile_height)
-        m_tilebuffer.resize(m_spec.image_bytes());
-
     return true;
 }
 
@@ -247,17 +238,6 @@ HdrOutput::write_scanline(int /*y*/, int /*z*/, TypeDesc format,
 
 
 bool
-HdrOutput::write_tile(int x, int y, int z, TypeDesc format, const void* data,
-                      stride_t xstride, stride_t ystride, stride_t zstride)
-{
-    // Emulate tiles by buffering the whole image
-    return copy_tile_to_image_buffer(x, y, z, format, data, xstride, ystride,
-                                     zstride, &m_tilebuffer[0]);
-}
-
-
-
-bool
 HdrOutput::close()
 {
     if (!ioproxy_opened()) {  // already closed
@@ -265,18 +245,9 @@ HdrOutput::close()
         return true;
     }
 
-    bool ok = true;
-    if (m_spec.tile_width) {
-        // We've been emulating tiles; now dump as scanlines.
-        OIIO_ASSERT(m_tilebuffer.size());
-        ok &= write_scanlines(m_spec.y, m_spec.y + m_spec.height, 0,
-                              m_spec.format, &m_tilebuffer[0]);
-        std::vector<unsigned char>().swap(m_tilebuffer);
-    }
-
     init();
 
-    return ok;
+    return true;
 }
 
 OIIO_PLUGIN_NAMESPACE_END


### PR DESCRIPTION
### Description

Since the OpenImageIO 2.5 series, when calls to `check_open` were added, any format that did not declare support for "tiles" would immediately fail to open. But many of the formats which attempted to emulate tiles, by buffering the contents and writing it all as scanlines at the end, were not updated. All of the tile emulation code for these formats is effectively dead-code and untested.

Remove the tile emulation code from these formats.

An example of what the failure currently looks like:
```python
>>> out = oiio.ImageOutput.create("test.png")
>>> spec = oiio.ImageSpec(64, 64, 3, 'uint8')
>>> spec.tile_width = 64
>>> out.open("test.png", spec)
False

>>> out.geterror()
'png does not support tiled images'
```

### Tests

None were impacted.

### Checklist:
- [x] **I have read the guidelines** on [contributions](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md) and [code review procedures](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/CodeReview.md).
- [ ] **I have updated the documentation** if my PR adds features or changes
  behavior.
- [ ] **I am sure that this PR's changes are tested somewhere in the
  testsuite**.
- [x] **I have run and passed the testsuite in CI** *before* submitting the
  PR, by pushing the changes to my fork and seeing that the automated CI
  passed there. (Exceptions: If most tests pass and you can't figure out why
  the remaining ones fail, it's ok to submit the PR and ask for help. Or if
  any failures seem entirely unrelated to your change; sometimes things break
  on the GitHub runners.)
- [x] **My code follows the prevailing code style of this project** and I
  fixed any problems reported by the clang-format CI test.
- [ ] If I added or modified a public C++ API call, I have also amended the
  corresponding Python bindings. If altering ImageBufAlgo functions, I also
  exposed the new functionality as oiiotool options.
