### PR TITLE
ci: Temporary fix -- make libheif optional for Ubuntu jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,7 +353,7 @@ jobs:
       # Override required_deps to be 'all' and explicitly list as optional
       # only the ones we are intentionally not testing for those jobs.
       required_deps: ${{ matrix.required_deps || 'all' }}
-      optional_deps: ${{ matrix.optional_deps || 'CUDAToolkit;DCMTK;JXL;Nuke;OpenGL;openjph;OpenVDB;Ptex;pystring;Qt5;R3DSDK;' }}${{matrix.optional_deps_append}}
+      optional_deps: ${{ matrix.optional_deps || 'CUDAToolkit;DCMTK;JXL;Nuke;OpenGL;openjph;OpenVDB;Ptex;pystring;Qt5;R3DSDK;Libheif;' }}${{matrix.optional_deps_append}}
       build_local_deps: ${{ matrix.build_local_deps }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
This will get us through the great Canonical attack of May 2026, where it seems that `add-apt-repository ppa:strukturag` is still unreliable even as we are now multiple days overdue to get our releases out.

We will revert this after everything is fixed. I don't like it silently passing when we think it's testing heif files but it's really not, any longer than we have to be in that state.

