### PR TITLE
ci: Unbreak Mac CI by adding jpeg-xl install

### DIFF
--- a/src/build-scripts/install_homebrew_deps.bash
+++ b/src/build-scripts/install_homebrew_deps.bash
@@ -35,6 +35,7 @@ if [[ "$OIIO_BREW_INSTALL_PACKAGES" == "" ]] ; then
         expat \
         ffmpeg \
         imath \
+        jpeg-xl \
         libheif \
         libraw \
         libultrahdr \


### PR DESCRIPTION
It must have been among the homebrew packages in the base Mac installation on GHA, until just a couple days ago?
