### PR TITLE
fix(tiff): care with missing rowsperstrip

### DIFF
--- a/src/include/OpenImageIO/fmath.h
+++ b/src/include/OpenImageIO/fmath.h
@@ -200,6 +200,7 @@ floor2(int x) noexcept
 template <typename V, typename M>
 inline OIIO_HOSTDEVICE V round_to_multiple (V value, M multiple)
 {
+    OIIO_DASSERT(multiple > M(0));
     if (value >= 0)
         value += V(multiple) - 1;
     return value - (value % V(multiple));

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -1309,8 +1309,13 @@ TIFFInput::readspec(bool read_meta)
     m_rowsperstrip = -1;
     if (!m_spec.tile_width) {
         TIFFGetField(m_tif, TIFFTAG_ROWSPERSTRIP, &m_rowsperstrip);
-        if (m_rowsperstrip > 0)
+        if (m_rowsperstrip > 0) {
+            // Only set the attrib if a legit value was found in the file
             m_spec.attribute("tiff:RowsPerStrip", m_rowsperstrip);
+        } else {
+            // Default if not found is "one strip for the whole image"
+            m_rowsperstrip = m_spec.height;
+        }
     }
 
     // The libtiff docs say that only uncompressed images, or those with

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -1312,6 +1312,7 @@ TIFFInput::readspec(bool read_meta)
         if (m_rowsperstrip > 0) {
             // Only set the attrib if a legit value was found in the file
             m_spec.attribute("tiff:RowsPerStrip", m_rowsperstrip);
+            m_rowsperstrip = std::min(m_rowsperstrip, m_spec.height);
         } else {
             // Default if not found is "one strip for the whole image"
             m_rowsperstrip = m_spec.height;


### PR DESCRIPTION
According to the TIFF spec, TIFF files with a missing rowsperstrip should assume the whole image is one strip.

Somewhat related (found in debugging): add a DASSERT to help debug if fmath.h's round_to_multiple() is given an invalid denominator.
