### PR TITLE
ci: Fix broken CI by locking down aswf container for 2023

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,7 @@ jobs:
           - desc: VFX2023 gcc11/C++17 py3.10 exr3.1 ocio2.3
             nametag: linux-vfx2023
             runner: ubuntu-latest
-            container: aswf/ci-osl:2023-clang15
+            container: aswf/ci-osl:2023-clang15.2
             opencolorio_ver: v2.3.0
             python_ver: "3.10"
             simd: "avx2,f16c"


### PR DESCRIPTION
Our CI job that builds against VFX Platform 2023 via docker container aswf/ci-osl:2023-clang15 broke after some dependency changes in a recent aswf docker container update. It's not worth trying to "fix" an old year, just lock down to the previous version of the container that is known to work.

