### PR TITLE
fix(gif): Preserve RGB values of transparent pixels

### DIFF
--- a/src/gif.imageio/gifinput.cpp
+++ b/src/gif.imageio/gifinput.cpp
@@ -366,12 +366,13 @@ GIFInput::read_subimage_data()
                 }
                 int x   = window_left + wx;
                 int idx = m_spec.nchannels * (y * m_spec.width + x);
-                if (0 <= x && x < m_spec.width
-                    && fscanline[wx] != m_transparent_color) {
+                if (0 <= x && x < m_spec.width) {
                     m_canvas[idx]     = colormap[fscanline[wx]].Red;
                     m_canvas[idx + 1] = colormap[fscanline[wx]].Green;
                     m_canvas[idx + 2] = colormap[fscanline[wx]].Blue;
-                    m_canvas[idx + 3] = 0xff;
+                    m_canvas[idx + 3] = (fscanline[wx] != m_transparent_color)
+                                            ? 0xff
+                                            : 0x00;
                 }
             }
         }

--- a/testsuite/gif/ref/out.txt
+++ b/testsuite/gif/ref/out.txt
@@ -90,6 +90,12 @@ Reading ../oiio-images/gif/gif_test_loop_count.gif
     gif:LoopCount: 12345
     oiio:ColorSpace: "srgb_rec709_scene"
     oiio:LoopCount: 12345
+Reading ../oiio-images/gif/gif_transparent_rgb.gif
+../oiio-images/gif/gif_transparent_rgb.gif :    2 x    1, 4 channel, uint8 gif
+    SHA-1: 0F690404DA2B75EFC8CE225B19C0F49FEF39F9DE
+    channel list: R, G, B, A
+    gif:Interlacing: 0
+    oiio:ColorSpace: "srgb_rec709_scene"
 Reading tahoe-tiny.gif
 tahoe-tiny.gif       :  128 x   96, 4 channel, uint8 gif
     SHA-1: B05CB30B2108904DAAD7B39E1BD7AA68D1D844CC

--- a/testsuite/gif/run.py
+++ b/testsuite/gif/run.py
@@ -8,7 +8,7 @@ files = ["gif_animation.gif", "gif_oiio_logo_with_alpha.gif",
          "gif_tahoe.gif", "gif_tahoe_interlaced.gif",
          "gif_bluedot.gif", "gif_diagonal_interlaced.gif",
          "gif_triangle_interlaced.gif", "gif_test_disposal_method.gif",
-         "gif_test_loop_count.gif"]
+         "gif_test_loop_count.gif", "gif_transparent_rgb.gif"]
 for f in files:
     command += info_command (OIIO_TESTSUITE_IMAGEDIR + "/" + f)
 


### PR DESCRIPTION
### Description

This is a PR proposaling to preserve RGB of transparent color index pixels in GIF files.

When reading GIF files, pixels of transparent color index were skipped. This left their RGB channels zeroed, discarding possible valid colormap data. To preserve the RGB values, we change to always write the colormap's RGB and set alpha conditionally.

According to [GIF spec](https://www.w3.org/Graphics/GIF/spec-gif89a.txt):

>viii) Transparency Index - The Transparency Index is such that when encountered, the corresponding pixel of the display device is not modified and processing goes on to the next pixel. The index is present if and only if the Transparency Flag is set to 1.

So basically, it just defines a display compositing behavior but says nothing about the color table entry for that index being invalid or empty. In practice, encoders may still assign meaningful RGB values to the transparent index, and those values are perfectly well-defined in the colormap. For example, GIMP reads the valid RGB values ​​of transparent pixels (see attachment below).

### Tests

A new test image and test case is added: https://github.com/AcademySoftwareFoundation/OpenImageIO-images/pull/11

<img width="847" height="695" alt="image" src="https://github.com/user-attachments/assets/484c8b53-5a1b-4732-b95c-55a2f52021b5" />

### Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] **I have read the guidelines** on [contributions](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md) and [code review procedures](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/CodeReview.md).
- [x] **I have read the [Policy on AI Coding Assistants](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/AI_Policy.md)**
  and if I used AI coding assistants, I have an `Assisted-by: TOOL / MODEL`
  line in the pull request description above.
- [x] **I have updated the documentation** if my PR adds features or changes
  behavior.
- [x] **I am sure that this PR's changes are tested in the testsuite**.
- [ ] **I have run and passed the testsuite in CI** *before* submitting the
  PR, by pushing the changes to my fork and seeing that the automated CI
  passed there. (Exceptions: If most tests pass and you can't figure out why
  the remaining ones fail, it's ok to submit the PR and ask for help. Or if
  any failures seem entirely unrelated to your change; sometimes things break
  on the GitHub runners.)
- [x] **My code follows the prevailing code style of this project** and I
  fixed any problems reported by the clang-format CI test.
- [x] If I added or modified a public C++ API call, I have also amended the
  corresponding Python bindings. If altering ImageBufAlgo functions, I also
  exposed the new functionality as oiiotool options.
