### PR TITLE
ci: Remove deprecated windows-2025 runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -755,15 +755,6 @@ jobs:
             python_ver: "3.12"
             ctest_test_timeout: "240"
             setenvs: export OPENIMAGEIO_PYTHON_LOAD_DLLS_FROM_PATH=1
-          - desc: Windows-2025 VS2022
-            runner: windows-2025
-            nametag: windows-2025
-            oiio_python_bindings_backend: both
-            generator: "Visual Studio 17 2022"
-            python_ver: "3.12"
-            ctest_test_timeout: "240"
-            setenvs: export OPENIMAGEIO_PYTHON_LOAD_DLLS_FROM_PATH=1
-            benchmark: 1
           - desc: Windows-2025 VS2026
             runner: windows-2025-vs2026
             nametag: windows-2025-vs2026
@@ -772,3 +763,4 @@ jobs:
             ctest_test_timeout: "240"
             setenvs: export OPENIMAGEIO_PYTHON_LOAD_DLLS_FROM_PATH=1
             benchmark: 1
+            oiio_python_bindings_backend: both


### PR DESCRIPTION
We test on 3 Windows runner configurations currently -- Windows 2022 with VS2022, Windows 2025 with VS2022, and Windows 2025 with VS2026. GitHub says the middle one will go away imminently (actually, it won't "break", but it will redirect to Windows 2025 with VS2026, which we already test). So take it out of our lineup, it's just waste.

The one thing the middle one did differently than the others is test nanobind, so just move that to the VS2026 one.
