### PR TITLE
oiiotool: Add --experimental command line argument.

### DIFF
--- a/src/doc/oiiotool.rst
+++ b/src/doc/oiiotool.rst
@@ -988,6 +988,12 @@ subimage according to its metadata::
 
         oiiotool --oiioattrib debug 1 in.jpg -o out.jpg
 
+.. option:: --experimental
+
+    Enables experimental features. Use at your own risk.
+
+    This was added in OIIO 3.1.13.
+
 
 .. _sec-oiiotool-control-flow-commands:
 

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -6664,6 +6664,8 @@ Oiiotool::getargs(int argc, char* argv[])
     ap.arg("--nostderr", &ot.nostderr)
       .help("Do not use stderr, output error messages to stdout")
       .hidden();
+    ap.arg("--experimental", &ot.experimental)
+      .help("Allow experimental features");
 
     ap.separator("Control flow and scripting:");
     ap.arg("--set %s:NAME %s:VALUE")

--- a/src/oiiotool/oiiotool.h
+++ b/src/oiiotool/oiiotool.h
@@ -83,6 +83,7 @@ public:
     bool nostderr        = false;  // If true, use stdout for errors
     bool noerrexit       = false;  // Don't exit on error
     bool create_dir      = false;
+    bool experimental    = false;  // Allow experimental features
     std::string dumpdata_C_name;
     std::string full_command_line;
     std::string printinfo_metamatch;


### PR DESCRIPTION
Introducing this as a way to allow us to have experimental oiiotool features or behaviors that are enabled only if this flag is also present.

It's a way of allowing features to be turned on for feedback before we're sure it's in a form that can be a permanent, supported feature, thus allowing it to undergo further change that is exempt from our usual rules about what may change in which versions. By forcing users to also employ this flag to enable the trial behavior, there's no way that they can inadvertently come to depend on a temporary behavior and be surprised if it changes later.
