### PR TITLE
int: Turn on OIIO_NODISCARD_ERROR_ENABLE for internal builds

### DIFF
--- a/src/doc/Doxyfile
+++ b/src/doc/Doxyfile
@@ -2202,6 +2202,7 @@ PREDEFINED             = DOXYGEN_SHOULD_SKIP_THIS \
                          OIIO_CONST_FUNC= \
                          OIIO_MAYBE_UNUSED= \
                          OIIO_NODISCARD:= \
+                         OIIO_NODISCARD_ERROR:= \
                          OIIO_DEPRECATED(x)=[[deprecated]] \
                          OIIO_FORMAT_DEPRECATED:= \
                          OIIO_FORCEINLINE=inline \

--- a/src/include/OpenImageIO/platform.h
+++ b/src/include/OpenImageIO/platform.h
@@ -475,10 +475,12 @@
 // override the default, for example to flag discarded errors in older
 // versions of OIIO, or to disable the warnings in future versions of OIIO.
 #ifndef OIIO_NODISCARD_ERROR_ENABLE
-#    if OIIO_VERSION_LESS(3, 3, 0)
-#        define OIIO_NODISCARD_ERROR_ENABLE 0 /* disable for now */
+#    if OIIO_VERSION_GREATER_EQUAL(3, 3, 0) || defined(OIIO_INTERNAL)
+         /* enable for OIIO >= 3.3, or now for OIIO's own build */
+#        define OIIO_NODISCARD_ERROR_ENABLE 1
 #    else
-#        define OIIO_NODISCARD_ERROR_ENABLE 1 /* enable for OIIO >= 3.3 */
+         /* disable for now externally */
+#        define OIIO_NODISCARD_ERROR_ENABLE 0
 #    endif
 #endif
 

