### PR TITLE
ImageBuf: `contiguous_scanline()` + fixes to internal span

### DIFF
--- a/src/include/OpenImageIO/imagebuf.h
+++ b/src/include/OpenImageIO/imagebuf.h
@@ -1386,13 +1386,22 @@ public:
     /// Z plane stride within the localpixels memory.
     stride_t z_stride() const;
 
-    /// Is this an in-memory buffer with the data layout "contiguous", i.e.,
+    /// Is this an in-memory buffer with the data layout "fully contiguous",
+    /// i.e.,
     /// ```
     ///     pixel_stride == nchannels * pixeltype().size()
     ///     scanline_stride == pixel_stride * spec().width
     ///     z_stride == scanline_stride * spec().height
     /// ```
     bool contiguous() const;
+
+    /// Is this an in-memory buffer with the data layout "contiguous" for
+    /// each scanline (but not considering whether adjacent scanlines or
+    /// image planes are fully contiguous), i.e.,
+    /// ```
+    ///     pixel_stride == nchannels * pixeltype().size()
+    /// ```
+    bool contiguous_scanline() const;
 
     /// Are the pixels backed by an ImageCache, rather than the whole
     /// image being in RAM somewhere?

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -155,6 +155,7 @@ public:
                                      m_spec.nchannels, m_spec.width, m_spec.height,
                                      m_spec.depth, formatsize, xstride, ystride,
                                      zstride, formatsize);
