### PR TITLE
fix: immediate fix to PR 5154, uncheked return

### DIFF
--- a/src/libOpenImageIO/imagebufalgo_flip.cpp
+++ b/src/libOpenImageIO/imagebufalgo_flip.cpp
@@ -1242,7 +1242,8 @@ ImageBufAlgo::experimental::FLIP_diff(const ImageBuf& ref, const ImageBuf& test,
                                       KWArgs options, ROI roi, int nthreads)
 {
     ImageBuf dst;
-    FLIP_diff(dst, ref, test, options, roi, nthreads);
+    (void)FLIP_diff(dst, ref, test, options, roi, nthreads);
+    // Ignoring error return is ok here because the error is reported in dst
     return dst;
 }
 


### PR DESCRIPTION
PR #5154 crossed streams with another that turned on more warnings for unchecked errors. The check isn't necessary here, though.
