### PR TITLE
build: self-builder logic fixes for deep vs shallow clones

### DIFF
--- a/src/cmake/build_pybind11.cmake
+++ b/src/cmake/build_pybind11.cmake
@@ -8,9 +8,12 @@
 
 set_cache (pybind11_BUILD_VERSION 3.0.1 "pybind11 version for local builds")
 set (pybind11_GIT_REPOSITORY "https://github.com/pybind/pybind11")
-set (pybind11_GIT_TAG "v${pybind11_BUILD_VERSION}")
+set_cache (pybind11_GIT_TAG "v${pybind11_BUILD_VERSION}"
+           "pybind11 git tag to checkout")
+set_cache (pybind11_GIT_COMMIT ""
+           "pybind11 specific commit to checkout (overrides tag if set)")
 set_cache (pybind11_BUILD_SHARED_LIBS ${LOCAL_BUILD_SHARED_LIBS_DEFAULT}
-           DOC "Should a local pybind11 build, if necessary, build shared libraries" ADVANCED)
+           "Should a local pybind11 build, if necessary, build shared libraries" ADVANCED)
 
 string (MAKE_C_IDENTIFIER ${pybind11_BUILD_VERSION} pybind11_VERSION_IDENT)
 

--- a/src/cmake/dependency_utils.cmake
+++ b/src/cmake/dependency_utils.cmake
@@ -609,7 +609,7 @@ macro (build_dependency_with_cmake pkgname)
         # noValueKeywords:
         "NOINSTALL"
         # singleValueKeywords:
-        "GIT_REPOSITORY;GIT_TAG;GIT_COMMIT;VERSION;SOURCE_SUBDIR;GIT_SHALLOW;QUIET"
+        "GIT_REPOSITORY;GIT_TAG;GIT_COMMIT;VERSION;SOURCE_SUBDIR;QUIET"
         # multiValueKeywords:
         "CMAKE_ARGS"
         # argsToParse:
@@ -629,8 +629,10 @@ macro (build_dependency_with_cmake pkgname)
 
     unset (${pkgname}_GIT_CLONE_ARGS)
     unset (_pkg_exec_quiet)
-    if (_pkg_GIT_SHALLOW OR "${_pkg_GIT_SHALLOW}" STREQUAL "")
-        list (APPEND ${pkgname}_GIT_CLONE_ARGS --depth 1)
+    if (NOT "${pkg_GIT_TAG}" STREQUAL "" AND "${_pkg_GIT_COMMIT}" STREQUAL "")
+        # If a tag was specified, but not a specific commit, do a shallow
+        # clone.
+        list (APPEND ${pkgname}_GIT_CLONE_ARGS -b ${pkg_GIT_TAG} --depth 1)
     endif ()
     if (_pkg_QUIET OR "${_pkg_QUIET}" STREQUAL "")
         list (APPEND ${pkgname}_GIT_CLONE_ARGS -q ERROR_VARIABLE ${pkgname}_clone_errors)
@@ -641,12 +643,10 @@ macro (build_dependency_with_cmake pkgname)
     find_package (Git REQUIRED)
     if (NOT IS_DIRECTORY ${${pkgname}_LOCAL_SOURCE_DIR})
         message (STATUS "COMMAND ${GIT_EXECUTABLE} clone ${_pkg_GIT_REPOSITORY} "
-                                "-b ${_pkg_GIT_TAG} "
                                 "${${pkgname}_LOCAL_SOURCE_DIR} "
                                 "${${pkgname}_GIT_CLONE_ARGS} "
                         "${_pkg_exec_quiet}")
         execute_process(COMMAND ${GIT_EXECUTABLE} clone ${_pkg_GIT_REPOSITORY}
-                                -b ${_pkg_GIT_TAG}
                                 ${${pkgname}_LOCAL_SOURCE_DIR}
                                 ${${pkgname}_GIT_CLONE_ARGS}
                         ${_pkg_exec_quiet})


### PR DESCRIPTION
* cmake utility build_dependency_with_cmake was unconditionally doing a shallow clone and using `clone -b`, but that only works if it's got a branch or tag name, not if it has a commit hash. So change the logic so it does a shallow clone only if GIT_TAG is specified but GIT_COMMIT is not.
* pybind11 self-builder is modified to allow a git commit override.

