### PR TITLE
fix(oiiotool): be cautious promoting to float due to color space name with --autocc

### DIFF
--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -5905,10 +5905,11 @@ output_file(Oiiotool& ot, cspan<const char*> argv)
         TypeDesc type;
         int bits;
         type = ot.colorconfig().getColorSpaceDataType(outcolorspace, &bits);
-        if (type.basetype != TypeDesc::UNKNOWN) {
+        if (type != TypeUnknown && type != TypeFloat) {
             if (ot.debug)
-                std::cout << "  Deduced data type " << type << " (" << bits
-                          << "bits) for output to " << filename << "\n";
+                OIIO::print(
+                    "  Deduced data type {} ({} bits) for output to {}\n", type,
+                    bits, filename);
             if ((ot.output_dataformat && ot.output_dataformat != type)
                 || (bits && ot.output_bitspersample
                     && ot.output_bitspersample != bits)) {


### PR DESCRIPTION
Background: OCIO 1.x configs were LUT based and so tended to have different color space names for different data types/bit depths. We capitalized on this to let `oiiotool --autocc` also select type/bits, but this trick doesn't work so well for OCIO 2.x configs with procedural (non-LUT) transformations that all look like "float". We don't want to promote to float just because of this!

Solution: When using color space data type (nearly always float for new configs and certainly the built-in configs) to infer output, DO NOT use "float" as a real request. Treat it as not being a specific type, don't let it override the intended output type for --autocc. (But a color space still marked as a particular integer bit depth is still an --autocc inferred request.)
