### PR TITLE
api(ColorConfig): add isData, fix python isColorSpaceLinear.

### DIFF
--- a/src/include/OpenImageIO/color.h
+++ b/src/include/OpenImageIO/color.h
@@ -175,6 +175,9 @@ public:
     /// will return false if it's not sure.
     bool isColorSpaceLinear(string_view name) const;
 
+    /// Is the color space non-color-managed "data"?
+    bool isData(string_view name) const;
+
     /// Retrieve the full list of aliases for the named color space.
     std::vector<std::string> getAliases(string_view color_space) const;
 

--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -610,7 +610,8 @@ ColorConfig::Impl::classify_by_name(CSInfo& cs)
                    ACEScg_alias);
     } else if (Strutil::iequals(cs.name, "Rec709")) {
         cs.setflag(CSInfo::is_Rec709, Rec709_alias);
-    } else if (Strutil::iequals(cs.name, "Raw")) {
+    } else if (config_
+               && Strutil::iequals(cs.name, config_->getCanonicalName("data"))) {
         cs.setflag(CSInfo::is_data);
     }
 #ifdef OIIO_SITE_spi

--- a/src/libOpenImageIO/color_ocio.cpp
+++ b/src/libOpenImageIO/color_ocio.cpp
@@ -165,6 +165,7 @@ struct CSInfo {
         is_lin_srgb        = 8,   // sRGB/Rec709 primaries, linear response
         is_ACEScg          = 16,  // ACEScg
         is_Rec709          = 32,  // Rec709 primaries and transfer function
+        is_data            = 64,  // Non-color-managed data
         is_known           = is_srgb | is_lin_srgb | is_ACEScg | is_Rec709
     };
     int m_flags   = 0;
@@ -340,6 +341,8 @@ public:
     get_to_builtin_cpu_proc(const char* my_from, const char* builtin_to) const;
 
     bool isColorSpaceLinear(string_view name) const;
+
+    bool isData(string_view name) const;
 
 private:
     // Return the CSInfo flags for the given color space name
@@ -607,6 +610,8 @@ ColorConfig::Impl::classify_by_name(CSInfo& cs)
                    ACEScg_alias);
     } else if (Strutil::iequals(cs.name, "Rec709")) {
         cs.setflag(CSInfo::is_Rec709, Rec709_alias);
+    } else if (Strutil::iequals(cs.name, "Raw")) {
+        cs.setflag(CSInfo::is_data);
     }
 #ifdef OIIO_SITE_spi
     // Ugly SPI-specific hacks, so sorry
@@ -619,6 +624,9 @@ ColorConfig::Impl::classify_by_name(CSInfo& cs)
     } else if (cs.name == "srgblnf" || cs.name == "srgblnh"
                || cs.name == "srgbln16" || cs.name == "srgbln8") {
         cs.setflag(CSInfo::is_lin_srgb, lin_srgb_alias);
+    } else if (Strutil::starts_with(cs.name, "nc")) {
+        cs.setflag(CSInfo::is_data);
+        DBG("Classifying {} as data based on SPI name\n", cs.name);
     }
 #endif
 
@@ -649,6 +657,10 @@ ColorConfig::Impl::classify_by_conversions(CSInfo& cs)
 
     if (isColorSpaceLinear(cs.name))
         cs.setflag(CSInfo::is_linear_response);
+    if (cs.ocio_cs && cs.ocio_cs->isData()) {
+        cs.setflag(CSInfo::is_data);
+        DBG("Classifying {} as data isData() [1]\n", cs.name);
+    }
 
     // If the name didn't already tell us what it is, and we have a new enough
     // OCIO that has built-in configs, test whether this color space is
@@ -683,7 +695,12 @@ ColorConfig::Impl::classify_by_conversions(CSInfo& cs)
                 cs.setflag(CSInfo::is_ACEScg | CSInfo::is_linear_response,
                            ACEScg_alias);
             }
-        } catch (...) {
+            if (cs.ocio_cs->isData()) {
+                cs.setflag(CSInfo::is_data);
+                DBG("Classifying {} as data isData() [2]\n", cs.name);
+            }
+        } catch (OCIO::Exception& e) {
+            DBG("OCIO exception in classify_by_conversions: {}", e.what());
         }
     }
 
@@ -1063,6 +1080,25 @@ ColorConfig::Impl::isColorSpaceLinear(string_view name) const
            || Strutil::istarts_with(name, "lin_")
            || Strutil::iends_with(name, "_linear")
            || Strutil::iends_with(name, "_lin");
+}
+
+
+
+bool
+ColorConfig::isData(string_view name) const
+{
+    return getImpl()->isData(name);
+}
+
+
+
+bool
+ColorConfig::Impl::isData(string_view name) const
+{
+    if (const CSInfo* cs = find(name)) {
+        return cs->flags() & CSInfo::is_data;
+    }
+    return false;
 }
 
 

