### PR TITLE
fix(heif): Fix incorrect tracking of current subimage

### DIFF
--- a/src/heif.imageio/heifinput.cpp
+++ b/src/heif.imageio/heifinput.cpp
@@ -79,6 +79,7 @@ public:
     bool open(const std::string& name, ImageSpec& newspec,
               const ImageSpec& config) override;
     bool close() override;
+    int current_subimage(void) const override { return m_subimage; }
     bool seek_subimage(int subimage, int miplevel) override;
     bool read_native_scanline(int subimage, int miplevel, int y, int z,
                               void* data) override;
@@ -188,16 +189,18 @@ HeifInput::open(const std::string& name, ImageSpec& newspec,
     try {
         m_ctx->read_from_reader(*m_reader);
 
-        m_item_ids   = m_ctx->get_list_of_top_level_image_IDs();
+        // Get the item IDs for each subimage, and force the "primary" one to
+        // have index 0.
         m_primary_id = m_ctx->get_primary_image_ID();
-        for (size_t i = 0; i < m_item_ids.size(); ++i)
-            if (m_item_ids[i] == m_primary_id) {
-                m_item_ids.erase(m_item_ids.begin() + i);
-                break;
-            }
+        m_item_ids.resize(0);
+        m_item_ids.push_back(m_primary_id);
+        for (auto id : m_ctx->get_list_of_top_level_image_IDs()) {
+            if (id != m_primary_id)
+                m_item_ids.push_back(id);
+        }
         // std::cout << " primary id: " << m_primary_id << "\n";
         // std::cout << " item ids: " << Strutil::join(m_item_ids, ", ") << "\n";
-        m_num_subimages = 1 + int(m_item_ids.size());
+        m_num_subimages = int(m_item_ids.size());
 
     } catch (const heif::Error& err) {
         std::string e = err.get_message();


### PR DESCRIPTION
Oh dear, somehow our heif reader never correctly overloaded the current_subimage method, instead inheriting the one from the base class that always returns 0. That's very bad for a file type that supports multiple subimages.

Along the way, simplified how we deal with the fact that the "primary" subimage doesn't need to be first in the file, but we always want to present it as if it were first. There was a point where I thought that was related to the bug so I was rewriting it; it turned out to not be the problem, but I'd still like to keep the cleanup I had done.
