### PR TITLE
perf: Speedup other file ops on Windows

### DIFF
--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -346,8 +346,14 @@ Filesystem::exists(string_view path) noexcept
 bool
 Filesystem::is_directory(string_view path) noexcept
 {
+#ifdef _WIN32
+    DWORD attr = GetFileAttributesW(
+        Strutil::utf8_to_utf16wstring(path).c_str());
+    return attr != INVALID_FILE_ATTRIBUTES && (attr & FILE_ATTRIBUTE_DIRECTORY);
+#else
     error_code ec;
     return filesystem::is_directory(u8path(path), ec);
+#endif
 }
 
 
@@ -355,8 +361,15 @@ Filesystem::is_directory(string_view path) noexcept
 bool
 Filesystem::is_regular(string_view path) noexcept
 {
+#ifdef _WIN32
+    DWORD attr = GetFileAttributesW(
+        Strutil::utf8_to_utf16wstring(path).c_str());
+    return attr != INVALID_FILE_ATTRIBUTES && !(attr & FILE_ATTRIBUTE_DIRECTORY)
+           && !(attr & FILE_ATTRIBUTE_REPARSE_POINT);  // exclude symlinks
+#else
     error_code ec;
     return filesystem::is_regular_file(u8path(path), ec);
+#endif
 }
 
 
@@ -774,9 +787,18 @@ Filesystem::last_write_time(string_view path, std::time_t time) noexcept
 uint64_t
 Filesystem::file_size(string_view path) noexcept
 {
+#ifdef _WIN32
+    WIN32_FILE_ATTRIBUTE_DATA data {};
+    if (!GetFileAttributesExW(Strutil::utf8_to_utf16wstring(path).c_str(),
+                              GetFileExInfoStandard, &data))
+        return 0;
+    return (static_cast<uint64_t>(data.nFileSizeHigh) << 32)
+           | static_cast<uint64_t>(data.nFileSizeLow);
+#else
     error_code ec;
     uint64_t sz = filesystem::file_size(u8path(path), ec);
     return ec ? 0 : sz;
+#endif
 }
 
 


### PR DESCRIPTION
### Description

Similar to https://github.com/AcademySoftwareFoundation/OpenImageIO/pull/4977, replace `std::filesystem` with Windows APIs for better performance.

### Tests

No new test.

### Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] **I have read the guidelines** on [contributions](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md) and [code review procedures](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/CodeReview.md).
- [x] **I have read the [Policy on AI Coding Assistants](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/AI_Policy.md)**
  and if I used AI coding assistants, I have an `Assisted-by: TOOL / MODEL`
  line in the pull request description above.
- [x] **I have updated the documentation** if my PR adds features or changes
  behavior.
- [x] **I am sure that this PR's changes are tested in the testsuite**.
- [ ] **I have run and passed the testsuite in CI** *before* submitting the
  PR, by pushing the changes to my fork and seeing that the automated CI
  passed there. (Exceptions: If most tests pass and you can't figure out why
  the remaining ones fail, it's ok to submit the PR and ask for help. Or if
  any failures seem entirely unrelated to your change; sometimes things break
  on the GitHub runners.)
- [x] **My code follows the prevailing code style of this project** and I
  fixed any problems reported by the clang-format CI test.
- [x] If I added or modified a public C++ API call, I have also amended the
  corresponding Python bindings. If altering ImageBufAlgo functions, I also
  exposed the new functionality as oiiotool options.
