### PR TITLE
build(deps): Raise minimum fmt library version to 9.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
             cxx_std: 17
             python_ver: 3.9
             simd: "avx2,f16c"
-            fmt_ver: 8.1.1
+            fmt_ver: 9.0.0
             opencolorio_ver: v2.3.0
             pybind11_ver: v2.9.0
             setenvs: export FREETYPE_VERSION=VER-2-12-0
@@ -123,7 +123,7 @@ jobs:
             vfxyear: 2022
             old_node: 1
             cxx_std: 17
-            fmt_ver: 7.0.1
+            fmt_ver: 9.0.0
             opencolorio_ver: v2.3.0
             openexr_ver: v3.1.0
             pybind11_ver: v2.7.0
@@ -145,7 +145,7 @@ jobs:
             cc_compiler: clang
             cxx_compiler: clang++
             cxx_std: 17
-            fmt_ver: 7.0.1
+            fmt_ver: 9.0.0
             opencolorio_ver: v2.3.0
             openexr_ver: v3.1.0
             pybind11_ver: v2.7.0
@@ -167,7 +167,7 @@ jobs:
             vfxyear: 2022
             old_node: 1
             cxx_std: 17
-            fmt_ver: 7.0.1
+            fmt_ver: 9.0.0
             opencolorio_ver: v2.3.0
             openexr_ver: v3.1.0
             pybind11_ver: v2.7.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@ Release 3.2 (target: Sept 2026?) -- compared to 3.1
 
 ### New minimum dependencies and compatibility changes:
   - The deprecated icc compiler is no longer supported. (3.2.0.0)
+  - **fmt**: Minimum required version is now 9.0 (was 7.0).
+
 ### ⛰️  New features and public API changes:
 * *New image file format support:*
 * *oiiotool new features and major improvements*:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,11 +23,11 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
  * Imath >= 3.1 (tested through 3.2 and main)
  * OpenEXR >= 3.1 (tested through 3.4 and main)
  * libTIFF >= 4.0 (tested through 4.7 and master)
- * *OpenColorIO >= 2.3* (tested through 2.5 and main)
+ * OpenColorIO >= 2.3 (tested through 2.5 and main)
  * libjpeg >= 8 (tested through jpeg9e), or libjpeg-turbo >= 2.1 (tested
    through 3.1)
  * zlib >= 1.2.7 (tested through 1.3.1)