+        eval_contiguous();
     }
 
     bool init_spec(string_view filename, int subimage, int miplevel,
@@ -319,10 +320,11 @@ public:
 
     void eval_contiguous()
     {
-        m_contiguous = m_bufspan.data() != nullptr
-                       && (m_storage == ImageBuf::LOCALBUFFER
-                           || m_storage == ImageBuf::APPBUFFER)
-                       && m_bufspan.is_contiguous();
+        bool in_memory = m_bufspan.data() != nullptr
+                         && (m_storage == ImageBuf::LOCALBUFFER
+                             || m_storage == ImageBuf::APPBUFFER);
+        m_contiguous          = in_memory && m_bufspan.is_contiguous();
+        m_contiguous_scanline = in_memory && m_bufspan.is_contiguous_scanline();
     }
 
     bool has_thumbnail(DoLock do_lock = DoLock(true)) const;
@@ -353,7 +355,8 @@ private:
     bool m_readonly            = true;   // The bufspan is read-only
     bool m_badfile             = false;  // File not found
     float m_pixelaspect        = 1.0f;   // Pixel aspect ratio of the image
-    bool m_contiguous          = false;
+    bool m_contiguous          = false;  // Full image is contiguous in memory
+    bool m_contiguous_scanline = false;  // Scanlines are contiguous in memory
     std::shared_ptr<ImageCache> m_imagecache;  // ImageCache to use
     TypeDesc m_cachedpixeltype;                // Data type stored in the cache
     DeepData m_deepdata;                       // Deep data
@@ -461,7 +464,6 @@ ImageBufImpl::ImageBufImpl(string_view filename, int subimage, int miplevel,
     , m_current_subimage(subimage)
     , m_current_miplevel(miplevel)
     , m_readonly(readonly)
-    , m_contiguous(false)
     , m_imagecache(imagecache)
 {
     if (spec) {
@@ -514,6 +516,7 @@ ImageBufImpl::ImageBufImpl(const ImageBufImpl& src)
     , m_badfile(src.m_badfile)
     , m_pixelaspect(src.m_pixelaspect)
     , m_contiguous(src.m_contiguous)
+    , m_contiguous_scanline(src.m_contiguous_scanline)
     , m_imagecache(src.m_imagecache)
     , m_cachedpixeltype(src.m_cachedpixeltype)
     , m_deepdata(src.m_deepdata)
@@ -774,7 +777,9 @@ ImageBufImpl::free_pixels()
     }
     m_pixels.reset();
     // print("IB Freed pixels of length {}\n", m_bufspan.size());
-    m_bufspan = {};
+    m_bufspan             = {};
+    m_contiguous          = false;
+    m_contiguous_scanline = false;
     m_deepdata.free();
     m_storage = ImageBuf::UNINITIALIZED;
     m_blackpixel.clear();
@@ -861,13 +866,14 @@ ImageBufImpl::clear()
     m_spec             = ImageSpec();
     m_nativespec       = ImageSpec();
     m_pixels.reset();
-    m_bufspan      = {};
-    m_spec_valid   = false;
-    m_pixels_valid = false;
-    m_badfile      = false;
-    m_pixels_read  = false;
-    m_pixelaspect  = 1;
-    m_contiguous   = false;
+    m_bufspan             = {};
+    m_spec_valid          = false;
+    m_pixels_valid        = false;
+    m_badfile             = false;
+    m_pixels_read         = false;
+    m_pixelaspect         = 1;
+    m_contiguous          = false;
+    m_contiguous_scanline = false;
     m_imagecache.reset();
     m_deepdata.free();
     m_blackpixel.clear();
@@ -1179,9 +1185,7 @@ ImageBufImpl::init_spec(string_view filename, int subimage, int miplevel,
             return false;
         }
 
-        m_bufspan = image_span<std::byte>(nullptr, m_spec.nchannels,
-                                          m_spec.width, m_spec.height,
-                                          m_spec.depth, m_spec.format.size());
+        set_bufspan(nullptr);
         m_blackpixel.resize(round_to_multiple(m_spec.pixel_bytes(),
                                               OIIO_SIMD_MAX_SIZE_BYTES),
                             0);
@@ -1263,9 +1267,7 @@ ImageBufImpl::init_spec(string_view filename, int subimage, int miplevel,
         m_spec_valid = true;
         m_fileformat = ustring(input->format_name());
         m_nativespec = m_spec;
-        m_bufspan    = image_span<std::byte>(nullptr, m_spec.nchannels,
-                                          m_spec.width, m_spec.height,
-                                          m_spec.depth, m_spec.format.size());
+        set_bufspan(nullptr);
         m_blackpixel.resize(
             round_to_multiple(m_spec.pixel_bytes(), OIIO_SIMD_MAX_SIZE_BYTES));
         // ^^^ NB make it big enough for SIMD
@@ -1381,10 +1383,7 @@ ImageBufImpl::read(int subimage, int miplevel, int chbegin, int chend,
         if (!localpixels() && !force && !use_channel_subset
             && (convert == m_cachedpixeltype || convert == TypeDesc::UNKNOWN)) {
             m_spec.format = m_cachedpixeltype;
-            m_bufspan     = image_span<std::byte>(nullptr, m_spec.nchannels,
-                                              m_spec.width, m_spec.height,
-                                              m_spec.depth,
-                                              m_spec.format.size());
+            set_bufspan(nullptr);
             m_blackpixel.resize(round_to_multiple(m_spec.pixel_bytes(),
                                                   OIIO_SIMD_MAX_SIZE_BYTES));
             // NB make it big enough for SSE
@@ -2197,7 +2196,17 @@ ImageBuf::z_stride() const
 bool
 ImageBuf::contiguous() const
 {
+    m_impl->validate_pixels();
     return m_impl->m_contiguous;
+}
+
+
+
+bool
+ImageBuf::contiguous_scanline() const
+{
+    m_impl->validate_pixels();
+    return m_impl->m_contiguous_scanline;
 }
 
 


### PR DESCRIPTION
Add a new ImageBuf method: `contiguous_scanline()`, which reveals if each scanline is contiguous in the ImageBuf's internal memory (no padding or unusual spacing between channels or pixels). It's analogous to the existing `contiguous()`, but the latter also tests contiguity in y and z.

Additional internal fixes:

* Always and only set m_bufspan via calls to `set_bufspan()`, so it's consistent. In particular, it ensures that we correctly set the channel size, which some call sites previously did not do correctly for untyped "byte" buffers.

* Re-evaluate the contiguous flags whenever resetting m_bufspan.

* contiguous() calls need to call validate_pixels().

  An IB from a file that hasn't been read yet into memory yet isn't considered contiguous. But once it's read, it will be (if it's got the strides right, etc.). So when somebody asks if it's contiguous, what does that mean? They are asking because they are about to do something that requires memory contiguity (meaning, it needs to be IN memory), just like if they call localpixels(). So just like localpixels(), we need to call validate_pixels() to assure that if the pixels are destined for the local buffer, it's done now if not yet.

