### PR TITLE
int: Some minor cleanup of the hwy related code

### DIFF
--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -3770,6 +3770,15 @@ OIIO_API std::string geterror(bool clear = true);
 ///    If zero, they will try to use OIIO's native thread pool even if TBB
 ///    is available.
 ///
+/// - `int enable_hwy' (0)
+///
+///    If nonzero and Google Highway was found and support configured when
+///    OIIO was built, SIMD accelertion using Highway will be used to
+///    accelerate certain ImageBufAlgo functionality. If this attribute is
+///    set to zero, that Highway-based SIMD acceleration will be disabled
+///    at runtime, even if support was enabled when OIIO was built.
+///    (Added in OIIO 3.2.)
+///
 /// - `string plugin_searchpath`
 ///
 ///    Colon-separated (or semicolon-separated) list of directories to search

--- a/src/libOpenImageIO/imagebufalgo_addsub.cpp
+++ b/src/libOpenImageIO/imagebufalgo_addsub.cpp
@@ -18,7 +18,7 @@
 #include <OpenImageIO/imagebufalgo.h>
 #include <OpenImageIO/imagebufalgo_util.h>
 
-#if defined(OIIO_USE_HWY) && OIIO_USE_HWY
+#if OIIO_USE_HWY
 #    include "imagebufalgo_hwy_pvt.h"
 #endif
 
@@ -131,7 +131,7 @@ add_impl_hwy(ImageBuf& R, const ImageBuf& A, cspan<float> b, ROI roi,
     });
     return true;
 }
-#endif  // defined(OIIO_USE_HWY) && OIIO_USE_HWY
+#endif  // OIIO_USE_HWY
 
 template<class Rtype, class Atype, class Btype>
 static bool
@@ -144,7 +144,7 @@ add_impl(ImageBuf& R, const ImageBuf& A, const ImageBuf& B, ROI roi,
         auto Rv             = HwyPixels(R);
         auto Av             = HwyPixels(A);
         auto Bv             = HwyPixels(B);
-        const int nchannels = RoiNChannels(roi);
+        const int nchannels = roi.nchannels();
         const bool contig   = ChannelsContiguous<Rtype>(Rv, nchannels)
                             && ChannelsContiguous<Atype>(Av, nchannels)
                             && ChannelsContiguous<Btype>(Bv, nchannels);
@@ -180,14 +180,14 @@ template<class Rtype, class Atype>
 static bool
 add_impl(ImageBuf& R, const ImageBuf& A, cspan<float> b, ROI roi, int nthreads)
 {
-#if defined(OIIO_USE_HWY) && OIIO_USE_HWY
+#if OIIO_USE_HWY
     if (OIIO::pvt::enable_hwy && R.localpixels() && A.localpixels())
         return add_impl_hwy<Rtype, Atype>(R, A, b, roi, nthreads);
 #endif
     return add_impl_scalar<Rtype, Atype>(R, A, b, roi, nthreads);
 }
 
-#if defined(OIIO_USE_HWY) && OIIO_USE_HWY
+#if OIIO_USE_HWY
 // Native integer sub using SaturatedSub (scale-invariant, no float conversion)
 template<class T>
 static bool
@@ -226,7 +226,7 @@ sub_impl_hwy(ImageBuf& R, const ImageBuf& A, const ImageBuf& B, ROI roi,
     return hwy_binary_perpixel_op<Rtype, Atype, Btype>(R, A, B, roi, nthreads,
                                                        op);
 }
-#endif  // defined(OIIO_USE_HWY) && OIIO_USE_HWY
+#endif  // OIIO_USE_HWY
 
 template<class Rtype, class Atype, class Btype>
 static bool
@@ -244,7 +244,7 @@ sub_impl(ImageBuf& R, const ImageBuf& A, const ImageBuf& B, ROI roi,
         auto Rv             = HwyPixels(R);
         auto Av             = HwyPixels(A);
         auto Bv             = HwyPixels(B);
-        const int nchannels = RoiNChannels(roi);
+        const int nchannels = roi.nchannels();
         const bool contig   = ChannelsContiguous<Rtype>(Rv, nchannels)
                             && ChannelsContiguous<Atype>(Av, nchannels)
                             && ChannelsContiguous<Btype>(Bv, nchannels);

--- a/src/libOpenImageIO/imagebufalgo_hwy_pvt.h
+++ b/src/libOpenImageIO/imagebufalgo_hwy_pvt.h
@@ -57,12 +57,6 @@ HwyPixels(const ImageBuf& img)
              spec.nchannels };
 }
 