- * [fmtlib](https://github.com/fmtlib/fmt) >= 7.0 (tested through 12.0 and master).
+ * **[fmtlib](https://github.com/fmtlib/fmt) >= 9.0** (tested through 12.1 and master).
    If not found at build time, this will be automatically downloaded and built.
  * [Robin-map](https://github.com/Tessil/robin-map) (unknown minimum, tested
    through 1.4, which is the recommended version). If not found at build time,
@@ -39,7 +39,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
      * Qt5 >= 5.6 (tested through 5.15) or Qt6 (tested through 6.9)
      * OpenGL
  * If you are building the Python bindings or running the testsuite:
-     * **Python >= 3.9** (tested through 3.13).
+     * Python >= 3.9 (tested through 3.13).
      * pybind11 >= 2.7 (tested through 3.0)
      * NumPy (tested through 2.2.4)
  * If you want support for PNG files:

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -231,9 +231,9 @@ checked_find_package (Robinmap REQUIRED
                      )
 
 # fmtlib
-option (OIIO_INTERNALIZE_FMT "Copy fmt headers into <install>/include/OpenImageIO/detail/fmt" ON)
+set_option (OIIO_INTERNALIZE_FMT "Copy fmt headers into <install>/include/OpenImageIO/detail/fmt" ON)
 checked_find_package (fmt REQUIRED
-                      VERSION_MIN 7.0
+                      VERSION_MIN 9.0
                       BUILD_LOCAL missing
                      )
 get_target_property(FMT_INCLUDE_DIR fmt::fmt-header-only INTERFACE_INCLUDE_DIRECTORIES)

--- a/src/include/OpenImageIO/detail/fmt.h
+++ b/src/include/OpenImageIO/detail/fmt.h
@@ -70,12 +70,9 @@ OIIO_PRAGMA_WARNING_PUSH
 
 OIIO_PRAGMA_WARNING_POP
 
-// At some point a method signature changed
-#if FMT_VERSION >= 90000
-#    define OIIO_FMT_CUSTOM_FORMATTER_CONST const
-#else
-#    define OIIO_FMT_CUSTOM_FORMATTER_CONST
-#endif
+// DEPRECATED(3.2): This definition is obsolete and should be removed at the
+// next ABI compatibility boundary.
+#define OIIO_FMT_CUSTOM_FORMATTER_CONST const
 
 
 OIIO_NAMESPACE_3_1_BEGIN
@@ -132,18 +129,14 @@ template<typename T,
 struct index_formatter : format_parser_with_separator {
     // inherits parse() from format_parser_with_separator
     template<typename FormatContext>
-    auto format(const T& v, FormatContext& ctx) OIIO_FMT_CUSTOM_FORMATTER_CONST
+    auto format(const T& v, FormatContext& ctx) const
     {
         std::string vspec = elem_fmt.size() ? fmt::format("{{:{}}}", elem_fmt)
                                             : std::string("{}");
         for (size_t i = 0; i < size_t(v.size()); ++i) {
             if (i)
                 fmt::format_to(ctx.out(), "{}", sep == ',' ? ", " : " ");
-#if FMT_VERSION >= 80000
             fmt::format_to(ctx.out(), fmt::runtime(vspec), v[i]);
-#else
-            fmt::format_to(ctx.out(), vspec, v[i]);
-#endif
         }
         return ctx.out();
     }
@@ -177,19 +170,15 @@ template<typename T, typename Elem, int Size>
 struct array_formatter : format_parser_with_separator {
     // inherits parse() from format_parser_with_separator
     template<typename FormatContext>
-    auto format(const T& v, FormatContext& ctx) OIIO_FMT_CUSTOM_FORMATTER_CONST
+    auto format(const T& v, FormatContext& ctx) const
     {
         std::string vspec = elem_fmt.size() ? fmt::format("{{:{}}}", elem_fmt)
                                             : std::string("{}");
         for (int i = 0; i < Size; ++i) {
             if (i)
                 fmt::format_to(ctx.out(), "{}", sep == ',' ? ", " : " ");
-#if FMT_VERSION >= 80000
             fmt::format_to(ctx.out(), fmt::runtime(vspec),
                            ((const Elem*)&v)[i]);
-#else
-            fmt::format_to(ctx.out(), vspec, ((const Elem*)&v)[i]);
-#endif
         }
         return ctx.out();
     }

--- a/src/include/OpenImageIO/strutil.h
+++ b/src/include/OpenImageIO/strutil.h
@@ -204,7 +204,6 @@ namespace sync {
 /// Output is fully thread-safe (the outputs are "atomic" to the file or
 /// stream), and if the stream is buffered, it is flushed after the output).
 
-#if FMT_VERSION >= 70000
 template<typename Str, typename... Args>
 inline void print (FILE *file, const Str& fmt, Args&&... args)
 {
@@ -223,26 +222,6 @@ inline void print (std::ostream &file, const Str& fmt, Args&&... args)
     sync_output (file, ::fmt::vformat(fmt, ::fmt::make_format_args(args...)));
 }
 
-#else
-
-template<typename... Args>
-inline void print (FILE *file, const char* fmt, Args&&... args)
-{
-    sync_output (file, ::fmt::format(fmt, std::forward<Args>(args)...));
-}
-
-template<typename... Args>
-inline void print (const char* fmt, Args&&... args)
-{
-    print(stdout, fmt, std::forward<Args>(args)...);
-}
-
-template<typename... Args>
-inline void print (std::ostream &file, const char* fmt, Args&&... args)
-{
-    sync_output (file, ::fmt::format(fmt, std::forward<Args>(args)...));
-}
-#endif
 } // namespace sync
 
 
@@ -275,7 +254,7 @@ void print (FILE *file, const char* fmt, const Args&... args);
 template<typename... Args>
 void print (std::ostream &file, const char* fmt, const Args&... args);
 
-#elif FMT_VERSION >= 70000 && !OIIO_PRINT_IS_SYNCHRONIZED
+#elif !OIIO_PRINT_IS_SYNCHRONIZED
 using ::fmt::print;
 #else
 using sync::print;

--- a/src/include/OpenImageIO/typedesc.h
+++ b/src/include/OpenImageIO/typedesc.h
@@ -681,7 +681,7 @@ struct fmt::formatter<OIIO::TypeDesc> {
     }
 
     template <typename FormatContext>
-    auto format(const OIIO::TypeDesc& t, FormatContext& ctx) OIIO_FMT_CUSTOM_FORMATTER_CONST
+    auto format(const OIIO::TypeDesc& t, FormatContext& ctx) const
     {
         // C++14:   auto format(const OIIO::TypeDesc& p, FormatContext& ctx) const {
         // ctx.out() is an output iterator to write to.

--- a/src/include/OpenImageIO/ustring.h
+++ b/src/include/OpenImageIO/ustring.h
@@ -1146,8 +1146,7 @@ FMT_BEGIN_NAMESPACE
 
 template<> struct formatter<OIIO::ustring> : formatter<fmt::string_view, char> {
     template<typename FormatContext>
-    auto format(const OIIO::ustring& u,
-                FormatContext& ctx) OIIO_FMT_CUSTOM_FORMATTER_CONST
+    auto format(const OIIO::ustring& u, FormatContext& ctx) const
     {
         return formatter<fmt::string_view, char>::format({ u.data(), u.size() },
                                                          ctx);
@@ -1157,8 +1156,7 @@ template<> struct formatter<OIIO::ustring> : formatter<fmt::string_view, char> {
 template<>
 struct formatter<OIIO::ustringhash> : formatter<fmt::string_view, char> {
     template<typename FormatContext>
-    auto format(const OIIO::ustringhash& h,
-                FormatContext& ctx) OIIO_FMT_CUSTOM_FORMATTER_CONST
+    auto format(const OIIO::ustringhash& h, FormatContext& ctx) const
     {
         OIIO::ustring u(h);
         return formatter<fmt::string_view, char>::format({ u.data(), u.size() },

--- a/src/libutil/typedesc_test.cpp
+++ b/src/libutil/typedesc_test.cpp
@@ -69,10 +69,7 @@ test_type(string_view textrep, TypeDesc constructed,
         tostring_formatting fm(tostring_formatting::STDFORMAT);
         fm.aggregate_sep = ", ";
         fm.array_sep     = ", ";
-#if FMT_VERSION < 70100
-        fm.float_fmt = "{:g}";
-#endif
-        std::string s = tostring(constructed, &value, fm);
+        std::string s    = tostring(constructed, &value, fm);
         if (valuerep.size()) {
             OIIO_CHECK_EQUAL(s, valuerep);
             Strutil::print("  {}\n", s);

--- a/src/libutil/ustring_test.cpp
+++ b/src/libutil/ustring_test.cpp
@@ -17,9 +17,7 @@
 #include <OpenImageIO/unittest.h>
 #include <OpenImageIO/ustring.h>
 
-#if FMT_VERSION >= 90000
-#    include <OpenImageIO/detail/fmt/std.h>
-#endif
+#include <OpenImageIO/detail/fmt/std.h>
 
 
 using namespace OIIO;


### PR DESCRIPTION
The previous minimum, 7.0, dated from mid-2020.

We are raising now (in main / future 3.2 only) to 9.0, which dates from mid-2022, so we're still supporting several versions and/or years back.

Because this changes minimum dependency versions, it will NOT be backported to release branches (3.1 or earlier).

I had to remove the CI test variant for icc, because ancient icc can't correctly build newer versions of fmt, it seems. There is a separate PR to simply drop icc from our list of supported compilers.

If anybody wants to argue for pulling the minimum up even farther (say, to fmt 10.0, released in 2023, so still supporting 3 years back), which would simplify even more places, I would consider it.

