### PR TITLE
admin: Update security instructions to emphasize reporting via GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,10 +123,14 @@ it and potentially be able to answer your question quickly (more so than a GH
 "issue"). For quick questions, you could also try the [ASWF
 Slack](https://slack.aswf.io) `#openimageio` channel.
 
-Bugs, build problems, and discovered vulnerabilities that you are relatively
-certain is a legit problem in the code, and **for which you can give clear
-instructions for how to reproduce**, should be [reported as
+A bug or build problem that you are relatively certain is a legit problem in
+the code, and **for which you can give clear instructions for how to
+reproduce**, should be [reported as
 issues](https://github.com/AcademySoftwareFoundation/OpenImageIO/issues).
+
+To report a security vulnerability that is serious enough that it should not
+be discussed publicly until a patch is ready, please file a GitHub [security
+advisory](https://github.com/AcademySoftwareFoundation/OpenImageIO/security/advisories/new).
 
 If confidentiality precludes a public question or issue, you may contact us
 privately at [info@openimageio.org](info@openimageio.org), or for

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,14 +16,18 @@ security vulnerabilities.
 ## Reporting a Vulnerability
 
 If you think you've found a potential vulnerability in OpenImageIO, please
-report it by emailing security@openimageio.org. Only the project administrators
-have access to these messages. Include detailed steps to reproduce the issue,
-and any other information that could aid an investigation. Our policy is to
-respond to vulnerability reports within 14 days.
+report it to the maintainers. Include detailed steps to reproduce the issue,
+and any other information that could aid an investigation.
 
-Our policy is to address critical security vulnerabilities rapidly and post
-patches as quickly as possible.
+The best way to report a vulnerability is to file a GitHub [security
+advisory](https://github.com/AcademySoftwareFoundation/OpenImageIO/security/advisories/new).
+If that is not possible, it is also fine to email your report to
+security@openimageio.org. Only the project administrators have access to these
+reports.
 
+Our policy is to respond to vulnerability reports within 14 days, and to
+address critical security vulnerabilities rapidly and post patches as quickly
+as possible.
 
 ## Other security features
 
@@ -44,7 +48,7 @@ None known
 
 ## History of CVE Fixes
 
-Most recent fixes listed first, more or less
+Most recent fixes listed first, more or less:
 
 - CVE-2024-40630: Fixed incorrect image size for certain HEIC files.
   [advisory](https://github.com/AcademySoftwareFoundation/OpenImageIO/security/advisories/GHSA-jjm9-9m4m-c8p2) (Fixed in 2.5.13.1)


### PR DESCRIPTION
The security@openimageio.org is still fine, but we prefer that true vulnerability reports come via the GitHub security advisory mechanism. (That makes it easy for us to turn them into CVEs when needed, among other administrative niceties.)
