### PR TITLE
build: Fix Makefile wrapper to properly quote test regex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ MY_CMAKE_FLAGS += -DTEX_BATCH_SIZE:STRING="${TEX_BATCH_SIZE}"
 endif
 
 ifneq (${TEST},)
-TEST_FLAGS += -R ${TEST}
+TEST_FLAGS += -R '${TEST}'
 endif
 
 ifneq (${USE_CCACHE},)


### PR DESCRIPTION
This fixes a longstanding issue where saying

    make test TEST="foo|bar"

would be malformed, instead of running tests that matched either foo or bar (misinterpreting the `|` as a pipe). The problem was just not quoting it properly.
