### PR TITLE
docs: Conversion of ImageOutput docs to tests for the copy image exam…

### DIFF
--- a/src/doc/imageoutput.rst
+++ b/src/doc/imageoutput.rst
@@ -1438,41 +1438,19 @@ without alteration while modifying the image description metadata:
 
 .. tabs::
 
-   .. code-tab:: c++
+   .. tab:: C++
+         .. literalinclude:: ../../testsuite/docs-examples-cpp/src/docs-examples-imageoutput.cpp
+          :language: c++
+          :start-after: BEGIN-imageoutput-copy
+          :end-before: END-imageoutput-copy
+          :dedent: 4
 
-      // Open the input file
-      auto in = ImageInput::open ("input.jpg");
-  
-      // Make an output spec, identical to the input except for metadata
-      ImageSpec out_spec = in->spec();
-      out_spec.attribute ("ImageDescription", "My Title");
-  
-      // Create the output file and copy the image
-      auto out = ImageOutput::create ("output.jpg");
-      out->open ("output.jpg", out_spec);
-      out->copy_image (in);
-  
-      // Clean up
-      out->close ();
-      in->close ();
-
-   .. code-tab:: py
-
-      # Open the input file
-      inp = ImageInput.open ("input.jpg")
-  
-      # Make an output spec, identical to the input except for metadata
-      out_spec = inp.spec()
-      out_spec.attribute ("ImageDescription", "My Title")
-  
-      # Create the output file and copy the image
-      out = ImageOutput.create ("output.jpg")
-      out.open ("output.jpg", out_spec)
-      out.copy_image (inp)
-  
-      # Clean up
-      out.close ()
-      inp.close ()
+   .. tab:: Python
+         .. literalinclude:: ../../testsuite/docs-examples-python/src/docs-examples-imageoutput.py
+          :language: py
+          :start-after: BEGIN-imageoutput-copy
+          :end-before: END-imageoutput-copy
+          :dedent: 4
 
 
 

