### PR TITLE
perf(dpx): use default_init_vector to speed up allocation for internal buffers

### DIFF
--- a/src/dpx.imageio/dpxinput.cpp
+++ b/src/dpx.imageio/dpxinput.cpp
@@ -57,9 +57,9 @@ private:
     int m_subimage;
     InStream* m_stream = nullptr;
     dpx::Reader m_dpx;
-    std::vector<unsigned char> m_userBuf;
+    default_init_vector<unsigned char> m_userBuf;
+    default_init_vector<unsigned char> m_decodebuf;  // temporary decode buffer
     bool m_rawcolor;
-    std::vector<unsigned char> m_decodebuf;  // temporary decode buffer
 
     /// Reset everything to initial state
     ///


### PR DESCRIPTION
This just avoids needing to zero out the allocated buffer, since we know we are allocating it merely to write into it. Uninitialized contents is ok and faster.

