### PR TITLE
fix(tiff): Fix TIFF output crash for multi-count Exif metadata

### DIFF
--- a/src/tiff.imageio/tiffoutput.cpp
+++ b/src/tiff.imageio/tiffoutput.cpp
@@ -1141,16 +1141,16 @@ TIFFOutput::write_exif_data()
             if (tifftype == TIFF_ASCII) {
                 ok = TIFFSetField(m_tif, tag, *(char**)p.data());
             } else if ((tifftype == TIFF_SHORT || tifftype == TIFF_LONG)
-                       && p.type() == TypeDesc::SHORT) {
+                       && p.type() == TypeDesc::SHORT && count == 1) {
                 ok = TIFFSetField(m_tif, tag, (int)*(short*)p.data());
             } else if ((tifftype == TIFF_SHORT || tifftype == TIFF_LONG)
-                       && p.type() == TypeDesc::INT) {
+                       && p.type() == TypeDesc::INT && count == 1) {
                 ok = TIFFSetField(m_tif, tag, *(int*)p.data());
             } else if ((tifftype == TIFF_RATIONAL || tifftype == TIFF_SRATIONAL)
-                       && p.type() == TypeDesc::FLOAT) {
+                       && p.type() == TypeDesc::FLOAT && count == 1) {
                 ok = TIFFSetField(m_tif, tag, *(float*)p.data());
             } else if ((tifftype == TIFF_RATIONAL || tifftype == TIFF_SRATIONAL)
-                       && p.type() == TypeDesc::DOUBLE) {
+                       && p.type() == TypeDesc::DOUBLE && count == 1) {
                 ok = TIFFSetField(m_tif, tag, *(double*)p.data());
             }
             if (!ok) {


### PR DESCRIPTION
Fixes #5023

This was crashing when writing TIFF information that was supposed to be arrays of more than one rational, but in fact was provided as a single value, it was reading past the end of a memory array.

I noticed that this whole region needs a cleanup, this is not the only problem. But a full overhaul seems too risky to backport, so my strategy is as follows:

* THIS fix first, which I will backport right away to 3.0 and 3.1.

* I will then submit a separate PR (already implemented and tested) that is a much more complete fix and overhaul of this portion of the code (and other places). That will get merged into main when approved.

* After the second PR is merged, I'll hold it in main for a while to test its safety, and then decide if it seems ok to backport to 3.1 (but definitely not 3.0).

