### PR TITLE
fix: gamma precision

### DIFF
--- a/src/hdr.imageio/hdrinput.cpp
+++ b/src/hdr.imageio/hdrinput.cpp
@@ -304,12 +304,7 @@ HdrInput::RGBE_ReadHeader()
             found_FORMAT_line = true;
             /* LG says no:    break;       // format found so break out of loop */
         } else if (Strutil::parse_values(line, "GAMMA=", span<float>(tempf))) {
-            // Round gamma to the nearest hundredth to prevent stupid
-            // precision choices and make it easier for apps to make
-            // decisions based on known gamma values. For example, you want
-            // 2.2, not 2.19998.
             float g = float(1.0 / tempf);
-            g       = roundf(100.0 * g) / 100.0f;
             set_colorspace_rec709_gamma(m_spec, g);
         } else if (Strutil::parse_values(line,
                                          "EXPOSURE=", span<float>(tempf))) {

--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -2803,21 +2803,25 @@ ColorConfig::set_colorspace(ImageSpec& spec, string_view colorspace) const
 void
 ColorConfig::set_colorspace_rec709_gamma(ImageSpec& spec, float gamma) const
 {
-    gamma = std::round(gamma * 100.0f) / 100.0f;
-    if (fabsf(gamma - 1.0f) <= 0.01f) {
+    // Round gamma to the nearest hundredth to prevent stupid precision choices
+    // and make it easier for apps to make decisions based on known gamma values.
+    float g_rounded = std::round(gamma * 100.0f) / 100.0f;
+    if (fabsf(g_rounded - 1.0f) <= 0.01f) {
         set_colorspace(spec, "lin_rec709_scene");
-    } else if (fabsf(gamma - 1.8f) <= 0.01f) {
+    } else if (fabsf(g_rounded - 1.8f) <= 0.01f) {
         set_colorspace(spec, "g18_rec709_scene");
         spec.attribute("oiio:Gamma", 1.8f);
-    } else if (fabsf(gamma - 2.2f) <= 0.01f) {
+    } else if (fabsf(g_rounded - 2.2f) <= 0.01f) {
         set_colorspace(spec, "g22_rec709_scene");
         spec.attribute("oiio:Gamma", 2.2f);
-    } else if (fabsf(gamma - 2.4f) <= 0.01f) {
+    } else if (fabsf(g_rounded - 2.4f) <= 0.01f) {
         set_colorspace(spec, "g24_rec709_scene");
         spec.attribute("oiio:Gamma", 2.4f);
     } else {
-        set_colorspace(spec, Strutil::fmt::format("g{}_rec709_scene",
-                                                  std::lround(gamma * 10.0f)));
+        set_colorspace(spec,
+                       Strutil::fmt::format("g{}_rec709_scene",
+                                            std::lround(g_rounded * 10.0f)));
+        // Preserve the original gamma value for use in color conversions.
         spec.attribute("oiio:Gamma", gamma);
     }
 }

--- a/src/png.imageio/png_pvt.h
+++ b/src/png.imageio/png_pvt.h
@@ -226,12 +226,7 @@ read_info(png_structp& sp, png_infop& ip, int& bit_depth, int& color_type,
     if (png_get_sRGB(sp, ip, &srgb_intent)) {
         spec.attribute("oiio:ColorSpace", "srgb_rec709_scene");
     } else if (png_get_gAMA(sp, ip, &gamma) && gamma > 0.0) {
-        // Round gamma to the nearest hundredth to prevent stupid
-        // precision choices and make it easier for apps to make
-        // decisions based on known gamma values. For example, you want
-        // 2.2, not 2.19998.
         float g = float(1.0 / gamma);
-        g       = roundf(100.0f * g) / 100.0f;
         set_colorspace_rec709_gamma(spec, g);
     } else {
         // If there's no info at all, assume sRGB.

--- a/src/rla.imageio/rlainput.cpp
+++ b/src/rla.imageio/rlainput.cpp
@@ -397,11 +397,6 @@ RLAInput::seek_subimage(int subimage, int miplevel)
 
     float gamma = Strutil::from_string<float>(m_rla.Gamma);
     if (gamma > 0.f) {
-        // Round gamma to the nearest hundredth to prevent stupid
-        // precision choices and make it easier for apps to make
-        // decisions based on known gamma values. For example, you want
-        // 2.2, not 2.19998.
-        gamma = roundf(100.0 * gamma) / 100.0f;
         set_colorspace_rec709_gamma(m_spec, gamma);
     }
 

--- a/src/targa.imageio/targainput.cpp
+++ b/src/targa.imageio/targainput.cpp
@@ -435,11 +435,6 @@ TGAInput::read_tga2_header()
             if (bigendian())
                 swap_endian(&buf.s[0], 2);
             float gamma = (float)buf.s[0] / (float)buf.s[1];
-            // Round gamma to the nearest hundredth to prevent stupid
-            // precision choices and make it easier for apps to make
-            // decisions based on known gamma values. For example, you want
-            // 2.2, not 2.19998.
-            gamma = roundf(100.0 * gamma) / 100.0f;
             set_colorspace_rec709_gamma(m_spec, gamma);
         }
 


### PR DESCRIPTION
### Description

This is a PR proposaling to keep the gamma precision.

In some cases, we need more precise gamma values, while the existing rounding operation loses most of the precision. This change will continue to use rounded values to calculate and store color space information, but retain the original value in the "Gamma" parameter. In addition, it can also tidy up existing code.

### Tests

I've verified with png/exif.png & python-colorconfig tests. No regression is introduced.

### Checklist:

- [x] **I have read the guidelines** on [contributions](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md) and [code review procedures](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/CodeReview.md).
- [x] **I have updated the documentation** if my PR adds features or changes
  behavior.
- [x] **I am sure that this PR's changes are tested somewhere in the
  testsuite**.
- [x] **I have run and passed the testsuite in CI** *before* submitting the
  PR, by pushing the changes to my fork and seeing that the automated CI
  passed there. (Exceptions: If most tests pass and you can't figure out why
  the remaining ones fail, it's ok to submit the PR and ask for help. Or if
  any failures seem entirely unrelated to your change; sometimes things break
  on the GitHub runners.)
- [x] **My code follows the prevailing code style of this project** and I
  fixed any problems reported by the clang-format CI test.
- [x] If I added or modified a public C++ API call, I have also amended the
  corresponding Python bindings. If altering ImageBufAlgo functions, I also
  exposed the new functionality as oiiotool options.
