### PR TITLE
build: Raise fmt auto-build version to 12.1, handle Windows flags

### DIFF
--- a/src/cmake/build_fmt.cmake
+++ b/src/cmake/build_fmt.cmake
@@ -6,7 +6,7 @@
 # fmt by hand!
 ######################################################################
 
-set_cache (fmt_BUILD_VERSION 10.2.1 "fmt version for local builds")
+set_cache (fmt_BUILD_VERSION 12.1.0 "fmt version for local builds")
 set (fmt_GIT_REPOSITORY "https://github.com/fmtlib/fmt")
 set (fmt_GIT_TAG "${fmt_BUILD_VERSION}")
 # Note: fmt doesn't put "v" in front of version for its git tags
@@ -22,8 +22,6 @@ build_dependency_with_cmake(fmt
         -D FMT_TEST=OFF
     )
 
-# Set some things up that we'll need for a subsequent find_package to work
-set (fmt_ROOT ${fmt_INSTALL_DIR})
-
 # Signal to caller that we need to find again at the installed location
 set (fmt_REFIND TRUE)
+set (fmt_VERSION ${fmt_BUILD_VERSION})

--- a/src/libutil/CMakeLists.txt
+++ b/src/libutil/CMakeLists.txt
@@ -51,6 +51,12 @@ function (setup_oiio_util_library targetname)
     target_link_options(${targetname} PRIVATE
                                ${${PROJECT_NAME}_link_options})
 
+    if (MSVC AND fmt_VERSION VERSION_GREATER_EQUAL 11.0)
+        # For MSVC, Unicode support requires compiling with /utf-8, and fmt
+        # needs this. This line adapted from fmt's CMakeLists.txt file.
+        target_compile_options(${targetname} PUBLIC $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:MSVC>>:/utf-8>)
+    endif ()
+
     target_include_directories (${targetname}
             PUBLIC
                 $<BUILD_INTERFACE:${OpenImageIO_LOCAL_DEPS_ROOT}/include>


### PR DESCRIPTION
Bump the version of 'fmt' library that we download and build (if not found) from 10.2 to 12.1.

Some other touch-ups in build_fmt.cmake.

Also, we have seen that recent fmt versions will fail to compile on MSVC unless using the `/utf-8` compiler flag, so ensure that is used and also passed on to other clients of libOpenImageIO_Util (which expose templates using those headers).
