### PR TITLE
fix: address fmath.h warning with ispow2

### DIFF
--- a/src/include/OpenImageIO/fmath.h
+++ b/src/include/OpenImageIO/fmath.h
@@ -144,7 +144,11 @@ ispow2(T x) noexcept
     // Numerous references for this bit trick are on the web.  The
     // principle is that x is a power of 2 <=> x == 1<<b <=> x-1 is
     // all 1 bits for bits < b.
-    return (x & (x - 1)) == 0 && (x >= 0);
+    if constexpr (std::is_signed<T>::value) {
+        return (x & (x - 1)) == 0 && (x >= 0);
+    } else {
+        return (x & (x - 1)) == 0;
+    }
 }
 
 


### PR DESCRIPTION
I was seeing warnings with instantiation of the ispow2 function template for unsigned type, where the `x >= 0` clause is meaningless. Use a constexpr if to eliminate that pointless test for unsigned types.