--- a/src/python/py_colorconfig.cpp
+++ b/src/python/py_colorconfig.cpp
@@ -124,6 +124,18 @@ declare_colorconfig(py::module& m)
                  return self.getNamedTransformAliases(named_transform);
              })
         .def(
+            "isColorSpaceLinear",
+            [](const ColorConfig& self, const std::string& name) {
+                return self.isColorSpaceLinear(name);
+            },
+            "name"_a)
+        .def(
+            "isData",
+            [](const ColorConfig& self, const std::string& name) {
+                return self.isData(name);
+            },
+            "name"_a)
+        .def(
             "getColorSpaceFromFilepath",
             [](const ColorConfig& self, const std::string& filepath) {
                 return std::string(self.getColorSpaceFromFilepath(filepath));

--- a/testsuite/python-colorconfig/ref/out-ocio23.txt
+++ b/testsuite/python-colorconfig/ref/out-ocio23.txt
@@ -31,6 +31,10 @@ get_color_interop_id('lin_srgb') =  lin_rec709_scene
 get_color_interop_id([1, 13, 1, 1]) =  srgb_rec709_scene
 get_cicp('pq_rec2020_display') =  [9, 16, 9, 1]
 get_cicp('unknown_interop_id') =  None
+isColorSpaceLinear('scene_linear') =  True
+isColorSpaceLinear('srgb') =  False
+isData('scene_linear') =  False
+isData('Raw') =  True
 
 Loaded test OCIO config: oiio_test_v0.9.2.ocio
 Parsed color space for filepath 'foo_lin_ap1.exr': ACEScg

--- a/testsuite/python-colorconfig/ref/out-ocio24.txt
+++ b/testsuite/python-colorconfig/ref/out-ocio24.txt
@@ -31,6 +31,10 @@ get_color_interop_id('lin_srgb') =  lin_rec709_scene
 get_color_interop_id([1, 13, 1, 1]) =  srgb_rec709_scene
 get_cicp('pq_rec2020_display') =  [9, 16, 9, 1]
 get_cicp('unknown_interop_id') =  None
+isColorSpaceLinear('scene_linear') =  True
+isColorSpaceLinear('srgb') =  False
+isData('scene_linear') =  False
+isData('Raw') =  True
 
 Loaded test OCIO config: oiio_test_v0.9.2.ocio
 Parsed color space for filepath 'foo_lin_ap1.exr': ACEScg

--- a/testsuite/python-colorconfig/ref/out-ocio25.txt
+++ b/testsuite/python-colorconfig/ref/out-ocio25.txt
@@ -31,6 +31,10 @@ get_color_interop_id('lin_srgb') =  lin_rec709_scene
 get_color_interop_id([1, 13, 1, 1]) =  srgb_rec709_scene
 get_cicp('pq_rec2020_display') =  [9, 16, 9, 1]
 get_cicp('unknown_interop_id') =  None
+isColorSpaceLinear('scene_linear') =  True
+isColorSpaceLinear('srgb') =  False
+isData('scene_linear') =  False
+isData('Raw') =  True
 
 Loaded test OCIO config: oiio_test_v0.9.2.ocio
 Parsed color space for filepath 'foo_lin_ap1.exr': ACEScg

--- a/testsuite/python-colorconfig/ref/out.txt
+++ b/testsuite/python-colorconfig/ref/out.txt
@@ -31,6 +31,10 @@ get_color_interop_id('lin_srgb') =  lin_rec709_scene
 get_color_interop_id([1, 13, 1, 1]) =  srgb_rec709_scene
 get_cicp('pq_rec2020_display') =  [9, 16, 9, 1]
 get_cicp('unknown_interop_id') =  None
+isColorSpaceLinear('scene_linear') =  True
+isColorSpaceLinear('srgb') =  False
+isData('scene_linear') =  False
+isData('Raw') =  True
 
 Loaded test OCIO config: oiio_test_v0.9.2.ocio
 Parsed color space for filepath 'foo_lin_ap1.exr': ACEScg

--- a/testsuite/python-colorconfig/src/test_colorconfig.py
+++ b/testsuite/python-colorconfig/src/test_colorconfig.py
@@ -53,6 +53,10 @@ try:
     print ("get_color_interop_id([1, 13, 1, 1]) = ", config.get_color_interop_id([1, 13, 1, 1]))
     print ("get_cicp('pq_rec2020_display') = ", config.get_cicp("pq_rec2020_display"))
     print ("get_cicp('unknown_interop_id') = ", config.get_cicp("unknown_interop_id"))
+    print ("isColorSpaceLinear('scene_linear') = ", config.isColorSpaceLinear('scene_linear'))
+    print ("isColorSpaceLinear('srgb') = ", config.isColorSpaceLinear('srgb'))
+    print ("isData('scene_linear') = ", config.isData('scene_linear'))
+    print ("isData('Raw') = ", config.isData('Raw'))
     print ("")
 
     config = oiio.ColorConfig(str(TEST_CONFIG_PATH))


### PR DESCRIPTION
* Add `ColorConfig::isData(name)` method to C++ and Python APIs.
* Fix `ColorConfig.isColorSpaceLinear()` that was missing from the Python bindings. (Tests added as well.)
