### PR TITLE
fix(oiiotool): Fix expression BOTTOM when there are exactly two images

### DIFF
--- a/src/oiiotool/expressions.cpp
+++ b/src/oiiotool/expressions.cpp
@@ -156,7 +156,7 @@ Oiiotool::express_parse_atom(const string_view expr, string_view& s,
         if (Strutil::parse_prefix(s, "TOP")) {
             img = curimg;
         } else if (Strutil::parse_prefix(s, "BOTTOM")) {
-            img = (image_stack.size() <= 1) ? curimg : image_stack[0];
+            img = image_stack.empty() ? curimg : image_stack[0];
         } else if (Strutil::parse_prefix(s, "IMG[")) {
             std::string until_bracket = Strutil::parse_until(s, "]");
             if (until_bracket.empty() || !Strutil::parse_char(s, ']')) {

--- a/testsuite/oiiotool-control/ref/out.txt
+++ b/testsuite/oiiotool-control/ref/out.txt
@@ -1,5 +1,19 @@
-Stack holds [0] = d.tif, [1] = c.tif, [2] = b.tif
+Stack holds [0] = d.tif, [1] = c.tif, [2] = b.tif , [3] = a.tif
 TOP = d.tif, BOTTOM = a.tif
+Stack holds [0] = b.tif, [1] = a.tif
+TOP = b.tif, BOTTOM = a.tif
+Stack holds [0] = a.tif
+TOP = a.tif, BOTTOM = a.tif
+Stack is empty
+oiiotool ERROR: expression : not a valid image at char 4 of 'TOP.filename'
+Full command line was:
+> oiiotool --echo "Stack is empty" --echo "TOP = {TOP.filename}"
+TOP = TOP.filename
+Stack is empty
+oiiotool ERROR: expression : not a valid image at char 7 of 'BOTTOM.filename'
+Full command line was:
+> oiiotool --echo "Stack is empty" --echo "BOTTOM = {BOTTOM.filename}"
+BOTTOM = BOTTOM.filename
 Stack bottom to top:
   a.tif
   b.tif

--- a/testsuite/oiiotool-control/run.py
+++ b/testsuite/oiiotool-control/run.py
@@ -23,9 +23,26 @@ command += oiiotool ('-pattern:type=uint8 constant:color=1,0,0 2x2 3 -o a.tif ' 
 # Test TOP, BOTTOM, IMG[]
 # TOP should be c.tif, BOTTOM should be a.tif
 command += oiiotool ("a.tif b.tif c.tif d.tif " +
-                     "--echo \"Stack holds [0] = {IMG[0].filename}, [1] = {IMG[1].filename}, [2] = {IMG[2].filename}\" " +
+                     "--echo \"Stack holds [0] = {IMG[0].filename}, [1] = {IMG[1].filename}, [2] = {IMG[2].filename} , [3] = {IMG[3].filename}\" " +
                      "--echo \"TOP = {TOP.filename}, BOTTOM = {BOTTOM.filename}\" "
                      )
+# Regression test (Issue #5044): make sure BOTTOM works correctly for 0-2 images
+command += oiiotool ("a.tif b.tif " +
+                     "--echo \"Stack holds [0] = {IMG[0].filename}, [1] = {IMG[1].filename}\" " +
+                     "--echo \"TOP = {TOP.filename}, BOTTOM = {BOTTOM.filename}\" "
+                     )
+command += oiiotool ("a.tif " +
+                     "--echo \"Stack holds [0] = {IMG[0].filename}\" " +
+                     "--echo \"TOP = {TOP.filename}, BOTTOM = {BOTTOM.filename}\" "
+                     )
+# Empty -- should get an error about TOP and BOTTOM not being available
+command += oiiotool ("--echo \"Stack is empty\" " +
+                     "--echo \"TOP = {TOP.filename}\" "
+                     )
+command += oiiotool ("--echo \"Stack is empty\" " +
+                     "--echo \"BOTTOM = {BOTTOM.filename}\" "
+                     )
+
 # Test --pop, --popbottom, --stackreverse, --stackclear, --stackextract
 command += oiiotool (
       "a.tif b.tif c.tif d.tif "


### PR DESCRIPTION
Fixes #5044

Oops, the logic was a little mixed up when there were exactly two images. One reason that this was a special case is that conceptually, there is just a stack, but the implementation is that there is a separate variable for the top item, and then the actual stack is all the other items.

Also add more thorough testing of TOP/BOTTOM, including what happens for 2, 1, and also 0 items on the image stack (errors in that last case).

