### PR TITLE
fix(dpx): Several safety fixes for corrupt DPX files

### DIFF
--- a/src/dpx.imageio/dpxinput.cpp
+++ b/src/dpx.imageio/dpxinput.cpp
@@ -208,6 +208,8 @@ DPXInput::seek_subimage(int subimage, int miplevel)
     m_spec = ImageSpec(m_dpx.header.Width(), m_dpx.header.Height(),
                        m_dpx.header.ImageElementComponentCount(subimage),
                        typedesc);
+    if (!check_open(m_spec, { 0, 1 << 20, 0, 1 << 20, 0, 1 << 16, 0, 8 }))
+        return false;
 
     // xOffset/yOffset are defined as unsigned 32-bit integers, but m_spec.x/y are signed
     // avoid casts that would result in negative values
@@ -599,7 +601,8 @@ DPXInput::read_native_scanlines(int subimage, int miplevel, int ybegin,
     } else {
         // read the scanline and convert to RGB
         unsigned char* ptr = (unsigned char*)data;
-        int bufsize = dpx::QueryRGBBufferSize(m_dpx.header, subimage, block);
+        int64_t bufsize    = dpx::QueryRGBBufferSize(m_dpx.header, subimage,
+                                                     block);
         if (bufsize > 0) {
             m_decodebuf.resize(bufsize);
             ptr = m_decodebuf.data();

--- a/src/dpx.imageio/libdpx/DPXColorConverter.cpp
+++ b/src/dpx.imageio/libdpx/DPXColorConverter.cpp
@@ -41,10 +41,9 @@
 namespace dpx {
 	template <typename DATA>
 	static inline bool SwapRGBABytes(OIIO::cspan<DATA> input, OIIO::span<DATA> output) {
-		size_t pixels = input.size() / 4;
-        if (pixels * 4 + 3 >= input.size() || pixels * 4 + 3 >= output.size())
-            return false;
-        // Because we checked the lengths, we can just use data pointers below
+        // Because we are within the lengths by definition, we can just use
+        // data pointers below to avoid a bounds check on every one.
+        size_t pixels = input.size() / 4;
         for (size_t i = 0; i < pixels; i++) {
 			DATA a = input.data()[i * 4 + 0], b = input.data()[i * 4 + 1];
 			output.data()[i * 4 + 0] = input.data()[i * 4 + 3];

--- a/src/dpx.imageio/libdpx/DPXColorConverter.cpp
+++ b/src/dpx.imageio/libdpx/DPXColorConverter.cpp
@@ -34,19 +34,23 @@
 
 
 #include "DPXColorConverter.h"
+#include <OpenImageIO/fmath.h>
+#include <OpenImageIO/span.h>
 #include <algorithm>
 
 namespace dpx {
 	template <typename DATA>
-	static inline bool SwapRGBABytes(const DATA *input, DATA *output, int pixels) {
-		// copy the data that could be destroyed to an additional buffer in case input == output
-		DATA tmp[2];
-		for (int i = 0; i < pixels; i++) {
-			memcpy(tmp, &input[i * 4], sizeof(DATA) * 2);
-			output[i * 4 + 0] = input[i * 4 + 3];
-			output[i * 4 + 1] = input[i * 4 + 2];
-			output[i * 4 + 2] = tmp[1];
-			output[i * 4 + 3] = tmp[0];
+	static inline bool SwapRGBABytes(OIIO::cspan<DATA> input, OIIO::span<DATA> output) {
+		size_t pixels = input.size() / 4;
+        if (pixels * 4 + 3 >= input.size() || pixels * 4 + 3 >= output.size())
+            return false;
+        // Because we checked the lengths, we can just use data pointers below
+        for (size_t i = 0; i < pixels; i++) {
+			DATA a = input.data()[i * 4 + 0], b = input.data()[i * 4 + 1];
+			output.data()[i * 4 + 0] = input.data()[i * 4 + 3];
+			output.data()[i * 4 + 1] = input.data()[i * 4 + 2];
+			output.data()[i * 4 + 2] = b;
+			output.data()[i * 4 + 3] = a;
 		}
 		return true;
 	}
@@ -107,12 +111,12 @@ namespace dpx {
 
 	// 4:4:4
 	template <typename DATA, unsigned int max>
-	static bool ConvertCbYCrToRGB(const Characteristic space, const DATA *input, DATA *output, const int pixels) {
+	static bool ConvertCbYCrToRGB(const Characteristic space, const DATA *input, DATA *output, const size_t pixels) {
 		const float *matrix = GetYCbCrToRGBColorMatrix(space);
 		if (matrix == NULL)
 			return false;
 		DATA RGB[3];
-		for (int i = 0; i < pixels; i++) {
+		for (size_t i = 0; i < pixels; i++) {
 			ConvertPixelYCbCrToRGB<DATA, max>(&input[i * 3], RGB, matrix);
 			memcpy(&output[i * 3], RGB, sizeof(DATA) * 3);
 		}
@@ -121,12 +125,12 @@ namespace dpx {
 
 	// 4:4:4:4
 	template <typename DATA, unsigned int max>
-	static bool ConvertCbYCrAToRGBA(const Characteristic space, const DATA *input, DATA *output, const int pixels) {
+	static bool ConvertCbYCrAToRGBA(const Characteristic space, const DATA *input, DATA *output, const size_t pixels) {
 		const float *matrix = GetYCbCrToRGBColorMatrix(space);
 		if (matrix == NULL)
 			return false;
 		DATA RGBA[4];
-		for (int i = 0; i < pixels; i++) {
+		for (size_t i = 0; i < pixels; i++) {
 			ConvertPixelYCbCrToRGB<DATA, max>(&input[i * 4], RGBA, matrix);
 			RGBA[3] = input[i * 4 + 3];
 			memcpy(&output[i * 4], RGBA, sizeof(DATA) * 4);
@@ -136,12 +140,12 @@ namespace dpx {
 
 	// 4:2:2
 	template <typename DATA, unsigned int max>
-	static bool ConvertCbYCrYToRGB(const Characteristic space, const DATA *input, DATA *output, const int pixels) {
+	static bool ConvertCbYCrYToRGB(const Characteristic space, const DATA *input, DATA *output, const size_t pixels) {
 		const float *matrix = GetYCbCrToRGBColorMatrix(space);
 		if (matrix == NULL)
 			return false;
 		DATA CbYCr[3];
-		for (int i = 0; i < pixels; i++) {
+		for (size_t i = 0; i < pixels; i++) {
 			// upsample to 4:4:4
 			// FIXME: proper interpolation
 			CbYCr[0] = input[(i | 1) * 2];	// Cb
@@ -155,12 +159,12 @@ namespace dpx {
 
 	// 4:2:2:4
 	template <typename DATA, unsigned int max>
-	static bool ConvertCbYACrYAToRGBA(const Characteristic space, const DATA *input, DATA *output, const int pixels) {
+	static bool ConvertCbYACrYAToRGBA(const Characteristic space, const DATA *input, DATA *output, const size_t pixels) {
 		const float *matrix = GetYCbCrToRGBColorMatrix(space);
 		if (matrix == NULL)
 			return false;
 		DATA CbYCr[3];
-		for (int i = 0; i < pixels; i++) {
+		for (size_t i = 0; i < pixels; i++) {
 			// upsample to 4:4:4
 			// FIXME: proper interpolation
 			CbYCr[0] = input[(i | 1) * 3];	// Cb
@@ -174,7 +178,7 @@ namespace dpx {
 	}
 
 	static inline bool ConvertToRGBInternal(const Descriptor desc, const DataSize size, const Characteristic space,
-		const void *input, void *output, const int pixels) {
+		const void *input, void *output, const size_t pixels) {
 		switch (desc) {
 			// redundant calls
 			case kRGB:
@@ -185,19 +189,19 @@ namespace dpx {
 			case kABGR:
 				switch (size) {
 					case kByte:
-						return SwapRGBABytes<U8>((const U8 *)input, (U8 *)output, pixels);
+						return SwapRGBABytes(OIIO::cspan<U8>((const U8*)input, pixels*4), OIIO::span<U8>((U8*)output, pixels*4));
 					case kWord:
-						return SwapRGBABytes<U16>((const U16 *)input, (U16 *)output, pixels);
+						return SwapRGBABytes(OIIO::cspan<U16>((const U16*)input, pixels*4), OIIO::span<U16>((U16*)output, pixels*4));
 					case kInt:
-						return SwapRGBABytes<U32>((const U32 *)input, (U32 *)output, pixels);
+						return SwapRGBABytes(OIIO::cspan<U32>((const U32*)input, pixels*4), OIIO::span<U32>((U32*)output, pixels*4));
 					case kFloat:
-						return SwapRGBABytes<R32>((const R32 *)input, (R32 *)output, pixels);
+						return SwapRGBABytes(OIIO::cspan<R32>((const R32*)input, pixels*4), OIIO::span<R32>((R32*)output, pixels*4));
 					case kDouble:
-						return SwapRGBABytes<R64>((const R64 *)input, (R64 *)output, pixels);
+						return SwapRGBABytes(OIIO::cspan<R64>((const R64*)input, pixels*4), OIIO::span<R64>((R64*)output, pixels*4));
 				}
 				// shouldn't ever get here
 				return false;
-				
+
 
 			// FIXME: can this be translated to RGB?
 			//case kCompositeVideo:
@@ -287,7 +291,7 @@ namespace dpx {
 		}
 	}
 
-	static inline int QueryRGBBufferSizeInternal(const Descriptor desc, const int pixels, const int bytes) {
+	static inline int64_t QueryRGBBufferSizeInternal(const Descriptor desc, const size_t pixels, const size_t bytes) {
 		switch (desc) {
 			//case kCompositeVideo:	// FIXME: can this be translated to RGB?
 			case kCbYCrY:	// 4:2:2 -> RGB, requires allocation
@@ -329,9 +333,10 @@ namespace dpx {
 		}
 	}
 
-	int QueryRGBBufferSize(const Header &header, const int element, const Block &block) {
+	int64_t QueryRGBBufferSize(const Header &header, const size_t element, const Block &block) {
 		return QueryRGBBufferSizeInternal(header.ImageDescriptor(element),
-			(block.x2 - block.x1 + 1) * (block.y2 - block.y1 + 1),
+			OIIO::clamped_mult64(block.x2 - block.x1 + 1,
+                                 block.y2 - block.y1 + 1),
 			header.ComponentByteCount(element));
 	}
 
@@ -344,10 +349,12 @@ namespace dpx {
 #endif /* NOT USED IN OIIO */
 
 	bool ConvertToRGB(const Header &header, const int element, const void *input, void *output, const Block &block) {
-		return ConvertToRGBInternal(header.ImageDescriptor(element),
-			header.ComponentDataSize(element), header.Colorimetric(element),
-			input, output, (block.x2 - block.x1 + 1) * (block.y2 - block.y1 + 1));
-	}
+        return ConvertToRGBInternal(
+            header.ImageDescriptor(element),
+            header.ComponentDataSize(element), header.Colorimetric(element),
+            input, output, OIIO::clamped_mult64(block.x2 - block.x1 + 1,
+                                                block.y2 - block.y1 + 1));
+    }
 
 #if 0 /* NOT USED IN OIIO */
 	bool ConvertToRGB(const Header &header, const int element, const void *input, void *output) {
@@ -479,7 +486,7 @@ namespace dpx {
 #endif /* NOT USED IN OIIO */
 
 	static inline bool ConvertToNativeInternal(const Descriptor desc, const DataSize size, const Characteristic space,
-		const void *input, void *output, const int pixels) {
+		const void *input, void *output, const size_t pixels) {
 		switch (desc) {
 			// redundant calls
 			case kRGB:
@@ -491,15 +498,15 @@ namespace dpx {
 			case kABGR:
 				switch (size) {
 					case kByte:
-						return SwapRGBABytes<U8>((const U8 *)input, (U8 *)output, pixels);
+						return SwapRGBABytes(OIIO::cspan<U8>((const U8*)input, pixels*4), OIIO::span<U8>((U8*)output, pixels*4));
 					case kWord:
-						return SwapRGBABytes<U16>((const U16 *)input, (U16 *)output, pixels);
+						return SwapRGBABytes(OIIO::cspan<U16>((const U16*)input, pixels*4), OIIO::span<U16>((U16*)output, pixels*4));
 					case kInt:
-						return SwapRGBABytes<U32>((const U32 *)input, (U32 *)output, pixels);
+						return SwapRGBABytes(OIIO::cspan<U32>((const U32*)input, pixels*4), OIIO::span<U32>((U32*)output, pixels*4));
 					case kFloat:
-						return SwapRGBABytes<R32>((const R32 *)input, (R32 *)output, pixels);
+						return SwapRGBABytes(OIIO::cspan<R32>((const R32*)input, pixels*4), OIIO::span<R32>((R32*)output, pixels*4));
 					case kDouble:
-						return SwapRGBABytes<R64>((const R64 *)input, (R64 *)output, pixels);
+						return SwapRGBABytes(OIIO::cspan<R64>((const R64*)input, pixels*4), OIIO::span<R64>((R64*)output, pixels*4));
 				}
 				// shouldn't ever get here
 				return false;
@@ -647,7 +654,7 @@ namespace dpx {
 	}
 #endif /* NOT USED IN OIIO */
 
-	bool ConvertToNative(const Descriptor desc, const DataSize compSize, const Characteristic cmetr, const int width, const int height, const void *input, void *output) {
-		return ConvertToNativeInternal(desc, compSize, cmetr, input, output, width * height);
+	bool ConvertToNative(const Descriptor desc, const DataSize compSize, const Characteristic cmetr, const size_t width, const size_t height, const void *input, void *output) {
+		return ConvertToNativeInternal(desc, compSize, cmetr, input, output, OIIO::clamped_mult64(width, height));
 	}
 }

--- a/src/dpx.imageio/libdpx/DPXColorConverter.h
+++ b/src/dpx.imageio/libdpx/DPXColorConverter.h
@@ -54,8 +54,9 @@ namespace dpx
 	* of the buffer in bytes; sign: positive - memory needs to be allocated,
 	* negative - allocation is optional, decoded data can replace the input
 	*/
-	int QueryRGBBufferSize(const Header &header, const int element, const Block &block);
+	int64_t QueryRGBBufferSize(const Header &header, const size_t element, const Block &block);
 
+#if 0 /* NOT USED IN OIIO */
 	/*!
 	* \brief Query the size of the buffer necessary to hold the decoded RGB data
 	* \param header DPX header
@@ -64,7 +65,8 @@ namespace dpx
 	* of the buffer in bytes; sign: positive - memory needs to be allocated,
 	* negative - allocation is optional, decoded data can replace the input
 	*/
-	int QueryRGBBufferSize(const Header &header, const int element);
+	int QueryRGBBufferSize(const Header &header, const size_t element);
+#endif
 
 	/*!
 	* \brief Convert native data from the input buffer into RGB in the output buffer
@@ -78,6 +80,7 @@ namespace dpx
 	*/
 	bool ConvertToRGB(const Header &header, const int element, const void *input, void *output, const Block &block);
 
+#if 0 /* NOT USED IN OIIO */
 	/*!
 	* \brief Convert native data from the input buffer into RGB in the output buffer
 	* \param header DPX header
@@ -122,6 +125,7 @@ namespace dpx
 	* \return success true/false
 	*/
     bool ConvertToNative(const Descriptor desc, const DataSize compSize, const Characteristic cmetr, const void *input, void *output, const Block &block);
+#endif
 
 	/*!
 	* \brief Convert RGB data from the input buffer into native format in the output buffer
@@ -132,7 +136,7 @@ namespace dpx
 	* \param output output buffer data; can be same as input if \ref QueryNativeBufferSize returns a negative number
 	* \return success true/false
 	*/
-	bool ConvertToNative(const Descriptor desc, const DataSize compSize, const Characteristic cmetr, const int width, const int height, const void *input, void *output);
+	bool ConvertToNative(const Descriptor desc, const DataSize compSize, const Characteristic cmetr, const size_t width, const size_t height, const void *input, void *output);
 
 }
 


### PR DESCRIPTION
* SWAPRGBABytes: convert to from raw pointers to span-based.
* A variety of overflow safety fixes, replace int (32 bit) with size_t or int64_t and use safe_mult64.
* Use ImageInput::check_open() for dpx files to check for reasonable/legal resolutions and channel counts
* Comment out more function declarations not used by OIIO.

Aside:

I should say, this code was originally imported/vendored from another project by Patrick Palmer: https://github.com/PatrickPalmer/dpx
We imagined it might be an ongoing/improving work, so we made some very minor changes here and there but endeavoured to make as little change as possible -- even excluding it from our clang-format rules! -- so that we could diff against the changing dpx project and pull in any changes or even use it as an external dependency.

But as you can see if you go there, it hasn't had any modifications for 17 years! So we never needed the "feature" of minimizing divergence from the original. And now I think with the rate of discovery and reporting of vulnerabilities and bugs accelerating, the pressure is on to make this code "safer," for example with these changes in this PR.

I think it's time to give up the pretense entirely and just allow ourselves to fully absorb this code as our own, be unconcerned about divergence. So after this PR is merged, I expect follow-ons to:
- Once and for all, fully remove the "dead code" parts that we commented out because they aren't used in OIIO.
- Allow clang-format to process these files and bring them into formatting unity with the rest of OIIO.
- Convert all the raw pointer use to spans
- Remove redundant code -- functions in the original dpx project that were functionality equivalent to things already in OIIO -- where we kept the originals in place for the sake of minimizing divergence. Let's just use the OIIO ones we use everywhere else, in cases where they already exist.
- Root out all remaining overflow and bounds issues, some of the new LLM based tools are really good at finding those.

