### PR TITLE
jxl: Extending JXL CICP support to include P3 / color primaries 12

### DIFF
--- a/src/jpegxl.imageio/jxlinput.cpp
+++ b/src/jpegxl.imageio/jxlinput.cpp
@@ -383,9 +383,15 @@ JxlInput::open(const std::string& name, ImageSpec& newspec)
     if (have_color_encoding && color_encoding.primaries != JXL_PRIMARIES_CUSTOM
         && color_encoding.white_point != JXL_WHITE_POINT_CUSTOM
         && color_encoding.transfer_function != JXL_TRANSFER_FUNCTION_GAMMA) {
-        const int cicp[4] = { color_encoding.primaries,
-                              color_encoding.transfer_function, 0 /* RGB */,
-                              1 /* Full range */ };
+        int color_primaries = color_encoding.primaries;
+        // JxlPrimaries enum only covers P3 primaries as value 11 and not 12
+        // but CICP has separate code values based on white point.
+        if (color_primaries == JXL_PRIMARIES_P3
+            && color_encoding.white_point == JXL_WHITE_POINT_D65) {
+            color_primaries = 12;
+        }
+        const int cicp[4] = { color_primaries, color_encoding.transfer_function,
+                              0 /* RGB */, 1 /* Full range */ };
         m_spec.attribute("CICP", TypeDesc(TypeDesc::INT, 4), cicp);
         const ColorConfig& colorconfig(ColorConfig::default_colorconfig());
         string_view interop_id = colorconfig.get_color_interop_id(cicp);

--- a/src/jpegxl.imageio/jxloutput.cpp
+++ b/src/jpegxl.imageio/jxloutput.cpp
@@ -571,7 +571,18 @@ JxlOutput::save_image(const void* data)
         // primaries and white point are not currently used but could help
         // support more CICP codes.
         JxlColorEncoding color_encoding {};
-        color_encoding.primaries         = JxlPrimaries(cicp[0]);
+        color_encoding.primaries = JxlPrimaries(cicp[0]);
+        // CICP primaries 11 and 12 both represent P3, but with different white points.
+        if (cicp[0] == 11) {
+            color_encoding.white_point = JXL_WHITE_POINT_DCI;
+        }
+        // JxlPrimaries enum only covers P3 primaries as value 11 and not 12.
+        else if (cicp[0] == 12) {
+            color_encoding.primaries   = JXL_PRIMARIES_P3;
+            color_encoding.white_point = JXL_WHITE_POINT_D65;
+        } else {
+            color_encoding.white_point = JXL_WHITE_POINT_D65;
+        }
         color_encoding.transfer_function = JxlTransferFunction(cicp[1]);
         color_encoding.color_space       = JXL_COLOR_SPACE_RGB;
 
@@ -581,10 +592,7 @@ JxlOutput::save_image(const void* data)
         switch (color_encoding.primaries) {
         case JXL_PRIMARIES_SRGB:
         case JXL_PRIMARIES_2100:
-        case JXL_PRIMARIES_P3:
-            supported_primaries        = true;
-            color_encoding.white_point = JXL_WHITE_POINT_D65;
-            break;
+        case JXL_PRIMARIES_P3: supported_primaries = true; break;
         case JXL_PRIMARIES_CUSTOM:  // Not an actual CICP code in JXL
             break;
         }

--- a/testsuite/jxl/ref/out.txt
+++ b/testsuite/jxl/ref/out.txt
@@ -42,3 +42,48 @@ tahoe-cicp-pq.jxl    :  128 x   96, 3 channel, uint8 jpegxl
     ICCProfile:profile_version: "4.4.0"
     ICCProfile:rendering_intent: "Perceptual"
     oiio:ColorSpace: "pq_rec2020_display"
+Reading tahoe-cicp-dcip3.jxl
+tahoe-cicp-dcip3.jxl :  128 x   96, 3 channel, uint8 jpegxl
+    SHA-1: 069F1A3E5567349C2D34E535B29913029EF1B09C
+    channel list: R, G, B
+    CICP: 11, 17, 0, 1
+    ICCProfile: 0, 0, 2, 24, 106, 120, 108, 32, 4, 64, 0, 0, 109, 110, 116, 114, ... [536 x uint8]
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1786276896
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "CC0"
+    ICCProfile:creation_date: "2019:12:01 00:00:00"
+    ICCProfile:creator_signature: "6a786c20"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "0"
+    ICCProfile:model: "0"
+    ICCProfile:platform_signature: "Apple Computer, Inc."
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "RGB_DCI_DCI_Per_DCI"
+    ICCProfile:profile_size: 536
+    ICCProfile:profile_version: "4.4.0"
+    ICCProfile:rendering_intent: "Perceptual"
+Reading tahoe-cicp-displayp3.jxl
+tahoe-cicp-displayp3.jxl :  128 x   96, 3 channel, uint8 jpegxl
+    SHA-1: 069F1A3E5567349C2D34E535B29913029EF1B09C
+    channel list: R, G, B
+    CICP: 12, 13, 0, 1
+    ICCProfile: 0, 0, 2, 4, 106, 120, 108, 32, 4, 64, 0, 0, 109, 110, 116, 114, ... [516 x uint8]
+    ICCProfile:attributes: "Reflective, Glossy, Positive, Color"
+    ICCProfile:cmm_type: 1786276896
+    ICCProfile:color_space: "RGB"
+    ICCProfile:copyright: "CC0"
+    ICCProfile:creation_date: "2019:12:01 00:00:00"
+    ICCProfile:creator_signature: "6a786c20"
+    ICCProfile:device_class: "Display device profile"
+    ICCProfile:flags: "Not Embedded, Independent"
+    ICCProfile:manufacturer: "0"
+    ICCProfile:model: "0"
+    ICCProfile:platform_signature: "Apple Computer, Inc."
+    ICCProfile:profile_connection_space: "XYZ"
+    ICCProfile:profile_description: "DisplayP3"
+    ICCProfile:profile_size: 516
+    ICCProfile:profile_version: "4.4.0"
+    ICCProfile:rendering_intent: "Perceptual"
+    oiio:ColorSpace: "srgb_p3d65_scene"

--- a/testsuite/jxl/run.py
+++ b/testsuite/jxl/run.py
@@ -13,6 +13,12 @@ command += oiiotool ("tahoe-icc.jxl --iccwrite test-jxl.icc")
 command += oiiotool ("../common/tahoe-tiny.tif --cicp \"9,16,9,1\" -o tahoe-cicp-pq.jxl")
 command += info_command ("tahoe-cicp-pq.jxl", safematch=True)
 
+command += oiiotool ("../common/tahoe-tiny.tif --cicp \"11,17,0,1\" -o tahoe-cicp-dcip3.jxl")
+command += info_command ("tahoe-cicp-dcip3.jxl", safematch=True)
+
+command += oiiotool ("../common/tahoe-tiny.tif --cicp \"12,13,0,1\" -o tahoe-cicp-displayp3.jxl")
+command += info_command ("tahoe-cicp-displayp3.jxl", safematch=True)
+
 outputs = [
             "test-jxl.icc",
             "out.txt"


### PR DESCRIPTION
### Description

I tested out the JPEG XL CICP support and noticed that color primaries 12 was not supported. This pull request is looking to extend P3 support for color primaries 12.
Note: color primaries 11 uses the DCI white point and color primaries 12 uses the D65 white point.

The JxlPrimaries enum only covers P3 primaries as value 11 and not 12. See, 
https://github.com/libjxl/libjxl/blob/main/lib/include/jxl/color_encoding.h#L55-L75
Further code is therefore required to account for this on read and write.


### Tests

Tests for read and write of color primaries 11 and 12 were added.


### Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] **I have read the guidelines** on [contributions](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md) and [code review procedures](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/CodeReview.md).
- [ ] **I have updated the documentation** if my PR adds features or changes
  behavior.
- [x] **I am sure that this PR's changes are tested somewhere in the
  testsuite**.
- [x] **I have run and passed the testsuite in CI** *before* submitting the
  PR, by pushing the changes to my fork and seeing that the automated CI
  passed there. (Exceptions: If most tests pass and you can't figure out why
  the remaining ones fail, it's ok to submit the PR and ask for help. Or if
  any failures seem entirely unrelated to your change; sometimes things break
  on the GitHub runners.)
- [x] **My code follows the prevailing code style of this project** and I
  fixed any problems reported by the clang-format CI test.
- [ ] If I added or modified a public C++ API call, I have also amended the
  corresponding Python bindings. If altering ImageBufAlgo functions, I also
  exposed the new functionality as oiiotool options.
