### PR TITLE
ci: Don't install OpenCV on Mac Intel job variant

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -628,7 +628,9 @@ jobs:
             python_ver: "3.13"
             simd: sse4.2,avx2
             ctest_test_timeout: 1200
-            setenvs: export MACOSX_DEPLOYMENT_TARGET=12.0 INSTALL_QT=0
+            setenvs: export MACOSX_DEPLOYMENT_TARGET=12.0
+                            INSTALL_QT=0 INSTALL_OPENCV=0
+            optional_deps_append: 'OpenCV;Qt5;Qt6'
             benchmark: 1
           - desc: MacOS-14-ARM aclang15/C++20/py3.13
             runner: macos-14

--- a/src/build-scripts/install_homebrew_deps.bash
+++ b/src/build-scripts/install_homebrew_deps.bash
@@ -47,7 +47,7 @@ if [[ "$OIIO_BREW_INSTALL_PACKAGES" == "" ]] ; then
         robin-map \
         tbb \
         "
-    if [[ "${USE_OPENCV}" != "0" ]] && [[ "${INSTALL_OPENCV:=1}" != "0" ]] ; then
+    if [[ "${USE_OPENCV:=}" != "0" ]] && [[ "${INSTALL_OPENCV:=1}" != "0" ]] ; then
         OIIO_BREW_INSTALL_PACKAGES+=" opencv"
     fi
     if [[ "${USE_QT:=1}" != "0" ]] && [[ "${INSTALL_QT:=1}" != "0" ]] ; then


### PR DESCRIPTION
Mac Intel is getting long in the tooth, and quite often the Homebrew packages for Intel are found to be uncached and will try to build from source. When it's OpenCV, that's disastrous for our CI build times, it can get stalled for hours building all of OpenCV and its dependencies. So disable it for that one build variant.