--- a/testsuite/docs-examples-cpp/run.py
+++ b/testsuite/docs-examples-cpp/run.py
@@ -19,6 +19,7 @@ command += run_app("cmake -E copy " + test_source_dir + "/../common/with_nans.ti
 command += run_app("cmake -E copy " + test_source_dir + "/../common/checker_with_alpha.exr checker_with_alpha.exr")
 command += run_app("cmake -E copy " + test_source_dir + "/../common/unpremult.tif unpremult.tif")
 command += run_app("cmake -E copy " + test_source_dir + "/../common/bayer.png bayer.png")
+command += run_app("cmake -E copy " + test_source_dir + "/../common/grid-small.exr input.exr")
 
 command += oiio_app("oiiotool") +  "--pattern fill:top=0:bottom=1 256x256 1 -o mono.exr > out.txt ;"
 

--- a/testsuite/docs-examples-cpp/src/docs-examples-imageoutput.cpp
+++ b/testsuite/docs-examples-cpp/src/docs-examples-imageoutput.cpp
@@ -125,11 +125,36 @@ tiles_write()
 
 
 
+void
+copy_write()
+{
+    // BEGIN-imageoutput-copy
+    // Open the input file
+    auto in = ImageInput::open("input.exr");
+
+    // Make an output spec, identical to the input except for metadata
+    ImageSpec out_spec = in->spec();
+    out_spec.attribute("ImageDescription", "My Title");
+
+    // Create the output file and copy the image
+    auto out = ImageOutput::create("output.exr");
+    out->open("output.exr", out_spec);
+    out->copy_image(in.get());
+
+    // Clean up
+    out->close();
+    in->close();
+    // END-imageoutput-copy
+}
+
+
+
 int
 main(int /*argc*/, char** /*argv*/)
 {
     simple_write();
     scanlines_write();
     tiles_write();
+    copy_write();
     return 0;
 }

--- a/testsuite/docs-examples-python/run.py
+++ b/testsuite/docs-examples-python/run.py
@@ -19,6 +19,7 @@ command += run_app("cmake -E copy " + test_source_dir + "/../common/with_nans.ti
 command += run_app("cmake -E copy " + test_source_dir + "/../common/checker_with_alpha.exr checker_with_alpha.exr")
 command += run_app("cmake -E copy " + test_source_dir + "/../common/unpremult.tif unpremult.tif")
 command += run_app("cmake -E copy " + test_source_dir + "/../common/bayer.png bayer.png")
+command += run_app("cmake -E copy " + test_source_dir + "/../common/grid-small.exr input.exr")
 
 command += oiio_app("oiiotool") +  "--pattern fill:top=0:bottom=1 256x256 1 -o mono.exr > out.txt ;"
 

--- a/testsuite/docs-examples-python/src/docs-examples-imageoutput.py
+++ b/testsuite/docs-examples-python/src/docs-examples-imageoutput.py
@@ -102,6 +102,27 @@ def tiles_write() -> None:
         # END-imageoutput-tiles
 
 
+def copy_write() -> None:
+    from OpenImageIO import ImageInput, ImageOutput
+
+    # BEGIN-imageoutput-copy
+    # Open the input file
+    inp = ImageInput.open("input.exr")
+
+    # Make an output spec, identical to the input except for metadata
+    out_spec = inp.spec()
+    out_spec.attribute("ImageDescription", "My Title")
+
+    # Create the output file and copy the image
+    out = ImageOutput.create("output.exr")
+    out.open("output.exr", out_spec)
+    out.copy_image(inp)
+
+    # Clean up
+    out.close()
+    inp.close()
+    # END-imageoutput-copy
+
 
 if __name__ == '__main__':
     # Each example function needs to get called here, or it won't execute
@@ -109,3 +130,4 @@ if __name__ == '__main__':
     simple_write()
     scanlines_write()
     tiles_write()
+    copy_write()


### PR DESCRIPTION
### Description

Convert C++ and Python example from the [ImageOutput: Copying an entire image](https://openimageio.readthedocs.io/en/latest/imageoutput.html#copying-an-entire-image) chapter into tests within the `docs-examples-{cpp,python}` test suites.
This was done following the steps outlined in  [Converting documentation examples to tests](https://github.com/AcademySoftwareFoundation/OpenImageIO/wiki/Converting-documentation-examples-to-tests).

----
* This PR contributes to addressing issue https://github.com/AcademySoftwareFoundation/OpenImageIO/issues/3992.
* This PR supersedes the closed PR https://github.com/AcademySoftwareFoundation/OpenImageIO/pull/5195.
----

#### Notes

- In both `python` and `cpp` I have replaced the file `{input,output}.jpg` mentioned in the example with `{input,output}.exr` in the test, so to reuse existing resource files (i.e. `testsuite/common/grid-small.exr`): do let me know if you prefer the tests also use a `.jpg`, in which case I'll add a new resource to that effect.
- The `cpp` example code was further modified to:
  1. pass the requirements of `clang-format` (see original failing output [here](https://github.com/demiaster/OpenImageIO/actions/runs/25871058187/job/76026144354))
  2. successfully run `ImageOutput.copy_image`
- The `python` example code was further modified to remove unnecessary whitespace before the brackets of function calls.

Finally, when following the [conversion docs](https://github.com/AcademySoftwareFoundation/OpenImageIO/wiki/Converting-documentation-examples-to-tests), I have not addressed point `5`: again, let me know if you prefer to have a positive fixture to compare the test output against.


### Tests

I have checked that, on my fork:
* The CI passes successfully: https://github.com/demiaster/OpenImageIO/actions/runs/25888576608
* The docs build successfully: https://github.com/demiaster/OpenImageIO/actions/runs/25888576599
* The replaced docs examples render correctly (see excerpt from above build here: [imageoutput.html](https://github.com/user-attachments/files/27781020/imageoutput.html))

### Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] **I have read the guidelines** on [contributions](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md) and [code review procedures](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/CodeReview.md).
- [x] **I have read the [Policy on AI Coding Assistants](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/AI_Policy.md)**
  and if I used AI coding assistants, I have an `Assisted-by: TOOL / MODEL`
  line in the pull request description above.
- [x] **I have updated the documentation** if my PR adds features or changes
  behavior.
- [x] **I am sure that this PR's changes are tested in the testsuite**.
- [x] **I have run and passed the testsuite in CI** *before* submitting the
  PR, by pushing the changes to my fork and seeing that the automated CI
  passed there. (Exceptions: If most tests pass and you can't figure out why
  the remaining ones fail, it's ok to submit the PR and ask for help. Or if
  any failures seem entirely unrelated to your change; sometimes things break
  on the GitHub runners.)
- [x] **My code follows the prevailing code style of this project** and I
  fixed any problems reported by the clang-format CI test.
- [x] If I added or modified a public C++ API call, I have also amended the
  corresponding Python bindings. If altering ImageBufAlgo functions, I also
  exposed the new functionality as oiiotool options.