### PR TITLE
fix(tiff): Correctly read TIFF EXIF fields for ExifVersion and FlashPixVersion

### DIFF
--- a/src/libOpenImageIO/exif.cpp
+++ b/src/libOpenImageIO/exif.cpp
@@ -260,13 +260,15 @@ print_dir_entry(std::ostream& out, const TagMap& tagmap,
 
     switch (dir.tdir_type) {
     case TIFF_ASCII:
+#    ifdef EXIF_TIFF_UTF8
     case EXIF_TIFF_UTF8:
+#    endif
         OIIO::print(out, "'{}'", string_view(mydata, dir.tdir_count));
         break;
     case TIFF_RATIONAL: {
         const unsigned int* u = (unsigned int*)mydata;
         for (size_t i = 0; i < dir.tdir_count; ++i)
-            OIIO::print(out, "{}/{} = {} ", u[2 * i], << u[2 * i + 1],
+            OIIO::print(out, "{}/{} = {} ", u[2 * i], u[2 * i + 1],
                         (double)u[2 * i] / (double)u[2 * i + 1]);
     } break;
     case TIFF_SRATIONAL: {
@@ -449,7 +451,7 @@ static const TagInfo exif_tag_table[] = {
     { EXIF_SPECTRALSENSITIVITY,"Exif:SpectralSensitivity",	TIFF_ASCII, 0 },
     { EXIF_ISOSPEEDRATINGS,	"Exif:ISOSpeedRatings",	TIFF_SHORT, 1 },
     { EXIF_OECF,	        "Exif:OECF",	TIFF_NOTYPE, 1 },	 // skip it
-    { EXIF_EXIFVERSION,	"Exif:ExifVersion",	TIFF_UNDEFINED, 1, version4char_handler },	 // skip it
+    { EXIF_EXIFVERSION,	"Exif:ExifVersion",	TIFF_UNDEFINED, 1, version4char_handler },
     { EXIF_DATETIMEORIGINAL,	"Exif:DateTimeOriginal",	TIFF_ASCII, 0 },
     { EXIF_DATETIMEDIGITIZED,"Exif:DateTimeDigitized",   TIFF_ASCII, 0 },
     { EXIF_OFFSETTIME,"Exif:OffsetTime",   TIFF_ASCII, 0 },
@@ -475,7 +477,7 @@ static const TagInfo exif_tag_table[] = {
     { EXIF_SUBSECTIME,	"Exif:SubsecTime",	        TIFF_ASCII, 0 },
     { EXIF_SUBSECTIMEORIGINAL,"Exif:SubsecTimeOriginal",	TIFF_ASCII, 0 },
     { EXIF_SUBSECTIMEDIGITIZED,"Exif:SubsecTimeDigitized",	TIFF_ASCII, 0 },
-    { EXIF_FLASHPIXVERSION,	"Exif:FlashPixVersion",	TIFF_UNDEFINED, 1, version4char_handler },	// skip "Exif:FlashPixVesion",	TIFF_NOTYPE, 1 },
+    { EXIF_FLASHPIXVERSION,	"Exif:FlashPixVersion",	TIFF_UNDEFINED, 1, version4char_handler },
     { EXIF_COLORSPACE,	"Exif:ColorSpace",	TIFF_SHORT, 1 },
     { EXIF_PIXELXDIMENSION,	"Exif:PixelXDimension",	TIFF_LONG, 1 },
     { EXIF_PIXELYDIMENSION,	"Exif:PixelYDimension",	TIFF_LONG, 1 },
@@ -1202,7 +1204,7 @@ decode_exif(cspan<uint8_t> exif, ImageSpec& spec)
 
 #if DEBUG_EXIF_READ
     std::cerr << "Exif dump:\n";
-    for (size_t i = 0; i < std::min(200L, exif.size()); ++i) {
+    for (size_t i = 0; i < std::min(200UL, exif.size()); ++i) {
         if ((i % 16) == 0)
             std::cerr << "[" << i << "] ";
         if (exif[i] >= ' ')

--- a/src/tiff.imageio/tiffoutput.cpp
+++ b/src/tiff.imageio/tiffoutput.cpp
@@ -1202,16 +1202,18 @@ TIFFOutput::write_exif_data()
                 handled = true;
             }
             if (!handled) {
-#    ifndef NDEBUG
+#    if 0
                 print("Unhandled EXIF {} ({}) / tag {} tifftype {} count {}\n",
                       p.name(), p.type(), tag, tifftype, count);
 #    endif
             }
             // NOTE: We are not handling arrays of values, just scalars.
             if (!ok) {
-                // print(
-                //     "Error handling EXIF {} ({}) / tag {} tifftype {} count {}\n",
-                //     p.name(), p.type(), tag, tifftype, count);
+#    if 0
+                print(
+                    "Error handling EXIF {} ({}) / tag {} tifftype {} count {}\n",
+                    p.name(), p.type(), tag, tifftype, count);
+#    endif
             }
         }
     }

--- a/testsuite/tiff-suite/ref/out-alt.txt
+++ b/testsuite/tiff-suite/ref/out-alt.txt
@@ -68,9 +68,11 @@ Reading ../oiio-images/libtiffpic/dscf0013.tif
     Exif:ColorSpace: 1
     Exif:DateTimeDigitized: "2004:11:10 00:00:31"
     Exif:DateTimeOriginal: "2004:11:10 00:00:31"
+    Exif:ExifVersion: "0210"
     Exif:ExposureBiasValue: 0
     Exif:ExposureProgram: 2 (normal program)
     Exif:Flash: 1 (flash fired)
+    Exif:FlashPixVersion: "0100"
     Exif:FocalLength: 7.4 (7.4 mm)
     Exif:FocalPlaneResolutionUnit: 3 (cm)
     Exif:FocalPlaneXResolution: 847
@@ -238,10 +240,12 @@ Reading ../oiio-images/libtiffpic/pc260001.tif
     Exif:DateTimeDigitized: "2005:12:26 17:09:35"
     Exif:DateTimeOriginal: "2005:12:26 17:09:35"
     Exif:DigitalZoomRatio: 0
+    Exif:ExifVersion: "0221"
     Exif:ExposureBiasValue: 0
     Exif:ExposureMode: 0 (auto)
     Exif:ExposureProgram: 2 (normal program)
     Exif:Flash: 89 (flash fired, auto flash, red-eye reduction)
+    Exif:FlashPixVersion: "0100"
     Exif:FocalLength: 17.8 (17.8 mm)
     Exif:LightSource: 0 (unknown)
     Exif:MaxApertureValue: 3 (f/2.8)

--- a/testsuite/tiff-suite/ref/out-alt2.txt
+++ b/testsuite/tiff-suite/ref/out-alt2.txt
@@ -68,9 +68,11 @@ Reading ../oiio-images/libtiffpic/dscf0013.tif
     Exif:ColorSpace: 1
     Exif:DateTimeDigitized: "2004:11:10 00:00:31"
     Exif:DateTimeOriginal: "2004:11:10 00:00:31"
+    Exif:ExifVersion: "0210"
     Exif:ExposureBiasValue: 0
     Exif:ExposureProgram: 2 (normal program)
     Exif:Flash: 1 (flash fired)
+    Exif:FlashPixVersion: "0100"
     Exif:FocalLength: 7.4 (7.4 mm)
     Exif:FocalPlaneResolutionUnit: 3 (cm)
     Exif:FocalPlaneXResolution: 847
@@ -238,10 +240,12 @@ Reading ../oiio-images/libtiffpic/pc260001.tif
     Exif:DateTimeDigitized: "2005:12:26 17:09:35"
     Exif:DateTimeOriginal: "2005:12:26 17:09:35"
     Exif:DigitalZoomRatio: 0
+    Exif:ExifVersion: "0221"
     Exif:ExposureBiasValue: 0
     Exif:ExposureMode: 0 (auto)
     Exif:ExposureProgram: 2 (normal program)
     Exif:Flash: 89 (flash fired, auto flash, red-eye reduction)
+    Exif:FlashPixVersion: "0100"
     Exif:FocalLength: 17.8 (17.8 mm)
     Exif:LightSource: 0 (unknown)
     Exif:MaxApertureValue: 3 (f/2.8)

--- a/testsuite/tiff-suite/ref/out-jpeg9b.txt
+++ b/testsuite/tiff-suite/ref/out-jpeg9b.txt
@@ -68,9 +68,11 @@ Reading ../oiio-images/libtiffpic/dscf0013.tif
     Exif:ColorSpace: 1
     Exif:DateTimeDigitized: "2004:11:10 00:00:31"
     Exif:DateTimeOriginal: "2004:11:10 00:00:31"
+    Exif:ExifVersion: "0210"
     Exif:ExposureBiasValue: 0
     Exif:ExposureProgram: 2 (normal program)
     Exif:Flash: 1 (flash fired)
+    Exif:FlashPixVersion: "0100"
     Exif:FocalLength: 7.4 (7.4 mm)
     Exif:FocalPlaneResolutionUnit: 3 (cm)
     Exif:FocalPlaneXResolution: 847
@@ -238,10 +240,12 @@ Reading ../oiio-images/libtiffpic/pc260001.tif
     Exif:DateTimeDigitized: "2005:12:26 17:09:35"
     Exif:DateTimeOriginal: "2005:12:26 17:09:35"
     Exif:DigitalZoomRatio: 0
+    Exif:ExifVersion: "0221"
     Exif:ExposureBiasValue: 0
     Exif:ExposureMode: 0 (auto)
     Exif:ExposureProgram: 2 (normal program)
     Exif:Flash: 89 (flash fired, auto flash, red-eye reduction)
+    Exif:FlashPixVersion: "0100"
     Exif:FocalLength: 17.8 (17.8 mm)
     Exif:LightSource: 0 (unknown)
     Exif:MaxApertureValue: 3 (f/2.8)

--- a/testsuite/tiff-suite/ref/out-jpeg9d-alt.txt
+++ b/testsuite/tiff-suite/ref/out-jpeg9d-alt.txt
@@ -68,9 +68,11 @@ Reading ../oiio-images/libtiffpic/dscf0013.tif
     Exif:ColorSpace: 1
     Exif:DateTimeDigitized: "2004:11:10 00:00:31"
     Exif:DateTimeOriginal: "2004:11:10 00:00:31"
+    Exif:ExifVersion: "0210"
     Exif:ExposureBiasValue: 0
     Exif:ExposureProgram: 2 (normal program)
     Exif:Flash: 1 (flash fired)
+    Exif:FlashPixVersion: "0100"
     Exif:FocalLength: 7.4 (7.4 mm)
     Exif:FocalPlaneResolutionUnit: 3 (cm)
     Exif:FocalPlaneXResolution: 847
@@ -238,10 +240,12 @@ Reading ../oiio-images/libtiffpic/pc260001.tif
     Exif:DateTimeDigitized: "2005:12:26 17:09:35"
     Exif:DateTimeOriginal: "2005:12:26 17:09:35"
     Exif:DigitalZoomRatio: 0
+    Exif:ExifVersion: "0221"
     Exif:ExposureBiasValue: 0
     Exif:ExposureMode: 0 (auto)
     Exif:ExposureProgram: 2 (normal program)
     Exif:Flash: 89 (flash fired, auto flash, red-eye reduction)
+    Exif:FlashPixVersion: "0100"
     Exif:FocalLength: 17.8 (17.8 mm)
     Exif:LightSource: 0 (unknown)
     Exif:MaxApertureValue: 3 (f/2.8)

--- a/testsuite/tiff-suite/ref/out.txt
+++ b/testsuite/tiff-suite/ref/out.txt
@@ -68,9 +68,11 @@ Reading ../oiio-images/libtiffpic/dscf0013.tif
     Exif:ColorSpace: 1
     Exif:DateTimeDigitized: "2004:11:10 00:00:31"
     Exif:DateTimeOriginal: "2004:11:10 00:00:31"
+    Exif:ExifVersion: "0210"
     Exif:ExposureBiasValue: 0
     Exif:ExposureProgram: 2 (normal program)
     Exif:Flash: 1 (flash fired)
+    Exif:FlashPixVersion: "0100"
     Exif:FocalLength: 7.4 (7.4 mm)
     Exif:FocalPlaneResolutionUnit: 3 (cm)
     Exif:FocalPlaneXResolution: 847
@@ -238,10 +240,12 @@ Reading ../oiio-images/libtiffpic/pc260001.tif
     Exif:DateTimeDigitized: "2005:12:26 17:09:35"
     Exif:DateTimeOriginal: "2005:12:26 17:09:35"
     Exif:DigitalZoomRatio: 0
+    Exif:ExifVersion: "0221"
     Exif:ExposureBiasValue: 0
     Exif:ExposureMode: 0 (auto)
     Exif:ExposureProgram: 2 (normal program)
     Exif:Flash: 89 (flash fired, auto flash, red-eye reduction)
+    Exif:FlashPixVersion: "0100"
     Exif:FocalLength: 17.8 (17.8 mm)
     Exif:LightSource: 0 (unknown)
     Exif:MaxApertureValue: 3 (f/2.8)


### PR DESCRIPTION
This allows us to correctly read the ExifVersion and FlashPixVersion metadata in an EXIF block of a TIFF file.