--- a/src/libOpenImageIO/imageinout_test.cpp
+++ b/src/libOpenImageIO/imageinout_test.cpp
@@ -483,7 +483,10 @@ test_read_tricky_sizes()
     // Read in, make sure it's right, several different ways
     {
         auto imgin = ImageInput::open(srcfilename);
-        imgin->read_image(0, 0, 0, 4, TypeUInt8, buf, 4 /* xstride */);
+        OIIO_ASSERT(imgin);
+        bool ok = imgin->read_image(0, 0, 0, 4, TypeUInt8, buf,
+                                    4 /* xstride */);
+        OIIO_ASSERT(ok);
         OIIO_CHECK_EQUAL(int(buf[0][0][0]), 128);
         OIIO_CHECK_EQUAL(int(buf[0][0][1]), 0);
         OIIO_CHECK_EQUAL(int(buf[0][0][2]), 0);
@@ -492,8 +495,9 @@ test_read_tricky_sizes()
     {
         memset(buf, 0, 4 * 4 * 4);
         auto imgin = ImageInput::open(srcfilename);
-        imgin->read_scanlines(0, 0, 0, 4, 0, 0, 4, TypeUInt8, buf,
-                              /*xstride=*/4);
+        bool ok    = imgin->read_scanlines(0, 0, 0, 4, 0, 0, 4, TypeUInt8, buf,
+                                           /*xstride=*/4);
+        OIIO_ASSERT(ok);
         OIIO_CHECK_EQUAL(int(buf[0][0][0]), 128);
         OIIO_CHECK_EQUAL(int(buf[0][0][1]), 0);
         OIIO_CHECK_EQUAL(int(buf[0][0][2]), 0);
@@ -502,8 +506,11 @@ test_read_tricky_sizes()
     {
         memset(buf, 0, 4 * 4 * 4);
         auto imgin = ImageInput::open(srcfilename);
+        OIIO_ASSERT(imgin);
+        bool ok = true;
         for (int y = 0; y < 4; ++y)
-            imgin->read_scanline(y, 0, TypeUInt8, buf, /*xstride=*/4);
+            ok &= imgin->read_scanline(y, 0, TypeUInt8, buf, /*xstride=*/4);
+        OIIO_ASSERT(ok);
         OIIO_CHECK_EQUAL(int(buf[0][0][0]), 128);
         OIIO_CHECK_EQUAL(int(buf[0][0][1]), 0);
         OIIO_CHECK_EQUAL(int(buf[0][0][2]), 0);
@@ -515,7 +522,10 @@ test_read_tricky_sizes()
     {
         memset(buf, 0, 4 * 4 * 4);
         auto imgin = ImageInput::open(srcfilename);
-        imgin->read_image(0, 0, 0, 4, TypeUInt8, buf, 4 /* xstride */);
+        OIIO_ASSERT(imgin);
+        bool ok = imgin->read_image(0, 0, 0, 4, TypeUInt8, buf,
+                                    4 /* xstride */);
+        OIIO_ASSERT(ok);
         OIIO_CHECK_EQUAL(int(buf[0][0][0]), 128);
         OIIO_CHECK_EQUAL(int(buf[0][0][1]), 0);
         OIIO_CHECK_EQUAL(int(buf[0][0][2]), 0);
@@ -524,8 +534,11 @@ test_read_tricky_sizes()
     {
         memset(buf, 0, 4 * 4 * 4);
         auto imgin = ImageInput::open(srcfilename);
-        imgin->read_tiles(0, 0, 0, 4, 0, 4, 0, 1, 0, 4, TypeUInt8, buf,
-                          /*xstride=*/4);
+        OIIO_ASSERT(imgin);
+        bool ok = imgin->read_tiles(0, 0, 0, 4, 0, 4, 0, 1, 0, 4, TypeUInt8,
+                                    buf,
+                                    /*xstride=*/4);
+        OIIO_ASSERT(ok);
         OIIO_CHECK_EQUAL(int(buf[0][0][0]), 128);
         OIIO_CHECK_EQUAL(int(buf[0][0][1]), 0);
         OIIO_CHECK_EQUAL(int(buf[0][0][2]), 0);
@@ -534,8 +547,10 @@ test_read_tricky_sizes()
     {
         memset(buf, 0, 4 * 4 * 4);
         auto imgin = ImageInput::open(srcfilename);
-        imgin->read_tile(0, 0, 0, TypeUInt8, buf, /*xstride=*/4);
+        OIIO_ASSERT(imgin);
+        bool ok = imgin->read_tile(0, 0, 0, TypeUInt8, buf, /*xstride=*/4);
         OIIO_CHECK_EQUAL(int(buf[0][0][0]), 128);
+        OIIO_ASSERT(ok);
         OIIO_CHECK_EQUAL(int(buf[0][0][1]), 0);
         OIIO_CHECK_EQUAL(int(buf[0][0][2]), 0);
         OIIO_CHECK_EQUAL(int(buf[0][0][3]), 0);

--- a/src/libOpenImageIO/imagespeed_test.cpp
+++ b/src/libOpenImageIO/imagespeed_test.cpp
@@ -86,7 +86,8 @@ time_read_image()
     for (ustring filename : input_filename) {
         auto in = ImageInput::open(filename.c_str());
         OIIO_ASSERT(in);
-        in->read_image(0, 0, 0, in->spec().nchannels, conversion, &buffer[0]);
+        (void)in->read_image(0, 0, 0, in->spec().nchannels, conversion,
+                             &buffer[0]);
         in->close();
     }
 }
@@ -126,10 +127,11 @@ time_read_64_scanlines_at_a_time()
             pixelsize = spec.pixel_bytes(true);  // UNKNOWN -> native
         imagesize_t scanlinesize = spec.width * pixelsize;
         for (int y = 0; y < spec.height; y += 64) {
-            in->read_scanlines(/*subimage=*/0, /*miplevel=*/0, y + spec.y,
-                               std::min(y + spec.y + 64, spec.y + spec.height),
-                               0, 0, spec.nchannels, conversion,
-                               &buffer[scanlinesize * y]);
+            bool ok = in->read_scanlines(
+                /*subimage=*/0, /*miplevel=*/0, y + spec.y,
+                std::min(y + spec.y + 64, spec.y + spec.height), 0, 0,
+                spec.nchannels, conversion, &buffer[scanlinesize * y]);
+            OIIO_ASSERT(ok);
         }
         in->close();
     }
@@ -548,7 +550,9 @@ main(int argc, char** argv)
         auto in = ImageInput::open(input_filename[0].c_str());
         OIIO_ASSERT(in);
         bufspec = in->spec(0, 0);
-        in->read_image(0, 0, 0, bufspec.nchannels, conversion, &buffer[0]);
+        bool ok = in->read_image(0, 0, 0, bufspec.nchannels, conversion,
+                                 &buffer[0]);
+        OIIO_ASSERT(ok);
         in->close();
         in.reset();
         std::cout << "Timing ways of writing images:\n";


### PR DESCRIPTION
Rearrange the automatic setting of `OIIO_NODISCARD_ERROR_ENABLE` so that for external (not OIIO itself) builds, we default to enabling for OIIO >= 3.3, and disabling for older and current versions. But now, when building OIIO itself, it is ENABLED regardless of version.

So this means that as we add OIIO_NODISCARD_ERROR annotations to functions, we MUST fix any calls to those functions where we ourselves don't check their return values, and can't accidentally add new breaking code.

Also, had to fix a bunch of spots that were missed in the original PR, places where we didn't patch up our sloppy uses of what was annotated in that patch. I'm not sure I understand how these could have been missed in that last PR, since that PR did fix other uses of the annotated functions.
