### PR TITLE
feat(iconvert): allow -o for convenience

### DIFF
--- a/src/doc/iconvert.rst
+++ b/src/doc/iconvert.rst
@@ -19,7 +19,8 @@ certain metadata to the image.
 
 The `iconvert` utility is invoked as follows:
 
-    `iconvert` *optiions input output*
+    `iconvert` *options input output*
+    `iconvert` *options input* `-o` *output*
 
 Where *input* and *output* name the input image and desired output filename.
 The image files may be of any format recognized by OpenImageIO (i.e., for
@@ -146,6 +147,10 @@ keywords, or arbitrary string metadata::
 .. describe:: -v
 
     Verbose status messages.
+
+.. describe:: -o filename
+
+    Specify the output filename. (Alternately, the `-o` can be dropped.)
 
 .. describe:: --threads n
 

--- a/src/iconvert/iconvert.cpp
+++ b/src/iconvert/iconvert.cpp
@@ -28,6 +28,7 @@ static float gammaval             = 1.0f;
 static bool verbose = false;
 static int nthreads = 0;  // default: use #cores threads if available
 static std::vector<std::string> filenames;
+static std::string out_filename;
 static int tile[3]   = { 0, 0, 1 };
 static bool scanline = false;
 //static bool zfile = false;
@@ -69,10 +70,12 @@ getargs(int argc, char* argv[])
     ap.options ("iconvert -- copy images with format conversions and other alterations\n"
                 OIIO_INTRO_STRING "\n"
                 "Usage:  iconvert [options] inputfile outputfile\n"
+                "   or:  iconvert [options] inputfile -o outputfile\n"
                 "   or:  iconvert --inplace [options] file...\n",
                 "%*", parse_files, "",
                 "--help", &help, "Print help message",
                 "-v", &verbose, "Verbose status messages",
+                "-o %s:FILENAME", &out_filename, "Output filename",
                 "--threads %d:NTHREADS", &nthreads, "Number of threads (default 0 = #cores)",
                 "-d %s:TYPE", &dataformatname, "Set the output data format to one of:"
                         "uint8, sint8, uint10, uint12, uint16, sint16, half, float, double",
@@ -115,6 +118,17 @@ getargs(int argc, char* argv[])
         return;
     }
 
+    if (!out_filename.empty() && filenames.size() == 1) {
+        // -o mode: one positional arg is input, -o specifies output
+        filenames.push_back(out_filename);
+    } else if (!out_filename.empty() && filenames.size() != 1) {
+        OIIO::print(stderr,
+                    "iconvert: -o requires exactly one input filename.\n");
+        ap.usage();
+        ap.abort();
+        return_code = EXIT_FAILURE;
+        return;
+    }
     if (filenames.size() != 2 && !inplace) {
         OIIO::print(
             stderr,

--- a/testsuite/runtest.py
+++ b/testsuite/runtest.py
@@ -297,13 +297,10 @@ def rw_command (dir: str, filename: str, testwrite: bool=True, use_oiiotool: boo
         cmd = ""
     if output_filename == "" :
         output_filename = filename
+    tool = "oiiotool" if use_oiiotool else "iconvert"
     if testwrite :
-        if use_oiiotool :
-            cmd = (cmd + oiio_app("oiiotool") + preargs + " " + fn
-                   + " " + extraargs + " -o " + output_filename + redirect + ";\n")
-        else :
-            cmd = (cmd + oiio_app("iconvert") + preargs + " " + fn
-                   + " " + extraargs + " " + output_filename + redirect + ";\n")
+        cmd = (cmd + oiio_app(tool) + preargs + " " + fn
+               + " " + extraargs + " -o " + output_filename + redirect + ";\n")
         cmd = (cmd + oiio_app("idiff") + " -a " + fn
                + " -fail " + str(failthresh)
                + " -failpercent " + str(failpercent)


### PR DESCRIPTION
iconvert was the very first command line utility for OIIO, and its syntax was just `iconvert [options] infile outfile`. YEARS later, oiiotool came along, superceding iconvert with 100x the functionality, and also differed by requiring `-o` to specify output file.

iconvert still exists for testing and examples -- iconvert uses just plain old ImageInput + ImageOutput straightforwardly, whereas oiiotool is a very complex app that's ImageBuf powered. It's often useful for debugging to test the ImageInput/ImageOutput layer without any extra complication, or to directly see how going through an ImageBuf might differ.

The fact that oiiotool requires `-o` to specify an output file, whereas iconvert considers that an error, is a minor annoyance when switching back and forth while debugging, and it's really bugging me.

So here it is, a tiny patch to let iconvert silently accept -o, or not, and do the obviously right thing. A little quality of life gift to myself.