-inline int
-RoiNChannels(const ROI& roi) noexcept
-{
-    return roi.chend - roi.chbegin;
-}
-
 template<class T, class ByteT>
 inline bool
 ChannelsContiguous(const HwyLocalPixelsView<ByteT>& v, int nchannels) noexcept
@@ -938,7 +932,7 @@ hwy_binary_perpixel_op(ImageBuf& R, const ImageBuf& A, const ImageBuf& B,
     auto Av = HwyPixels(A);
     auto Bv = HwyPixels(B);
     ImageBufAlgo::parallel_image(roi, nthreads, [&, op](ROI roi) {
-        const int nchannels = RoiNChannels(roi);
+        const int nchannels = roi.nchannels();
         const size_t n      = static_cast<size_t>(roi.width())
                          * static_cast<size_t>(nchannels);
         for (int y = roi.ybegin; y < roi.yend; ++y) {
@@ -965,7 +959,7 @@ hwy_ternary_perpixel_op(ImageBuf& R, const ImageBuf& A, const ImageBuf& B,
     auto Bv = HwyPixels(B);
     auto Cv = HwyPixels(C);
     ImageBufAlgo::parallel_image(roi, nthreads, [&, op](ROI roi) {
-        const int nchannels = RoiNChannels(roi);
+        const int nchannels = roi.nchannels();
         const size_t n      = static_cast<size_t>(roi.width())
                          * static_cast<size_t>(nchannels);
         for (int y = roi.ybegin; y < roi.yend; ++y) {
@@ -992,7 +986,7 @@ hwy_binary_native_int_perpixel_op(ImageBuf& R, const ImageBuf& A,
     auto Av = HwyPixels(A);
     auto Bv = HwyPixels(B);
     ImageBufAlgo::parallel_image(roi, nthreads, [&, op](ROI roi) {
-        const int nchannels = RoiNChannels(roi);
+        const int nchannels = roi.nchannels();
         const size_t n      = static_cast<size_t>(roi.width())
                          * static_cast<size_t>(nchannels);
         for (int y = roi.ybegin; y < roi.yend; ++y) {

--- a/src/libOpenImageIO/imagebufalgo_mad.cpp
+++ b/src/libOpenImageIO/imagebufalgo_mad.cpp
@@ -16,7 +16,7 @@
 #include <OpenImageIO/imagebufalgo.h>
 #include <OpenImageIO/imagebufalgo_util.h>
 
-#if defined(OIIO_USE_HWY) && OIIO_USE_HWY
+#if OIIO_USE_HWY
 #    include "imagebufalgo_hwy_pvt.h"
 #endif
 #include "imageio_pvt.h"
@@ -46,7 +46,7 @@ mad_impl_scalar(ImageBuf& R, const ImageBuf& A, const ImageBuf& B,
 
 
 
-#if defined(OIIO_USE_HWY) && OIIO_USE_HWY
+#if OIIO_USE_HWY
 template<class Rtype, class ABCtype>
 static bool
 mad_impl_hwy(ImageBuf& R, const ImageBuf& A, const ImageBuf& B,
@@ -63,21 +63,21 @@ mad_impl_hwy(ImageBuf& R, const ImageBuf& A, const ImageBuf& B,
     return hwy_ternary_perpixel_op<Rtype, ABCtype>(R, A, B, C, roi, nthreads,
                                                    op);
 }
-#endif  // defined(OIIO_USE_HWY) && OIIO_USE_HWY
+#endif  // OIIO_USE_HWY
 
 template<class Rtype, class ABCtype>
 static bool
 mad_impl(ImageBuf& R, const ImageBuf& A, const ImageBuf& B, const ImageBuf& C,
          ROI roi, int nthreads)
 {
-#if defined(OIIO_USE_HWY) && OIIO_USE_HWY
+#if OIIO_USE_HWY
     if (OIIO::pvt::enable_hwy && R.localpixels() && A.localpixels()
         && B.localpixels() && C.localpixels()) {
         auto Rv             = HwyPixels(R);
         auto Av             = HwyPixels(A);
         auto Bv             = HwyPixels(B);
         auto Cv             = HwyPixels(C);
-        const int nchannels = RoiNChannels(roi);
+        const int nchannels = roi.nchannels();
         const bool contig   = ChannelsContiguous<Rtype>(Rv, nchannels)
                             && ChannelsContiguous<ABCtype>(Av, nchannels)
                             && ChannelsContiguous<ABCtype>(Bv, nchannels)

--- a/src/libOpenImageIO/imagebufalgo_muldiv.cpp
+++ b/src/libOpenImageIO/imagebufalgo_muldiv.cpp
@@ -16,7 +16,7 @@
 
 #include <OpenImageIO/half.h>
 
-#if defined(OIIO_USE_HWY) && OIIO_USE_HWY
+#if OIIO_USE_HWY
 #    include "imagebufalgo_hwy_pvt.h"
 #endif
 #include <OpenImageIO/dassert.h>
@@ -125,7 +125,7 @@ mul_impl_scalar(ImageBuf& R, const ImageBuf& A, cspan<float> b, ROI roi,
 
 
 
-#if defined(OIIO_USE_HWY) && OIIO_USE_HWY
+#if OIIO_USE_HWY
 template<class Rtype, class Atype, class Btype>
 static bool
 mul_impl_hwy(ImageBuf& R, const ImageBuf& A, const ImageBuf& B, ROI roi,
@@ -168,7 +168,7 @@ mul_impl_hwy(ImageBuf& R, const ImageBuf& A, cspan<float> b, ROI roi,
     });
     return true;
 }
-#endif  // defined(OIIO_USE_HWY) && OIIO_USE_HWY
+#endif  // OIIO_USE_HWY
 
 template<class Rtype, class Atype, class Btype>
 static bool
@@ -181,7 +181,7 @@ mul_impl(ImageBuf& R, const ImageBuf& A, const ImageBuf& B, ROI roi,
         auto Rv             = HwyPixels(R);
         auto Av             = HwyPixels(A);
         auto Bv             = HwyPixels(B);
-        const int nchannels = RoiNChannels(roi);
+        const int nchannels = roi.nchannels();
         const bool contig   = ChannelsContiguous<Rtype>(Rv, nchannels)
                             && ChannelsContiguous<Atype>(Av, nchannels)
                             && ChannelsContiguous<Btype>(Bv, nchannels);
@@ -208,7 +208,7 @@ template<class Rtype, class Atype>
 static bool
 mul_impl(ImageBuf& R, const ImageBuf& A, cspan<float> b, ROI roi, int nthreads)
 {
-#if defined(OIIO_USE_HWY) && OIIO_USE_HWY
+#if OIIO_USE_HWY
     if (OIIO::pvt::enable_hwy && R.localpixels() && A.localpixels())
         return mul_impl_hwy<Rtype, Atype>(R, A, b, roi, nthreads);
 #endif
@@ -314,7 +314,7 @@ div_impl_scalar(ImageBuf& R, const ImageBuf& A, const ImageBuf& B, ROI roi,
 
 
 
-#if defined(OIIO_USE_HWY) && OIIO_USE_HWY
+#if OIIO_USE_HWY
 template<class Rtype, class Atype, class Btype>
 static bool
 div_impl_hwy(ImageBuf& R, const ImageBuf& A, const ImageBuf& B, ROI roi,
@@ -336,7 +336,7 @@ div_impl_hwy(ImageBuf& R, const ImageBuf& A, const ImageBuf& B, ROI roi,
     return hwy_binary_perpixel_op<Rtype, Atype, Btype>(R, A, B, roi, nthreads,
                                                        op);
 }
-#endif  // defined(OIIO_USE_HWY) && OIIO_USE_HWY
+#endif  // OIIO_USE_HWY
 
 template<class Rtype, class Atype, class Btype>
 static bool
@@ -349,7 +349,7 @@ div_impl(ImageBuf& R, const ImageBuf& A, const ImageBuf& B, ROI roi,
         auto Rv             = HwyPixels(R);
         auto Av             = HwyPixels(A);
         auto Bv             = HwyPixels(B);
-        const int nchannels = RoiNChannels(roi);
+        const int nchannels = roi.nchannels();
         const bool contig   = ChannelsContiguous<Rtype>(Rv, nchannels)
                             && ChannelsContiguous<Atype>(Av, nchannels)
                             && ChannelsContiguous<Btype>(Bv, nchannels);

--- a/src/libOpenImageIO/imagebufalgo_test.cpp
+++ b/src/libOpenImageIO/imagebufalgo_test.cpp
@@ -518,7 +518,7 @@ test_mad()
 void
 test_hwy_strided_roi_fallback()
 {
-#if defined(OIIO_USE_HWY) && OIIO_USE_HWY
+#if OIIO_USE_HWY
     std::cout << "test hwy strided roi fallback\n";
 
     int prev_enable_hwy = 0;

--- a/src/libOpenImageIO/imagebufalgo_xform.cpp
+++ b/src/libOpenImageIO/imagebufalgo_xform.cpp
@@ -21,7 +21,7 @@
 
 #include <Imath/ImathBox.h>
 
-#if defined(OIIO_USE_HWY) && OIIO_USE_HWY
+#if OIIO_USE_HWY
 #    include "imagebufalgo_hwy_pvt.h"
 #endif
 
@@ -1266,7 +1266,7 @@ resample_deep(ImageBuf& dst, const ImageBuf& src, bool interpolate, ROI roi,
 
 
 
-#if defined(OIIO_USE_HWY) && OIIO_USE_HWY
+#if OIIO_USE_HWY
 template<typename DSTTYPE, typename SRCTYPE>
 static bool
 resample_hwy(ImageBuf& dst, const ImageBuf& src, bool interpolate, ROI roi,
@@ -1427,14 +1427,14 @@ resample_hwy(ImageBuf& dst, const ImageBuf& src, bool interpolate, ROI roi,
     });
     return true;
 }
-#endif  // defined(OIIO_USE_HWY) && OIIO_USE_HWY
+#endif  // OIIO_USE_HWY
 
 template<typename DSTTYPE, typename SRCTYPE>
 static bool
 resample_(ImageBuf& dst, const ImageBuf& src, bool interpolate, ROI roi,
           int nthreads)
 {
-#if defined(OIIO_USE_HWY) && OIIO_USE_HWY
+#if OIIO_USE_HWY
     if (OIIO::pvt::enable_hwy && dst.localpixels() && src.localpixels())
         return resample_hwy<DSTTYPE, SRCTYPE>(dst, src, interpolate, roi,
                                               nthreads);


### PR DESCRIPTION
* imageio.h: Document 'enable_hwy' global option.

* imagebufalgo_hwy_pvt.h: Remove RoiNChannels -- it's the same as roi.nchannels()

* Macros: we can simply test OIIO_USE_HWY, since it's always defined; there is no need to also test defined(OIIO_USE_HWY).

