### PR TITLE
api: add OIIO_NODISCARD_ERROR to ImageOutput methods

### DIFF
--- a/src/iconvert/iconvert.cpp
+++ b/src/iconvert/iconvert.cpp
@@ -494,7 +494,9 @@ convert_file(const std::string& in_filename, const std::string& out_filename)
         } while (ok && in->seek_subimage(subimage, miplevel));
     }
 
-    out->close();
+    if (!out->close()) {
+        errorfmt("Error closing \"{}\" : {}", out_filename, out->geterror());
+    }
     in->close();
 
     // Figure out a time for the input file -- either one supplied by

--- a/src/iconvert/iconvert.cpp
+++ b/src/iconvert/iconvert.cpp
@@ -496,6 +496,7 @@ convert_file(const std::string& in_filename, const std::string& out_filename)
 
     if (!out->close()) {
         errorfmt("Error closing \"{}\" : {}", out_filename, out->geterror());
+        ok = false;
     }
     in->close();
 

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -2572,11 +2572,11 @@ public:
     ///                     append another subimage (`AppendSubimage`), or
     ///                     append another MIP level (`AppendMIPLevel`).
     /// @returns            `true` upon success, or `false` upon failure.
-    virtual bool open (const std::string &filename, const ImageSpec &newspec,
+    OIIO_NODISCARD_ERROR virtual bool open (const std::string &filename, const ImageSpec &newspec,
                        OpenMode mode=Create) = 0;
 
     /// Open an ImageOutput using a UTF-16 encoded wstring filename.
-    bool open (const std::wstring &filename, const ImageSpec &newspec,
+    OIIO_NODISCARD_ERROR bool open (const std::wstring &filename, const ImageSpec &newspec,
                OpenMode mode=Create) {
         return open(Strutil::utf16_to_utf8(filename), newspec, mode);
     }
@@ -2603,7 +2603,7 @@ public:
     ///                      Pointer to an array of `ImageSpec` objects
     ///                      describing each of the expected subimages.
     /// @returns            `true` upon success, or `false` upon failure.
-    virtual bool open (const std::string &filename,
+    OIIO_NODISCARD_ERROR virtual bool open (const std::string &filename,
                        int subimages OIIO_MAYBE_UNUSED,
                        const ImageSpec *specs) {
         // Default implementation: just a regular open, assume that
@@ -2611,7 +2611,7 @@ public:
         return open (filename, specs[0]);
     }
 
-    bool open (const std::wstring &filename, int subimages OIIO_MAYBE_UNUSED,
+    OIIO_NODISCARD_ERROR bool open (const std::wstring &filename, int subimages OIIO_MAYBE_UNUSED,
                const ImageSpec *specs) {
         // Default implementation: just a regular open, assume that
         // appending will work.
@@ -2625,7 +2625,7 @@ public:
 
     /// Closes the currently open file associated with this ImageOutput and
     /// frees any memory or resources associated with it.
-    virtual bool close () = 0;
+    OIIO_NODISCARD_ERROR virtual bool close () = 0;
     /// @}
 
     // clang-format on
@@ -2687,13 +2687,14 @@ public:
     ///                     y, and z).
     /// @returns            `true` upon success, or `false` upon failure.
     ///
-    virtual bool write_image(TypeDesc format,
-                             const image_span<const std::byte>& data);
+    OIIO_NODISCARD_ERROR virtual bool
+    write_image(TypeDesc format, const image_span<const std::byte>& data);
 
     /// A version of `write_image()` taking an `image_span<T>`, where the type
     /// of the underlying data is `T`.  This is a convenience wrapper around
     /// the `write_image()` that takes an `image_span<const std::byte>`.
-    template<typename T> bool write_image(const image_span<T>& data)
+    template<typename T>
+    OIIO_NODISCARD_ERROR bool write_image(const image_span<T>& data)
     {
         return write_image(TypeDescFromC<T>::value(),
                            as_image_span_bytes(data));
@@ -2702,7 +2703,7 @@ public:
     /// A version of `write_image()` taking a `cspan<T>`, which assumes
     /// contiguous strides in all dimensions. This is a convenience wrapper
     /// around the `write_image()` that takes an `image_span<const T>`.
-    template<typename T> bool write_image(span<T> data)
+    template<typename T> OIIO_NODISCARD_ERROR bool write_image(span<T> data)
     {
         auto ispan = image_span<const T>(data.data(), m_spec.nchannels,
                                          m_spec.width, m_spec.height,
@@ -2734,14 +2735,16 @@ public:
     ///                     dimension (channel, x, y, z).
     /// @returns            `true` upon success, or `false` upon failure.
     ///
-    virtual bool write_scanline(int y, TypeDesc format,
-                                const image_span<const std::byte>& data);
+    OIIO_NODISCARD_ERROR virtual bool
+    write_scanline(int y, TypeDesc format,
+                   const image_span<const std::byte>& data);
 
     /// A version of `write_scanline()` taking an `image_span<T>`, where the
     /// type of the underlying data is `T`.  This is a convenience wrapper
     /// around the `write_scanline()` that takes an `image_span<const
     /// std::byte>`.
-    template<typename T> bool write_scanline(int y, const image_span<T>& data)
+    template<typename T>
+    OIIO_NODISCARD_ERROR bool write_scanline(int y, const image_span<T>& data)
     {
         // reduce to type + image_span<byte>
         return write_scanline(y, TypeDescFromC<T>::value(),
@@ -2751,7 +2754,8 @@ public:
     /// A version of `write_scanline()` taking a `cspan<T>`, which assumes
     /// contiguous strides in all dimensions. This is a convenience wrapper
     /// around the `write_scanline()` that takes an `image_span<const T>`.
-    template<typename T> bool write_scanline(int y, span<T> data)
+    template<typename T>
+    OIIO_NODISCARD_ERROR bool write_scanline(int y, span<T> data)
     {
         // reduce to type + image_span<byte>
         return write_scanline(y, image_span<T>(data.data(), m_spec.nchannels,
@@ -2783,8 +2787,9 @@ public:
     ///                     dimension (channel, x, y, z).
     /// @returns            `true` upon success, or `false` upon failure.
     ///
-    virtual bool write_scanlines(int ybegin, int yend, TypeDesc format,
-                                 const image_span<const std::byte>& data);
+    OIIO_NODISCARD_ERROR virtual bool
+    write_scanlines(int ybegin, int yend, TypeDesc format,
+                    const image_span<const std::byte>& data);
 
     /// A version of `write_scanlines()` taking an `image_span<T>`, where the
     /// type of the underlying data is `T`.  This is a convenience wrapper
@@ -2802,7 +2807,8 @@ public:
     /// contiguous strides in all dimensions. This is a convenience wrapper
     /// around the `write_scanlines()` that takes an `image_span<const T>`.
     template<typename T>
-    bool write_scanlines(int ybegin, int yend, span<T> data)
+    OIIO_NODISCARD_ERROR bool write_scanlines(int ybegin, int yend,
+                                              span<T> data)
     {
         auto ispan = image_span<T>(data.data(), m_spec.nchannels, m_spec.width,
                                    yend - ybegin, 1);
@@ -2839,14 +2845,16 @@ public:
     /// Added in OIIO 3.1, this is the "safe" preferred alternative to
     /// the version of write_tile that takes raw pointers.
     ///
-    virtual bool write_tile(int x, int y, int z, TypeDesc format,
-                            const image_span<const std::byte>& data);
+    OIIO_NODISCARD_ERROR virtual bool
+    write_tile(int x, int y, int z, TypeDesc format,
+               const image_span<const std::byte>& data);
 
     /// A version of `write_tile()` taking an `image_span<T>`, where the type
     /// of the underlying data is `T`.  This is a convenience wrapper around
     /// the `write_tile()` that takes an `image_span<const std::byte>`.
     template<typename T>
-    bool write_tile(int x, int y, int z, const image_span<T>& data)
+    OIIO_NODISCARD_ERROR bool write_tile(int x, int y, int z,
+                                         const image_span<T>& data)
     {
         return write_tile(x, y, z, TypeDescFromC<T>::value(),
                           as_image_span_bytes(data));
@@ -2855,7 +2863,8 @@ public:
     /// A version of `write_tile()` taking a `cspan<T>`, which assumes
     /// contiguous strides in all dimensions. This is a convenience wrapper
     /// around the `write_tile()` that takes an `image_span<const T>`.
-    template<typename T> bool write_tile(int x, int y, int z, span<T> data)
+    template<typename T>
+    OIIO_NODISCARD_ERROR bool write_tile(int x, int y, int z, span<T> data)
     {
         auto ispan = image_span<T>(data.data(), m_spec.nchannels,
                                    m_spec.tile_width, m_spec.tile_height,
@@ -2891,16 +2900,18 @@ public:
     ///                     dimension (channel, x, y, z).
     /// @returns            `true` upon success, or `false` upon failure.
     ///
-    virtual bool write_tiles(int xbegin, int xend, int ybegin, int yend,
-                             int zbegin, int zend, TypeDesc format,
-                             const image_span<const std::byte>& data);
+    OIIO_NODISCARD_ERROR virtual bool
+    write_tiles(int xbegin, int xend, int ybegin, int yend, int zbegin,
+                int zend, TypeDesc format,
+                const image_span<const std::byte>& data);
 
     /// A version of `write_tiles()` taking an `image_span<T>`, where the type
     /// of the underlying data is `T`.  This is a convenience wrapper around
     /// the `write_tiles()` that takes an `image_span<const std::byte>`.
     template<typename T>
-    bool write_tiles(int xbegin, int xend, int ybegin, int yend, int zbegin,
-                     int zend, const image_span<T>& data)
+    OIIO_NODISCARD_ERROR bool write_tiles(int xbegin, int xend, int ybegin,
+                                          int yend, int zbegin, int zend,
+                                          const image_span<T>& data)
     {
         return write_tiles(xbegin, xend, ybegin, yend, zbegin, zend,
                            TypeDescFromC<T>::value(),
@@ -2911,8 +2922,9 @@ public:
     /// contiguous strides in all dimensions. This is a convenience wrapper
     /// around the `write_tiles()` that takes an `image_span<const T>`.
     template<typename T>
-    bool write_tiles(int xbegin, int xend, int ybegin, int yend, int zbegin,
-                     int zend, span<T> data)
+    OIIO_NODISCARD_ERROR bool write_tiles(int xbegin, int xend, int ybegin,
+                                          int yend, int zbegin, int zend,
+                                          span<T> data)
     {
         auto ispan = image_span<T>(data.data(), m_spec.nchannels, xend - xbegin,
                                    yend - ybegin, zend - zbegin);
@@ -2946,17 +2958,19 @@ public:
     ///                     dimension (channel, x, y, z).
     /// @returns            `true` upon success, or `false` upon failure.
     ///
-    virtual bool write_rectangle(int xbegin, int xend, int ybegin, int yend,
-                                 int zbegin, int zend, TypeDesc format,
-                                 const image_span<const std::byte>& data);
+    OIIO_NODISCARD_ERROR virtual bool
+    write_rectangle(int xbegin, int xend, int ybegin, int yend, int zbegin,
+                    int zend, TypeDesc format,
+                    const image_span<const std::byte>& data);
 
     /// A version of `write_rectangle()` taking an `image_span<T>`, where the
     /// type of the underlying data is `T`.  This is a convenience wrapper
     /// around the `write_rectangle()` that takes an `image_span<const
     /// std::byte>`.
     template<typename T>
-    bool write_rectangle(int xbegin, int xend, int ybegin, int yend, int zbegin,
-                         int zend, const image_span<T>& data)
+    OIIO_NODISCARD_ERROR bool write_rectangle(int xbegin, int xend, int ybegin,
+                                              int yend, int zbegin, int zend,
+                                              const image_span<T>& data)
     {
         return write_rectangle(xbegin, xend, ybegin, yend, zbegin, zend,
                                TypeDescFromC<T>::value(),
@@ -2967,8 +2981,9 @@ public:
     /// contiguous strides in all dimensions. This is a convenience wrapper
     /// around the `write_rectangle()` that takes an `image_span<const T>`.
     template<typename T>
-    bool write_rectangle(int xbegin, int xend, int ybegin, int yend, int zbegin,
-                         int zend, span<T> data)
+    OIIO_NODISCARD_ERROR bool write_rectangle(int xbegin, int xend, int ybegin,
+                                              int yend, int zbegin, int zend,
+                                              span<T> data)
     {
         auto ispan = image_span<const T>(data.data(), m_spec.nchannels,
                                          xend - xbegin, yend - ybegin,
@@ -2989,7 +3004,7 @@ public:
     /// @param  deepdata    A `DeepData` object with the data for these
     ///                     scanlines.
     /// @returns            `true` upon success, or `false` upon failure.
-    virtual bool write_deep_scanlines (int ybegin, int yend, int z,
+    OIIO_NODISCARD_ERROR virtual bool write_deep_scanlines (int ybegin, int yend, int z,
                                        const DeepData &deepdata);
 
     /// Write the block of deep tiles that include all pixels in
@@ -3012,7 +3027,7 @@ public:
     /// @note The call will fail if the image is not tiled, or if the pixel
     /// ranges do not fall along tile (or image) boundaries, or if it is not
     /// a valid tile range.
-    virtual bool write_deep_tiles (int xbegin, int xend, int ybegin, int yend,
+    OIIO_NODISCARD_ERROR virtual bool write_deep_tiles (int xbegin, int xend, int ybegin, int yend,
                                    int zbegin, int zend,
                                    const DeepData &deepdata);
 
@@ -3021,7 +3036,7 @@ public:
     ///
     /// @param  deepdata    A `DeepData` object with the data for the image.
     /// @returns            `true` upon success, or `false` upon failure.
-    virtual bool write_deep_image (const DeepData &deepdata);
+    OIIO_NODISCARD_ERROR virtual bool write_deep_image (const DeepData &deepdata);
 
     /// Specify a reduced-resolution ("thumbnail") version of the image.
     /// Note that many image formats may require the thumbnail to be
@@ -3103,7 +3118,7 @@ public:
     /// @param  xstride     The distance in bytes between successive
     ///                     pixels in `data` (or `AutoStride`).
     /// @returns            `true` upon success, or `false` upon failure.
-    virtual bool write_scanline (int y, int z, TypeDesc format,
+    OIIO_NODISCARD_ERROR virtual bool write_scanline (int y, int z, TypeDesc format,
                                  const void *data, stride_t xstride=AutoStride);
 
     /// Write multiple scanlines that include pixels (*,y,z) for all ybegin
@@ -3121,7 +3136,7 @@ public:
     ///                     The distance in bytes between successive pixels
     ///                     and scanlines (or `AutoStride`).
     /// @returns            `true` upon success, or `false` upon failure.
-    virtual bool write_scanlines (int ybegin, int yend, int z,
+    OIIO_NODISCARD_ERROR virtual bool write_scanlines (int ybegin, int yend, int z,
                                   TypeDesc format, const void *data,
                                   stride_t xstride=AutoStride,
                                   stride_t ystride=AutoStride);
@@ -3147,7 +3162,7 @@ public:
     ///
     /// @note This call will fail if the image is not tiled, or if (x,y,z)
     /// is not the upper left corner coordinates of a tile.
-    virtual bool write_tile (int x, int y, int z, TypeDesc format,
+    OIIO_NODISCARD_ERROR virtual bool write_tile (int x, int y, int z, TypeDesc format,
                              const void *data, stride_t xstride=AutoStride,
                              stride_t ystride=AutoStride,
                              stride_t zstride=AutoStride);
@@ -3186,7 +3201,7 @@ public:
     /// @note The call will fail if the image is not tiled, or if the pixel
     /// ranges do not fall along tile (or image) boundaries, or if it is not
     /// a valid tile range.
-    virtual bool write_tiles (int xbegin, int xend, int ybegin, int yend,
+    OIIO_NODISCARD_ERROR virtual bool write_tiles (int xbegin, int xend, int ybegin, int yend,
                               int zbegin, int zend, TypeDesc format,
                               const void *data, stride_t xstride=AutoStride,
                               stride_t ystride=AutoStride,
@@ -3218,7 +3233,7 @@ public:
     ///
     /// @note The call will fail for a format plugin that does not return
     /// true for `supports("rectangles")`.
-    virtual bool write_rectangle (int xbegin, int xend, int ybegin, int yend,
+    OIIO_NODISCARD_ERROR virtual bool write_rectangle (int xbegin, int xend, int ybegin, int yend,
                                   int zbegin, int zend, TypeDesc format,
                                   const void *data, stride_t xstride=AutoStride,
                                   stride_t ystride=AutoStride,
@@ -3247,7 +3262,7 @@ public:
     /// @param  progress_callback/progress_callback_data
     ///                     Optional progress callback.
     /// @returns            `true` upon success, or `false` upon failure.
-    virtual bool write_image (TypeDesc format, const void *data,
+    OIIO_NODISCARD_ERROR virtual bool write_image (TypeDesc format, const void *data,
                               stride_t xstride=AutoStride,
                               stride_t ystride=AutoStride,
                               stride_t zstride=AutoStride,
@@ -3283,7 +3298,7 @@ public:
     ///
     /// @param  in          A pointer to the open `ImageInput` to read from.
     /// @returns            `true` upon success, or `false` upon failure.
-    virtual bool copy_image (ImageInput *in);
+    OIIO_NODISCARD_ERROR virtual bool copy_image (ImageInput *in);
 
     // General message passing between client and image output server. This
     // is currently undefined and is reserved for future use.

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -4725,6 +4725,6 @@ OIIO_NAMESPACE_END
 
 #if FMT_VERSION >= 100000
 FMT_BEGIN_NAMESPACE
-template<> struct formatter<OIIO::ROI> : ostream_formatter {};
+template<> struct formatter<OIIO::ROI> : ostream_formatter { };
 FMT_END_NAMESPACE
 #endif

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -4725,6 +4725,6 @@ OIIO_NAMESPACE_END
 
 #if FMT_VERSION >= 100000
 FMT_BEGIN_NAMESPACE
-template<> struct formatter<OIIO::ROI> : ostream_formatter { };
+template<> struct formatter<OIIO::ROI> : ostream_formatter {};
 FMT_END_NAMESPACE
 #endif

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -1811,7 +1811,10 @@ ImageBuf::write(string_view _filename, TypeDesc dtype, string_view _fileformat,
     }
     if (!write(out.get(), progress_callback, progress_callback_data))
         return false;
-    out->close();
+    if (!out->close()) {
+        error(out->geterror());
+        return false;
+    }
     if (progress_callback)
         progress_callback(progress_callback_data, 0);
     return true;

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -112,9 +112,9 @@ force_as_image_span_writable_bytes(const image_span<T, Rank>& src) noexcept
 class ImageBufImpl {
 public:
     ImageBufImpl(string_view filename, int subimage, int miplevel,
-                 std::shared_ptr<ImageCache> imagecache = {},
+                 std::shared_ptr<ImageCache> imagecache = { },
                  const ImageSpec* spec                  = nullptr,
-                 const image_span<std::byte>& bufspan   = {},
+                 const image_span<std::byte>& bufspan   = { },
                  bool readonly = false, const ImageSpec* config = nullptr,
                  Filesystem::IOProxy* ioproxy = nullptr);
     ImageBufImpl(string_view filename, int subimage, int miplevel,
@@ -136,7 +136,7 @@ public:
     // just copy the regular spec.
     void reset(string_view name, const ImageSpec& spec,
                const ImageSpec* nativespec          = nullptr,
-               const image_span<std::byte>& bufspan = {},
+               const image_span<std::byte>& bufspan = { },
                bool readonly                        = false);
     // alloc() resets the internal spec and nativespec, does some sanity
     // checks on the image sizes, and calls realloc.
@@ -151,10 +151,10 @@ public:
                      stride_t zstride = AutoStride)
     {
         auto formatsize = m_spec.format.size();
-        m_bufspan       = image_span(reinterpret_cast<std::byte*>(data),
-                                     m_spec.nchannels, m_spec.width, m_spec.height,
-                                     m_spec.depth, formatsize, xstride, ystride,
-                                     zstride, formatsize);
+        m_bufspan = image_span(reinterpret_cast<std::byte*>(data),
+                               m_spec.nchannels, m_spec.width, m_spec.height,
+                               m_spec.depth, formatsize, xstride, ystride,
+                               zstride, formatsize);
         eval_contiguous();
     }
 
@@ -167,22 +167,18 @@ public:
               DoLock do_lock                     = DoLock(true));
     void copy_metadata(const ImageBufImpl& src);
     void merge_metadata(const ImageBufImpl& src, bool override = false,
-                        string_view pattern = {});
+                        string_view pattern = { });
 
     // Note: Uses std::format syntax
     template<typename... Args>
     void error(const char* fmt, const Args&... args) const
-    {
-        error(Strutil::fmt::format(fmt, args...));
-    }
+    { error(Strutil::fmt::format(fmt, args...)); }
 
     // Another alias for error so we don't get mixed up with the global
     // OIIO::errorfmt.
     template<typename... Args>
     void errorfmt(const char* fmt, const Args&... args) const
-    {
-        error(Strutil::fmt::format(fmt, args...));
-    }
+    { error(Strutil::fmt::format(fmt, args...)); }
 
     void error(string_view message) const;
 
@@ -205,9 +201,7 @@ public:
         return m_spec.deep ? &m_deepdata : NULL;
     }
     bool initialized() const
-    {
-        return m_spec_valid && m_storage != ImageBuf::UNINITIALIZED;
-    }
+    { return m_spec_valid && m_storage != ImageBuf::UNINITIALIZED; }
     bool cachedpixels() const { return m_storage == ImageBuf::IMAGECACHE; }
     void* localpixels() const { return m_bufspan.data(); }
 
@@ -320,9 +314,9 @@ public:
 
     void eval_contiguous()
     {
-        bool in_memory = m_bufspan.data() != nullptr
-                         && (m_storage == ImageBuf::LOCALBUFFER
-                             || m_storage == ImageBuf::APPBUFFER);
+        bool in_memory        = m_bufspan.data() != nullptr
+                                && (m_storage == ImageBuf::LOCALBUFFER
+                                    || m_storage == ImageBuf::APPBUFFER);
         m_contiguous          = in_memory && m_bufspan.is_contiguous();
         m_contiguous_scanline = in_memory && m_bufspan.is_contiguous_scanline();
     }
@@ -402,9 +396,7 @@ private:
 
 void
 ImageBuf::impl_deleter(ImageBufImpl* todel)
-{
-    delete todel;
-}
+{ delete todel; }
 
 
 
@@ -545,7 +537,7 @@ ImageBufImpl::ImageBufImpl(const ImageBufImpl& src)
     } else {
         // Source was cache-based or deep
         // nothing else to do
-        m_bufspan = {};
+        m_bufspan = { };
     }
     if (localpixels() || m_spec.deep) {
         // A copied ImageBuf is no longer a direct file reference, so clear
@@ -604,7 +596,7 @@ ImageBuf::ImageBuf(string_view filename, int subimage, int miplevel,
                    const ImageSpec* config, Filesystem::IOProxy* ioproxy)
     : m_impl(new ImageBufImpl(filename, subimage, miplevel,
                               std::move(imagecache), nullptr /*spec*/,
-                              {} /*bufspan*/, nullptr /*buforigin*/, true,
+                              { } /*bufspan*/, nullptr /*buforigin*/, true,
                               config, ioproxy),
              &impl_deleter)
 {
@@ -626,7 +618,7 @@ ImageBuf::ImageBuf(const ImageSpec& spec, InitializePixels zero)
 ImageBuf::ImageBuf(const ImageSpec& spec, void* buffer, stride_t xstride,
                    stride_t ystride, stride_t zstride)
     : m_impl(new ImageBufImpl("", 0, 0, nullptr /*imagecache*/, &spec,
-                              {} /*bufspan*/, buffer /*buforigin*/,
+                              { } /*bufspan*/, buffer /*buforigin*/,
                               false /*readonly*/, nullptr /*config*/,
                               nullptr /*ioproxy*/, xstride, ystride, zstride),
              &impl_deleter)
@@ -697,7 +689,7 @@ ImageBuf::ImageBuf(ImageBuf&& src)
 
 
 
-ImageBuf::~ImageBuf() {}
+ImageBuf::~ImageBuf() { }
 
 
 
@@ -746,7 +738,7 @@ ImageBufImpl::new_pixels(ImageBuf::IBStorage storage, size_t size,
             error("ImageBuf unable to allocate {} bytes ({})\n", size,
                   e.what());
             size      = 0;
-            m_bufspan = {};
+            m_bufspan = { };
         }
         m_allocated_size = size;
         OIIO::pvt::IB_local_mem_current += m_allocated_size;
@@ -777,7 +769,7 @@ ImageBufImpl::free_pixels()
     }
     m_pixels.reset();
     // print("IB Freed pixels of length {}\n", m_bufspan.size());
-    m_bufspan             = {};
+    m_bufspan             = { };
     m_contiguous          = false;
     m_contiguous_scanline = false;
     m_deepdata.free();
@@ -832,17 +824,13 @@ ImageBufImpl::error(string_view message) const
 
 void
 ImageBuf::error(string_view message) const
-{
-    m_impl->error(message);
-}
+{ m_impl->error(message); }
 
 
 
 ImageBuf::IBStorage
 ImageBuf::storage() const
-{
-    return m_impl->storage();
-}
+{ return m_impl->storage(); }
 
 
 
@@ -866,7 +854,7 @@ ImageBufImpl::clear()
     m_spec             = ImageSpec();
     m_nativespec       = ImageSpec();
     m_pixels.reset();
-    m_bufspan             = {};
+    m_bufspan             = { };
     m_spec_valid          = false;
     m_pixels_valid        = false;
     m_badfile             = false;
@@ -891,9 +879,7 @@ ImageBufImpl::clear()
 
 void
 ImageBuf::clear()
-{
-    m_impl->clear();
-}
+{ m_impl->clear(); }
 
 
 
@@ -919,7 +905,7 @@ ImageBufImpl::reset(string_view filename, int subimage, int miplevel,
         add_configspec();
         m_configspec->attribute("oiio:ioproxy", TypeDesc::PTR, &m_rioproxy);
     }
-    m_bufspan = {};
+    m_bufspan = { };
     m_storage = ImageBuf::LOCALBUFFER;
     if (m_name.length() > 0) {
         // For IC-backed file ImageBuf's, call read now. For other file-based
@@ -1016,9 +1002,7 @@ ImageBuf::reset(const ImageSpec& spec,
 
 void
 ImageBuf::reset(const ImageSpec& spec, const image_span<std::byte>& buffer)
-{
-    m_impl->reset("", spec, nullptr, buffer, false /*readonly*/);
-}
+{ m_impl->reset("", spec, nullptr, buffer, false /*readonly*/); }
 
 
 
@@ -1552,9 +1536,7 @@ ImageBuf::set_write_format(cspan<TypeDesc> format)
 
 void
 ImageBuf::set_write_format(TypeDesc format)
-{
-    set_write_format(cspan<TypeDesc>(format));
-}
+{ set_write_format(cspan<TypeDesc>(format)); }
 
 
 
@@ -1570,9 +1552,7 @@ ImageBuf::set_write_tiles(int width, int height, int depth)
 
 void
 ImageBuf::set_write_ioproxy(Filesystem::IOProxy* ioproxy)
-{
-    m_impl->m_wioproxy = ioproxy;
-}
+{ m_impl->m_wioproxy = ioproxy; }
 
 
 
@@ -1660,9 +1640,9 @@ ImageBuf::write(ImageOutput* out, ProgressCallback progress_callback,
                                        && outspec.get_string_attribute(
                                               "openexr:lineOrder")
                                               == "decreasingY";
-            const int numChunks  = outspec.height > 0
-                                       ? 1 + ((outspec.height - 1) / chunk)
-                                       : 0;
+            const int numChunks      = outspec.height > 0
+                                           ? 1 + ((outspec.height - 1) / chunk)
+                                           : 0;
             const int yLoopStart = isDecreasingY ? (numChunks - 1) * chunk : 0;
             const int yDelta     = isDecreasingY ? -chunk : chunk;
             const int yLoopEnd   = yLoopStart + numChunks * yDelta;
@@ -1865,9 +1845,7 @@ ImageBufImpl::copy_metadata(const ImageBufImpl& src)
 
 void
 ImageBuf::copy_metadata(const ImageBuf& src)
-{
-    m_impl->copy_metadata(*src.m_impl);
-}
+{ m_impl->copy_metadata(*src.m_impl); }
 
 
 
@@ -1914,33 +1892,25 @@ ImageBufImpl::merge_metadata(const ImageBufImpl& src, bool override,
 void
 ImageBuf::merge_metadata(const ImageBuf& src, bool override,
                          string_view pattern)
-{
-    m_impl->merge_metadata(*src.m_impl, override, pattern);
-}
+{ m_impl->merge_metadata(*src.m_impl, override, pattern); }
 
 
 
 const ImageSpec&
 ImageBuf::spec() const
-{
-    return m_impl->spec();
-}
+{ return m_impl->spec(); }
 
 
 
 ImageSpec&
 ImageBuf::specmod()
-{
-    return m_impl->specmod();
-}
+{ return m_impl->specmod(); }
 
 
 
 const ImageSpec&
 ImageBuf::nativespec() const
-{
-    return m_impl->nativespec();
-}
+{ return m_impl->nativespec(); }
 
 
 
@@ -1998,56 +1968,42 @@ ImageBufImpl::get_thumbnail(DoLock do_lock) const
 
 bool
 ImageBuf::has_thumbnail() const
-{
-    return m_impl->has_thumbnail();
-}
+{ return m_impl->has_thumbnail(); }
 
 
 
 void
 ImageBuf::set_thumbnail(const ImageBuf& thumb)
-{
-    m_impl->set_thumbnail(thumb);
-}
+{ m_impl->set_thumbnail(thumb); }
 
 
 
 void
 ImageBuf::clear_thumbnail()
-{
-    m_impl->clear_thumbnail();
-}
+{ m_impl->clear_thumbnail(); }
 
 
 
 std::shared_ptr<ImageBuf>
 ImageBuf::get_thumbnail() const
-{
-    return m_impl->get_thumbnail();
-}
+{ return m_impl->get_thumbnail(); }
 
 
 
 string_view
 ImageBuf::name(void) const
-{
-    return m_impl->m_name;
-}
+{ return m_impl->m_name; }
 
 
 ustring
 ImageBuf::uname(void) const
-{
-    return m_impl->m_name;
-}
+{ return m_impl->m_name; }
 
 
 
 void
 ImageBuf::set_name(string_view name)
-{
-    m_impl->m_name = name;
-}
+{ m_impl->m_name = name; }
 
 
 
@@ -2061,9 +2017,7 @@ ImageBuf::file_format_name(void) const
 
 int
 ImageBuf::subimage() const
-{
-    return m_impl->m_current_subimage;
-}
+{ return m_impl->m_current_subimage; }
 
 
 int
@@ -2076,9 +2030,7 @@ ImageBuf::nsubimages() const
 
 int
 ImageBuf::miplevel() const
-{
-    return m_impl->m_current_miplevel;
-}
+{ return m_impl->m_current_miplevel; }
 
 
 int
@@ -2091,9 +2043,7 @@ ImageBuf::nmiplevels() const
 
 int
 ImageBuf::nchannels() const
-{
-    return m_impl->spec().nchannels;
-}
+{ return m_impl->spec().nchannels; }
 
 
 
@@ -2108,33 +2058,25 @@ ImageBuf::orientation() const
 
 void
 ImageBuf::set_orientation(int orient)
-{
-    m_impl->specmod().attribute("Orientation", orient);
-}
+{ m_impl->specmod().attribute("Orientation", orient); }
 
 
 
 bool
 ImageBuf::pixels_valid(void) const
-{
-    return m_impl->m_pixels_valid;
-}
+{ return m_impl->m_pixels_valid; }
 
 
 
 bool
 ImageBuf::pixels_read(void) const
-{
-    return m_impl->m_pixels_read;
-}
+{ return m_impl->m_pixels_read; }
 
 
 
 TypeDesc
 ImageBuf::pixeltype() const
-{
-    return m_impl->pixeltype();
-}
+{ return m_impl->pixeltype(); }
 
 
 
@@ -2149,17 +2091,13 @@ ImageBuf::localpixels()
 
 image_span<const std::byte>
 ImageBuf::localpixels_as_byte_image_span() const
-{
-    return m_impl->m_bufspan;
-}
+{ return m_impl->m_bufspan; }
 
 
 
 image_span<std::byte>
 ImageBuf::localpixels_as_writable_byte_image_span()
-{
-    return m_impl->m_readonly ? image_span<std::byte>() : m_impl->m_bufspan;
-}
+{ return m_impl->m_readonly ? image_span<std::byte>() : m_impl->m_bufspan; }
 
 
 
@@ -2174,25 +2112,19 @@ ImageBuf::localpixels() const
 
 stride_t
 ImageBuf::pixel_stride() const
-{
-    return m_impl->m_bufspan.xstride();
-}
+{ return m_impl->m_bufspan.xstride(); }
 
 
 
 stride_t
 ImageBuf::scanline_stride() const
-{
-    return m_impl->m_bufspan.ystride();
-}
+{ return m_impl->m_bufspan.ystride(); }
 
 
 
 stride_t
 ImageBuf::z_stride() const
-{
-    return m_impl->m_bufspan.zstride();
-}
+{ return m_impl->m_bufspan.zstride(); }
 
 
 
@@ -2216,62 +2148,46 @@ ImageBuf::contiguous_scanline() const
 
 bool
 ImageBuf::cachedpixels() const
-{
-    return m_impl->cachedpixels();
-}
+{ return m_impl->cachedpixels(); }
 
 
 
 std::shared_ptr<ImageCache>
 ImageBuf::imagecache() const
-{
-    return m_impl->m_imagecache;
-}
+{ return m_impl->m_imagecache; }
 
 
 
 bool
 ImageBuf::deep() const
-{
-    return spec().deep;
-}
+{ return spec().deep; }
 
 
 DeepData*
 ImageBuf::deepdata()
-{
-    return m_impl->deepdata();
-}
+{ return m_impl->deepdata(); }
 
 
 const DeepData*
 ImageBuf::deepdata() const
-{
-    return m_impl->deepdata();
-}
+{ return m_impl->deepdata(); }
 
 
 bool
 ImageBuf::initialized() const
-{
-    return m_impl->initialized();
-}
+{ return m_impl->initialized(); }
 
 
 
 void
 ImageBuf::threads(int n) const
-{
-    m_impl->threads(n);
-}
+{ m_impl->threads(n); }
 
 
 
 int
 ImageBuf::threads() const
-{
-    return m_impl->threads();
-}
+{ return m_impl->threads(); }
 
 
 
@@ -2511,9 +2427,7 @@ interppixel_wrapper(float x, float y, span<float> pixel,
 
 void
 ImageBuf::interppixel(float x, float y, span<float> pixel, WrapMode wrap) const
-{
-    interppixel_wrapper(x, y, pixel, wrap, *this);
-}
+{ interppixel_wrapper(x, y, pixel, wrap, *this); }
 
 
 
@@ -2579,9 +2493,7 @@ interppixel_bicubic_wrapper(float x, float y, span<float> pixel,
 void
 ImageBuf::interppixel_bicubic(float x, float y, span<float> pixel,
                               WrapMode wrap) const
-{
-    interppixel_bicubic_wrapper(x, y, pixel, wrap, *this);
-}
+{ interppixel_bicubic_wrapper(x, y, pixel, wrap, *this); }
 
 
 
@@ -2661,7 +2573,7 @@ get_pixels_(const ImageBuf& buf, const ImageBuf& /*dummy*/, ROI whole_roi,
                 imagesize_t offset = (p.z() - whole_roi.zbegin) * zstride
                                      + (p.y() - whole_roi.ybegin) * ystride
                                      + (p.x() - whole_roi.xbegin) * xstride;
-                D* rc = (D*)((char*)r + offset);
+                D* rc              = (D*)((char*)r + offset);
                 for (int c = 0; c < nchans; ++c)
                     rc[c] = p[c + roi.chbegin];
             }
@@ -2755,7 +2667,7 @@ set_pixels_(ImageBuf& buf, ROI roi, const void* data_, stride_t xstride,
         imagesize_t offset = (p.z() - roi.zbegin) * zstride
                              + (p.y() - roi.ybegin) * ystride
                              + (p.x() - roi.xbegin) * xstride;
-        const S* src = (const S*)((const char*)data + offset);
+        const S* src       = (const S*)((const char*)data + offset);
         for (int c = 0; c < nchans; ++c)
             p[c + roi.chbegin] = src[c];
     }
@@ -2972,9 +2884,7 @@ ImageBuf::copy_deep_pixel(int x, int y, int z, const ImageBuf& src, int srcx,
 
 int
 ImageBuf::xbegin() const
-{
-    return spec().x;
-}
+{ return spec().x; }
 
 
 
@@ -2989,9 +2899,7 @@ ImageBuf::xend() const
 
 int
 ImageBuf::ybegin() const
-{
-    return spec().y;
-}
+{ return spec().y; }
 
 
 
@@ -3006,9 +2914,7 @@ ImageBuf::yend() const
 
 int
 ImageBuf::zbegin() const
-{
-    return spec().z;
-}
+{ return spec().z; }
 
 
 
@@ -3023,9 +2929,7 @@ ImageBuf::zend() const
 
 int
 ImageBuf::xmin() const
-{
-    return spec().x;
-}
+{ return spec().x; }
 
 
 
@@ -3040,9 +2944,7 @@ ImageBuf::xmax() const
 
 int
 ImageBuf::ymin() const
-{
-    return spec().y;
-}
+{ return spec().y; }
 
 
 
@@ -3057,9 +2959,7 @@ ImageBuf::ymax() const
 
 int
 ImageBuf::zmin() const
-{
-    return spec().z;
-}
+{ return spec().z; }
 
 
 
@@ -3171,23 +3071,17 @@ ImageBuf::set_full(int xbegin, int xend, int ybegin, int yend, int zbegin,
 
 ROI
 ImageBuf::roi() const
-{
-    return get_roi(spec());
-}
+{ return get_roi(spec()); }
 
 
 ROI
 ImageBuf::roi_full() const
-{
-    return get_roi_full(spec());
-}
+{ return get_roi_full(spec()); }
 
 
 void
 ImageBuf::set_roi_full(const ROI& newroi)
-{
-    OIIO::set_roi_full(specmod(), newroi);
-}
+{ OIIO::set_roi_full(specmod(), newroi); }
 
 
 
@@ -3228,33 +3122,25 @@ ImageBufImpl::pixeladdr(int x, int y, int z, int ch)
 
 const void*
 ImageBuf::pixeladdr(int x, int y, int z, int ch) const
-{
-    return m_impl->pixeladdr(x, y, z, ch);
-}
+{ return m_impl->pixeladdr(x, y, z, ch); }
 
 
 
 void*
 ImageBuf::pixeladdr(int x, int y, int z, int ch)
-{
-    return m_impl->pixeladdr(x, y, z, ch);
-}
+{ return m_impl->pixeladdr(x, y, z, ch); }
 
 
 
 int
 ImageBuf::pixelindex(int x, int y, int z, bool check_range) const
-{
-    return m_impl->pixelindex(x, y, z, check_range);
-}
+{ return m_impl->pixelindex(x, y, z, check_range); }
 
 
 
 const void*
 ImageBuf::blackpixel() const
-{
-    return m_impl->blackpixel();
-}
+{ return m_impl->blackpixel(); }
 
 
 
@@ -3302,9 +3188,7 @@ ImageBufImpl::do_wrap(int& x, int& y, int& z, ImageBuf::WrapMode wrap) const
 
 bool
 ImageBuf::do_wrap(int& x, int& y, int& z, WrapMode wrap) const
-{
-    return m_impl->do_wrap(x, y, z, wrap);
-}
+{ return m_impl->do_wrap(x, y, z, wrap); }
 
 
 
@@ -3683,16 +3567,12 @@ ImageBuf::IteratorBase::rerange(int xbegin, int xend, int ybegin, int yend,
 
 void
 ImageBuf::lock() const
-{
-    m_impl->lock();
-}
+{ m_impl->lock(); }
 
 
 void
 ImageBuf::unlock() const
-{
-    m_impl->unlock();
-}
+{ m_impl->unlock(); }
 
 
 OIIO_NAMESPACE_3_1_END

--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -112,9 +112,9 @@ force_as_image_span_writable_bytes(const image_span<T, Rank>& src) noexcept
 class ImageBufImpl {
 public:
     ImageBufImpl(string_view filename, int subimage, int miplevel,
-                 std::shared_ptr<ImageCache> imagecache = { },
+                 std::shared_ptr<ImageCache> imagecache = {},
                  const ImageSpec* spec                  = nullptr,
-                 const image_span<std::byte>& bufspan   = { },
+                 const image_span<std::byte>& bufspan   = {},
                  bool readonly = false, const ImageSpec* config = nullptr,
                  Filesystem::IOProxy* ioproxy = nullptr);
     ImageBufImpl(string_view filename, int subimage, int miplevel,
@@ -136,7 +136,7 @@ public:
     // just copy the regular spec.
     void reset(string_view name, const ImageSpec& spec,
                const ImageSpec* nativespec          = nullptr,
-               const image_span<std::byte>& bufspan = { },
+               const image_span<std::byte>& bufspan = {},
                bool readonly                        = false);
     // alloc() resets the internal spec and nativespec, does some sanity
     // checks on the image sizes, and calls realloc.
@@ -151,10 +151,10 @@ public:
                      stride_t zstride = AutoStride)
     {
         auto formatsize = m_spec.format.size();
-        m_bufspan = image_span(reinterpret_cast<std::byte*>(data),
-                               m_spec.nchannels, m_spec.width, m_spec.height,
-                               m_spec.depth, formatsize, xstride, ystride,
-                               zstride, formatsize);
+        m_bufspan       = image_span(reinterpret_cast<std::byte*>(data),
+                                     m_spec.nchannels, m_spec.width, m_spec.height,
+                                     m_spec.depth, formatsize, xstride, ystride,
+                                     zstride, formatsize);
         eval_contiguous();
     }
 
@@ -167,18 +167,22 @@ public:
               DoLock do_lock                     = DoLock(true));
     void copy_metadata(const ImageBufImpl& src);
     void merge_metadata(const ImageBufImpl& src, bool override = false,
-                        string_view pattern = { });
+                        string_view pattern = {});
 
     // Note: Uses std::format syntax
     template<typename... Args>
     void error(const char* fmt, const Args&... args) const
-    { error(Strutil::fmt::format(fmt, args...)); }
+    {
+        error(Strutil::fmt::format(fmt, args...));
+    }
 
     // Another alias for error so we don't get mixed up with the global
     // OIIO::errorfmt.
     template<typename... Args>
     void errorfmt(const char* fmt, const Args&... args) const
-    { error(Strutil::fmt::format(fmt, args...)); }
+    {
+        error(Strutil::fmt::format(fmt, args...));
+    }
 
     void error(string_view message) const;
 
@@ -201,7 +205,9 @@ public:
         return m_spec.deep ? &m_deepdata : NULL;
     }
     bool initialized() const
-    { return m_spec_valid && m_storage != ImageBuf::UNINITIALIZED; }
+    {
+        return m_spec_valid && m_storage != ImageBuf::UNINITIALIZED;
+    }
     bool cachedpixels() const { return m_storage == ImageBuf::IMAGECACHE; }
     void* localpixels() const { return m_bufspan.data(); }
 
@@ -314,9 +320,9 @@ public:
 
     void eval_contiguous()
     {
-        bool in_memory        = m_bufspan.data() != nullptr
-                                && (m_storage == ImageBuf::LOCALBUFFER
-                                    || m_storage == ImageBuf::APPBUFFER);
+        bool in_memory = m_bufspan.data() != nullptr
+                         && (m_storage == ImageBuf::LOCALBUFFER
+                             || m_storage == ImageBuf::APPBUFFER);
         m_contiguous          = in_memory && m_bufspan.is_contiguous();
         m_contiguous_scanline = in_memory && m_bufspan.is_contiguous_scanline();
     }
@@ -396,7 +402,9 @@ private:
 
 void
 ImageBuf::impl_deleter(ImageBufImpl* todel)
-{ delete todel; }
+{
+    delete todel;
+}
 
 
 
@@ -537,7 +545,7 @@ ImageBufImpl::ImageBufImpl(const ImageBufImpl& src)
     } else {
         // Source was cache-based or deep
         // nothing else to do
-        m_bufspan = { };
+        m_bufspan = {};
     }
     if (localpixels() || m_spec.deep) {
         // A copied ImageBuf is no longer a direct file reference, so clear
@@ -596,7 +604,7 @@ ImageBuf::ImageBuf(string_view filename, int subimage, int miplevel,
                    const ImageSpec* config, Filesystem::IOProxy* ioproxy)
     : m_impl(new ImageBufImpl(filename, subimage, miplevel,
                               std::move(imagecache), nullptr /*spec*/,
-                              { } /*bufspan*/, nullptr /*buforigin*/, true,
+                              {} /*bufspan*/, nullptr /*buforigin*/, true,
                               config, ioproxy),
              &impl_deleter)
 {
@@ -618,7 +626,7 @@ ImageBuf::ImageBuf(const ImageSpec& spec, InitializePixels zero)
 ImageBuf::ImageBuf(const ImageSpec& spec, void* buffer, stride_t xstride,
                    stride_t ystride, stride_t zstride)
     : m_impl(new ImageBufImpl("", 0, 0, nullptr /*imagecache*/, &spec,
-                              { } /*bufspan*/, buffer /*buforigin*/,
+                              {} /*bufspan*/, buffer /*buforigin*/,
                               false /*readonly*/, nullptr /*config*/,
                               nullptr /*ioproxy*/, xstride, ystride, zstride),
              &impl_deleter)
@@ -689,7 +697,7 @@ ImageBuf::ImageBuf(ImageBuf&& src)
 
 
 
-ImageBuf::~ImageBuf() { }
+ImageBuf::~ImageBuf() {}
 
 
 
@@ -738,7 +746,7 @@ ImageBufImpl::new_pixels(ImageBuf::IBStorage storage, size_t size,
             error("ImageBuf unable to allocate {} bytes ({})\n", size,
                   e.what());
             size      = 0;
-            m_bufspan = { };
+            m_bufspan = {};
         }
         m_allocated_size = size;
         OIIO::pvt::IB_local_mem_current += m_allocated_size;
@@ -769,7 +777,7 @@ ImageBufImpl::free_pixels()
     }
     m_pixels.reset();
     // print("IB Freed pixels of length {}\n", m_bufspan.size());
-    m_bufspan             = { };
+    m_bufspan             = {};
     m_contiguous          = false;
     m_contiguous_scanline = false;
     m_deepdata.free();
@@ -824,13 +832,17 @@ ImageBufImpl::error(string_view message) const
 
 void
 ImageBuf::error(string_view message) const
-{ m_impl->error(message); }
+{
+    m_impl->error(message);
+}
 
 
 
 ImageBuf::IBStorage
 ImageBuf::storage() const
-{ return m_impl->storage(); }
+{
+    return m_impl->storage();
+}
 
 
 
@@ -854,7 +866,7 @@ ImageBufImpl::clear()
     m_spec             = ImageSpec();
     m_nativespec       = ImageSpec();
     m_pixels.reset();
-    m_bufspan             = { };
+    m_bufspan             = {};
     m_spec_valid          = false;
     m_pixels_valid        = false;
     m_badfile             = false;
@@ -879,7 +891,9 @@ ImageBufImpl::clear()
 
 void
 ImageBuf::clear()
-{ m_impl->clear(); }
+{
+    m_impl->clear();
+}
 
 
 
@@ -905,7 +919,7 @@ ImageBufImpl::reset(string_view filename, int subimage, int miplevel,
         add_configspec();
         m_configspec->attribute("oiio:ioproxy", TypeDesc::PTR, &m_rioproxy);
     }
-    m_bufspan = { };
+    m_bufspan = {};
     m_storage = ImageBuf::LOCALBUFFER;
     if (m_name.length() > 0) {
         // For IC-backed file ImageBuf's, call read now. For other file-based
@@ -1002,7 +1016,9 @@ ImageBuf::reset(const ImageSpec& spec,
 
 void
 ImageBuf::reset(const ImageSpec& spec, const image_span<std::byte>& buffer)
-{ m_impl->reset("", spec, nullptr, buffer, false /*readonly*/); }
+{
+    m_impl->reset("", spec, nullptr, buffer, false /*readonly*/);
+}
 
 
 
@@ -1536,7 +1552,9 @@ ImageBuf::set_write_format(cspan<TypeDesc> format)
 
 void
 ImageBuf::set_write_format(TypeDesc format)
-{ set_write_format(cspan<TypeDesc>(format)); }
+{
+    set_write_format(cspan<TypeDesc>(format));
+}
 
 
 
@@ -1552,7 +1570,9 @@ ImageBuf::set_write_tiles(int width, int height, int depth)
 
 void
 ImageBuf::set_write_ioproxy(Filesystem::IOProxy* ioproxy)
-{ m_impl->m_wioproxy = ioproxy; }
+{
+    m_impl->m_wioproxy = ioproxy;
+}
 
 
 
@@ -1640,9 +1660,9 @@ ImageBuf::write(ImageOutput* out, ProgressCallback progress_callback,
                                        && outspec.get_string_attribute(
                                               "openexr:lineOrder")
                                               == "decreasingY";
-            const int numChunks      = outspec.height > 0
-                                           ? 1 + ((outspec.height - 1) / chunk)
-                                           : 0;
+            const int numChunks  = outspec.height > 0
+                                       ? 1 + ((outspec.height - 1) / chunk)
+                                       : 0;
             const int yLoopStart = isDecreasingY ? (numChunks - 1) * chunk : 0;
             const int yDelta     = isDecreasingY ? -chunk : chunk;
             const int yLoopEnd   = yLoopStart + numChunks * yDelta;
@@ -1845,7 +1865,9 @@ ImageBufImpl::copy_metadata(const ImageBufImpl& src)
 
 void
 ImageBuf::copy_metadata(const ImageBuf& src)
-{ m_impl->copy_metadata(*src.m_impl); }
+{
+    m_impl->copy_metadata(*src.m_impl);
+}
 
 
 
@@ -1892,25 +1914,33 @@ ImageBufImpl::merge_metadata(const ImageBufImpl& src, bool override,
 void
 ImageBuf::merge_metadata(const ImageBuf& src, bool override,
                          string_view pattern)
-{ m_impl->merge_metadata(*src.m_impl, override, pattern); }
+{
+    m_impl->merge_metadata(*src.m_impl, override, pattern);
+}
 
 
 
 const ImageSpec&
 ImageBuf::spec() const
-{ return m_impl->spec(); }
+{
+    return m_impl->spec();
+}
 
 
 
 ImageSpec&
 ImageBuf::specmod()
-{ return m_impl->specmod(); }
+{
+    return m_impl->specmod();
+}
 
 
 
 const ImageSpec&
 ImageBuf::nativespec() const
-{ return m_impl->nativespec(); }
+{
+    return m_impl->nativespec();
+}
 
 
 
@@ -1968,42 +1998,56 @@ ImageBufImpl::get_thumbnail(DoLock do_lock) const
 
 bool
 ImageBuf::has_thumbnail() const
-{ return m_impl->has_thumbnail(); }
+{
+    return m_impl->has_thumbnail();
+}
 
 
 
 void
 ImageBuf::set_thumbnail(const ImageBuf& thumb)
-{ m_impl->set_thumbnail(thumb); }
+{
+    m_impl->set_thumbnail(thumb);
+}
 
 
 
 void
 ImageBuf::clear_thumbnail()
-{ m_impl->clear_thumbnail(); }
+{
+    m_impl->clear_thumbnail();
+}
 
 
 
 std::shared_ptr<ImageBuf>
 ImageBuf::get_thumbnail() const
-{ return m_impl->get_thumbnail(); }
+{
+    return m_impl->get_thumbnail();
+}
 
 
 
 string_view
 ImageBuf::name(void) const
-{ return m_impl->m_name; }
+{
+    return m_impl->m_name;
+}
 
 
 ustring
 ImageBuf::uname(void) const
-{ return m_impl->m_name; }
+{
+    return m_impl->m_name;
+}
 
 
 
 void
 ImageBuf::set_name(string_view name)
-{ m_impl->m_name = name; }
+{
+    m_impl->m_name = name;
+}
 
 
 
@@ -2017,7 +2061,9 @@ ImageBuf::file_format_name(void) const
 
 int
 ImageBuf::subimage() const
-{ return m_impl->m_current_subimage; }
+{
+    return m_impl->m_current_subimage;
+}
 
 
 int
@@ -2030,7 +2076,9 @@ ImageBuf::nsubimages() const
 
 int
 ImageBuf::miplevel() const
-{ return m_impl->m_current_miplevel; }
+{
+    return m_impl->m_current_miplevel;
+}
 
 
 int
@@ -2043,7 +2091,9 @@ ImageBuf::nmiplevels() const
 
 int
 ImageBuf::nchannels() const
-{ return m_impl->spec().nchannels; }
+{
+    return m_impl->spec().nchannels;
+}
 
 
 
@@ -2058,25 +2108,33 @@ ImageBuf::orientation() const
 
 void
 ImageBuf::set_orientation(int orient)
-{ m_impl->specmod().attribute("Orientation", orient); }
+{
+    m_impl->specmod().attribute("Orientation", orient);
+}
 
 
 
 bool
 ImageBuf::pixels_valid(void) const
-{ return m_impl->m_pixels_valid; }
+{
+    return m_impl->m_pixels_valid;
+}
 
 
 
 bool
 ImageBuf::pixels_read(void) const
-{ return m_impl->m_pixels_read; }
+{
+    return m_impl->m_pixels_read;
+}
 
 
 
 TypeDesc
 ImageBuf::pixeltype() const
-{ return m_impl->pixeltype(); }
+{
+    return m_impl->pixeltype();
+}
 
 
 
@@ -2091,13 +2149,17 @@ ImageBuf::localpixels()
 
 image_span<const std::byte>
 ImageBuf::localpixels_as_byte_image_span() const
-{ return m_impl->m_bufspan; }
+{
+    return m_impl->m_bufspan;
+}
 
 
 
 image_span<std::byte>
 ImageBuf::localpixels_as_writable_byte_image_span()
-{ return m_impl->m_readonly ? image_span<std::byte>() : m_impl->m_bufspan; }
+{
+    return m_impl->m_readonly ? image_span<std::byte>() : m_impl->m_bufspan;
+}
 
 
 
@@ -2112,19 +2174,25 @@ ImageBuf::localpixels() const
 
 stride_t
 ImageBuf::pixel_stride() const
-{ return m_impl->m_bufspan.xstride(); }
+{
+    return m_impl->m_bufspan.xstride();
+}
 
 
 
 stride_t
 ImageBuf::scanline_stride() const
-{ return m_impl->m_bufspan.ystride(); }
+{
+    return m_impl->m_bufspan.ystride();
+}
 
 
 
 stride_t
 ImageBuf::z_stride() const
-{ return m_impl->m_bufspan.zstride(); }
+{
+    return m_impl->m_bufspan.zstride();
+}
 
 
 
@@ -2148,46 +2216,62 @@ ImageBuf::contiguous_scanline() const
 
 bool
 ImageBuf::cachedpixels() const
-{ return m_impl->cachedpixels(); }
+{
+    return m_impl->cachedpixels();
+}
 
 
 
 std::shared_ptr<ImageCache>
 ImageBuf::imagecache() const
-{ return m_impl->m_imagecache; }
+{
+    return m_impl->m_imagecache;
+}
 
 
 
 bool
 ImageBuf::deep() const
-{ return spec().deep; }
+{
+    return spec().deep;
+}
 
 
 DeepData*
 ImageBuf::deepdata()
-{ return m_impl->deepdata(); }
+{
+    return m_impl->deepdata();
+}
 
 
 const DeepData*
 ImageBuf::deepdata() const
-{ return m_impl->deepdata(); }
+{
+    return m_impl->deepdata();
+}
 
 
 bool
 ImageBuf::initialized() const
-{ return m_impl->initialized(); }
+{
+    return m_impl->initialized();
+}
 
 
 
 void
 ImageBuf::threads(int n) const
-{ m_impl->threads(n); }
+{
+    m_impl->threads(n);
+}
 
 
 
 int
 ImageBuf::threads() const
-{ return m_impl->threads(); }
+{
+    return m_impl->threads();
+}
 
 
 
@@ -2427,7 +2511,9 @@ interppixel_wrapper(float x, float y, span<float> pixel,
 
 void
 ImageBuf::interppixel(float x, float y, span<float> pixel, WrapMode wrap) const
-{ interppixel_wrapper(x, y, pixel, wrap, *this); }
+{
+    interppixel_wrapper(x, y, pixel, wrap, *this);
+}
 
 
 
@@ -2493,7 +2579,9 @@ interppixel_bicubic_wrapper(float x, float y, span<float> pixel,
 void
 ImageBuf::interppixel_bicubic(float x, float y, span<float> pixel,
                               WrapMode wrap) const
-{ interppixel_bicubic_wrapper(x, y, pixel, wrap, *this); }
+{
+    interppixel_bicubic_wrapper(x, y, pixel, wrap, *this);
+}
 
 
 
@@ -2573,7 +2661,7 @@ get_pixels_(const ImageBuf& buf, const ImageBuf& /*dummy*/, ROI whole_roi,
                 imagesize_t offset = (p.z() - whole_roi.zbegin) * zstride
                                      + (p.y() - whole_roi.ybegin) * ystride
                                      + (p.x() - whole_roi.xbegin) * xstride;
-                D* rc              = (D*)((char*)r + offset);
+                D* rc = (D*)((char*)r + offset);
                 for (int c = 0; c < nchans; ++c)
                     rc[c] = p[c + roi.chbegin];
             }
@@ -2667,7 +2755,7 @@ set_pixels_(ImageBuf& buf, ROI roi, const void* data_, stride_t xstride,
         imagesize_t offset = (p.z() - roi.zbegin) * zstride
                              + (p.y() - roi.ybegin) * ystride
                              + (p.x() - roi.xbegin) * xstride;
-        const S* src       = (const S*)((const char*)data + offset);
+        const S* src = (const S*)((const char*)data + offset);
         for (int c = 0; c < nchans; ++c)
             p[c + roi.chbegin] = src[c];
     }
@@ -2884,7 +2972,9 @@ ImageBuf::copy_deep_pixel(int x, int y, int z, const ImageBuf& src, int srcx,
 
 int
 ImageBuf::xbegin() const
-{ return spec().x; }
+{
+    return spec().x;
+}
 
 
 
@@ -2899,7 +2989,9 @@ ImageBuf::xend() const
 
 int
 ImageBuf::ybegin() const
-{ return spec().y; }
+{
+    return spec().y;
+}
 
 
 
@@ -2914,7 +3006,9 @@ ImageBuf::yend() const
 
 int
 ImageBuf::zbegin() const
-{ return spec().z; }
+{
+    return spec().z;
+}
 
 
 
@@ -2929,7 +3023,9 @@ ImageBuf::zend() const
 
 int
 ImageBuf::xmin() const
-{ return spec().x; }
+{
+    return spec().x;
+}
 
 
 
@@ -2944,7 +3040,9 @@ ImageBuf::xmax() const
 
 int
 ImageBuf::ymin() const
-{ return spec().y; }
+{
+    return spec().y;
+}
 
 
 
@@ -2959,7 +3057,9 @@ ImageBuf::ymax() const
 
 int
 ImageBuf::zmin() const
-{ return spec().z; }
+{
+    return spec().z;
+}
 
 
 
@@ -3071,17 +3171,23 @@ ImageBuf::set_full(int xbegin, int xend, int ybegin, int yend, int zbegin,
 
 ROI
 ImageBuf::roi() const
-{ return get_roi(spec()); }
+{
+    return get_roi(spec());
+}
 
 
 ROI
 ImageBuf::roi_full() const
-{ return get_roi_full(spec()); }
+{
+    return get_roi_full(spec());
+}
 
 
 void
 ImageBuf::set_roi_full(const ROI& newroi)
-{ OIIO::set_roi_full(specmod(), newroi); }
+{
+    OIIO::set_roi_full(specmod(), newroi);
+}
 
 
 
@@ -3122,25 +3228,33 @@ ImageBufImpl::pixeladdr(int x, int y, int z, int ch)
 
 const void*
 ImageBuf::pixeladdr(int x, int y, int z, int ch) const
-{ return m_impl->pixeladdr(x, y, z, ch); }
+{
+    return m_impl->pixeladdr(x, y, z, ch);
+}
 
 
 
 void*
 ImageBuf::pixeladdr(int x, int y, int z, int ch)
-{ return m_impl->pixeladdr(x, y, z, ch); }
+{
+    return m_impl->pixeladdr(x, y, z, ch);
+}
 
 
 
 int
 ImageBuf::pixelindex(int x, int y, int z, bool check_range) const
-{ return m_impl->pixelindex(x, y, z, check_range); }
+{
+    return m_impl->pixelindex(x, y, z, check_range);
+}
 
 
 
 const void*
 ImageBuf::blackpixel() const
-{ return m_impl->blackpixel(); }
+{
+    return m_impl->blackpixel();
+}
 
 
 
@@ -3188,7 +3302,9 @@ ImageBufImpl::do_wrap(int& x, int& y, int& z, ImageBuf::WrapMode wrap) const
 
 bool
 ImageBuf::do_wrap(int& x, int& y, int& z, WrapMode wrap) const
-{ return m_impl->do_wrap(x, y, z, wrap); }
+{
+    return m_impl->do_wrap(x, y, z, wrap);
+}
 
 
 
@@ -3567,12 +3683,16 @@ ImageBuf::IteratorBase::rerange(int xbegin, int xend, int ybegin, int yend,
 
 void
 ImageBuf::lock() const
-{ m_impl->lock(); }
+{
+    m_impl->lock();
+}
 
 
 void
 ImageBuf::unlock() const
-{ m_impl->unlock(); }
+{
+    m_impl->unlock();
+}
 
 
 OIIO_NAMESPACE_3_1_END

--- a/src/libOpenImageIO/imagebufalgo_test.cpp
+++ b/src/libOpenImageIO/imagebufalgo_test.cpp
@@ -1743,7 +1743,7 @@ test_demosaic()
 
     if (write_files) {
         auto imageOutput = OIIO::ImageOutput::create("exr");
-        bool ok = imageOutput->open("source.exr", src_image.spec());
+        bool ok          = imageOutput->open("source.exr", src_image.spec());
         OIIO_ASSERT(ok);
         src_image.write(imageOutput.get());
     }

--- a/src/libOpenImageIO/imagebufalgo_test.cpp
+++ b/src/libOpenImageIO/imagebufalgo_test.cpp
@@ -129,9 +129,7 @@ filled_image(cspan<float> value, int width = 4, int height = 4,
 // the value array).
 inline ImageBuf
 filled_image(cspan<float> value, TypeDesc dtype)
-{
-    return filled_image(value, 4, 4, dtype);
-}
+{ return filled_image(value, 4, 4, dtype); }
 
 
 
@@ -1255,9 +1253,9 @@ test_opencv()
         std::cout << loaded_image.geterror() << 'n';
         return;
     }
-    auto cv_image = cv::Mat {};
+    auto cv_image = cv::Mat { };
     try {
-        bool ok = OIIO::ImageBufAlgo::to_OpenCV(cv_image, loaded_image, {}, 1);
+        bool ok = OIIO::ImageBufAlgo::to_OpenCV(cv_image, loaded_image, { }, 1);
         OIIO_CHECK_ASSERT(ok);
         if (!ok) {
             std::cout << "Error when converting: " << OIIO::geterror() << '\n';
@@ -1406,7 +1404,7 @@ chan_reverse(span<float> d, cspan<float> s)
 // Functor to reverse channels
 class ChannelReverser {
 public:
-    ChannelReverser() {}
+    ChannelReverser() { }
     bool operator()(span<float> d, cspan<float> s)
     {
         for (size_t c = 0, nc = size_t(d.size()); c < nc; ++c)
@@ -1448,7 +1446,7 @@ test_simple_perpixel()
         // Test with lambda, including variable capture
         float bias = 0.0;  // Force capture of this variable
         result     = ImageBufAlgo::perpixel_op(src, [&](span<float> d,
-                                                    cspan<float> s) {
+                                                        cspan<float> s) {
             for (size_t c = 0, nc = size_t(d.size()); c < nc; ++c)
                 d[c] = s[nc - 1 - c] + bias;
             return true;

--- a/src/libOpenImageIO/imagebufalgo_test.cpp
+++ b/src/libOpenImageIO/imagebufalgo_test.cpp
@@ -1613,7 +1613,7 @@ test_demosaic_algo(const ImageBuf& src_image, const ImageBuf& mosaiced_image,
         std::string ext  = type.is_floating_point() ? "exr" : "png";
         std::string path = file_name + "_" + test_name + "." + ext;
         auto imageOutput = ImageOutput::create(ext);
-        imageOutput->open(path, demosaiced_image.spec());
+        (void)imageOutput->open(path, demosaiced_image.spec());
         demosaiced_image.write(imageOutput.get());
     }
 }
@@ -1650,7 +1650,7 @@ test_demosaic(const DemosaicTestConfig& config, const ImageBuf& src_image,
                 std::string path = file_name + "_src." + ext;
 
                 auto imageOutput = ImageOutput::create(ext);
-                imageOutput->open(path, mosaiced_image.spec());
+                (void)imageOutput->open(path, mosaiced_image.spec());
                 mosaiced_image.write(imageOutput.get());
             }
 
@@ -1741,7 +1741,7 @@ test_demosaic()
 
     if (write_files) {
         auto imageOutput = OIIO::ImageOutput::create("exr");
-        imageOutput->open("source.exr", src_image.spec());
+        (void)imageOutput->open("source.exr", src_image.spec());
         src_image.write(imageOutput.get());
     }
 

--- a/src/libOpenImageIO/imagebufalgo_test.cpp
+++ b/src/libOpenImageIO/imagebufalgo_test.cpp
@@ -129,7 +129,9 @@ filled_image(cspan<float> value, int width = 4, int height = 4,
 // the value array).
 inline ImageBuf
 filled_image(cspan<float> value, TypeDesc dtype)
-{ return filled_image(value, 4, 4, dtype); }
+{
+    return filled_image(value, 4, 4, dtype);
+}
 
 
 
@@ -1253,9 +1255,9 @@ test_opencv()
         std::cout << loaded_image.geterror() << 'n';
         return;
     }
-    auto cv_image = cv::Mat { };
+    auto cv_image = cv::Mat {};
     try {
-        bool ok = OIIO::ImageBufAlgo::to_OpenCV(cv_image, loaded_image, { }, 1);
+        bool ok = OIIO::ImageBufAlgo::to_OpenCV(cv_image, loaded_image, {}, 1);
         OIIO_CHECK_ASSERT(ok);
         if (!ok) {
             std::cout << "Error when converting: " << OIIO::geterror() << '\n';
@@ -1404,7 +1406,7 @@ chan_reverse(span<float> d, cspan<float> s)
 // Functor to reverse channels
 class ChannelReverser {
 public:
-    ChannelReverser() { }
+    ChannelReverser() {}
     bool operator()(span<float> d, cspan<float> s)
     {
         for (size_t c = 0, nc = size_t(d.size()); c < nc; ++c)
@@ -1446,7 +1448,7 @@ test_simple_perpixel()
         // Test with lambda, including variable capture
         float bias = 0.0;  // Force capture of this variable
         result     = ImageBufAlgo::perpixel_op(src, [&](span<float> d,
-                                                        cspan<float> s) {
+                                                    cspan<float> s) {
             for (size_t c = 0, nc = size_t(d.size()); c < nc; ++c)
                 d[c] = s[nc - 1 - c] + bias;
             return true;

--- a/src/libOpenImageIO/imagebufalgo_test.cpp
+++ b/src/libOpenImageIO/imagebufalgo_test.cpp
@@ -1743,7 +1743,8 @@ test_demosaic()
 
     if (write_files) {
         auto imageOutput = OIIO::ImageOutput::create("exr");
-        (void)imageOutput->open("source.exr", src_image.spec());
+        bool ok = imageOutput->open("source.exr", src_image.spec());
+        OIIO_ASSERT(ok);
         src_image.write(imageOutput.get());
     }
 

--- a/src/libOpenImageIO/imagebufalgo_test.cpp
+++ b/src/libOpenImageIO/imagebufalgo_test.cpp
@@ -1613,7 +1613,8 @@ test_demosaic_algo(const ImageBuf& src_image, const ImageBuf& mosaiced_image,
         std::string ext  = type.is_floating_point() ? "exr" : "png";
         std::string path = file_name + "_" + test_name + "." + ext;
         auto imageOutput = ImageOutput::create(ext);
-        (void)imageOutput->open(path, demosaiced_image.spec());
+        bool ok          = imageOutput->open(path, demosaiced_image.spec());
+        OIIO_ASSERT(ok);
         demosaiced_image.write(imageOutput.get());
     }
 }
@@ -1650,7 +1651,8 @@ test_demosaic(const DemosaicTestConfig& config, const ImageBuf& src_image,
                 std::string path = file_name + "_src." + ext;
 
                 auto imageOutput = ImageOutput::create(ext);
-                (void)imageOutput->open(path, mosaiced_image.spec());
+                bool ok = imageOutput->open(path, mosaiced_image.spec());
+                OIIO_ASSERT(ok);
                 mosaiced_image.write(imageOutput.get());
             }
 

--- a/src/libOpenImageIO/imagespeed_test.cpp
+++ b/src/libOpenImageIO/imagespeed_test.cpp
@@ -204,10 +204,11 @@ time_write_scanline_at_a_time()
     size_t pixelsize         = outspec.nchannels * sizeof(float);
     imagesize_t scanlinesize = outspec.width * pixelsize;
     bool ok                  = true;
-    for (int y = 0; y < outspec.height; ++y) {
+    for (int y = 0; y < outspec.height && ok; ++y) {
         ok = out->write_scanline(y + outspec.y, outspec.z, bufspec.format,
                                  &buffer[scanlinesize * y]);
     }
+    OIIO_ASSERT(ok);
 }
 
 
@@ -219,16 +220,17 @@ time_write_64_scanlines_at_a_time()
     OIIO_ASSERT(out);
     bool ok = out->open(output_filename, outspec);
     OIIO_ASSERT(ok);
-
+    bool ok                  = true;
     size_t pixelsize         = outspec.nchannels * sizeof(float);
     imagesize_t scanlinesize = outspec.width * pixelsize;
-    for (int y = 0; y < outspec.height; y += 64) {
-        (void)out->write_scanlines(y + outspec.y,
-                                   std::min(y + outspec.y + 64,
-                                            outspec.y + outspec.height),
-                                   outspec.z, bufspec.format,
-                                   &buffer[scanlinesize * y]);
+    for (int y = 0; y < outspec.height && ok; y += 64) {
+        ok = out->write_scanlines(y + outspec.y,
+                                  std::min(y + outspec.y + 64,
+                                           outspec.y + outspec.height),
+                                  outspec.z, bufspec.format,
+                                  &buffer[scanlinesize * y]);
     }
+    OIIO_ASSERT(ok);
 }
 
 
@@ -245,9 +247,9 @@ time_write_tile_at_a_time()
     imagesize_t scanlinesize = outspec.width * pixelsize;
     imagesize_t planesize    = outspec.height * scanlinesize;
     bool ok                  = true;
-    for (int z = 0; z < outspec.depth; z += outspec.tile_depth) {
-        for (int y = 0; y < outspec.height; y += outspec.tile_height) {
-            for (int x = 0; x < outspec.width; x += outspec.tile_width) {
+    for (int z = 0; z < outspec.depth && ok; z += outspec.tile_depth) {
+        for (int y = 0; y < outspec.height && ok; y += outspec.tile_height) {
+            for (int x = 0; x < outspec.width && ok; x += outspec.tile_width) {
                 ok = out->write_tile(x + outspec.x, y + outspec.y,
                                      z + outspec.z, bufspec.format,
                                      &buffer[scanlinesize * y + pixelsize * x],
@@ -255,6 +257,7 @@ time_write_tile_at_a_time()
             }
         }
     }
+    OIIO_ASSERT(ok);
 }
 
 
@@ -270,8 +273,8 @@ time_write_tiles_row_at_a_time()
     size_t pixelsize         = outspec.nchannels * sizeof(float);
     imagesize_t scanlinesize = outspec.width * pixelsize;
     bool ok                  = true;
-    for (int z = 0; z < outspec.depth; z += outspec.tile_depth) {
-        for (int y = 0; y < outspec.height; y += outspec.tile_height) {
+    for (int z = 0; z < outspec.depth && ok; z += outspec.tile_depth) {
+        for (int y = 0; y < outspec.height && ok; y += outspec.tile_height) {
             ok = out->write_tiles(outspec.x, outspec.x + outspec.width,
                                   y + outspec.y,
                                   y + outspec.y + outspec.tile_height,
@@ -282,6 +285,7 @@ time_write_tiles_row_at_a_time()
                                   scanlinesize /*ystride*/);
         }
     }
+    OIIO_ASSERT(ok);
 }
 
 

--- a/src/libOpenImageIO/imagespeed_test.cpp
+++ b/src/libOpenImageIO/imagespeed_test.cpp
@@ -187,7 +187,7 @@ time_write_image()
     OIIO_ASSERT(out);
     bool ok = out->open(output_filename, outspec);
     OIIO_ASSERT(ok);
-    out->write_image(bufspec.format, &buffer[0]);
+    (void)out->write_image(bufspec.format, &buffer[0]);
 }
 
 
@@ -203,7 +203,7 @@ time_write_scanline_at_a_time()
     size_t pixelsize         = outspec.nchannels * sizeof(float);
     imagesize_t scanlinesize = outspec.width * pixelsize;
     for (int y = 0; y < outspec.height; ++y) {
-        out->write_scanline(y + outspec.y, outspec.z, bufspec.format,
+        (void)out->write_scanline(y + outspec.y, outspec.z, bufspec.format,
                             &buffer[scanlinesize * y]);
     }
 }
@@ -221,7 +221,7 @@ time_write_64_scanlines_at_a_time()
     size_t pixelsize         = outspec.nchannels * sizeof(float);
     imagesize_t scanlinesize = outspec.width * pixelsize;
     for (int y = 0; y < outspec.height; y += 64) {
-        out->write_scanlines(y + outspec.y,
+        (void)out->write_scanlines(y + outspec.y,
                              std::min(y + outspec.y + 64,
                                       outspec.y + outspec.height),
                              outspec.z, bufspec.format,
@@ -245,10 +245,10 @@ time_write_tile_at_a_time()
     for (int z = 0; z < outspec.depth; z += outspec.tile_depth) {
         for (int y = 0; y < outspec.height; y += outspec.tile_height) {
             for (int x = 0; x < outspec.width; x += outspec.tile_width) {
-                out->write_tile(x + outspec.x, y + outspec.y, z + outspec.z,
-                                bufspec.format,
-                                &buffer[scanlinesize * y + pixelsize * x],
-                                pixelsize, scanlinesize, planesize);
+                (void)out->write_tile(x + outspec.x, y + outspec.y, z + outspec.z,
+                                       bufspec.format,
+                                       &buffer[scanlinesize * y + pixelsize * x],
+                                       pixelsize, scanlinesize, planesize);
             }
         }
     }
@@ -268,11 +268,11 @@ time_write_tiles_row_at_a_time()
     imagesize_t scanlinesize = outspec.width * pixelsize;
     for (int z = 0; z < outspec.depth; z += outspec.tile_depth) {
         for (int y = 0; y < outspec.height; y += outspec.tile_height) {
-            out->write_tiles(outspec.x, outspec.x + outspec.width,
-                             y + outspec.y, y + outspec.y + outspec.tile_height,
-                             z + outspec.z, z + outspec.z + outspec.tile_depth,
-                             bufspec.format, &buffer[scanlinesize * y],
-                             pixelsize /*xstride*/, scanlinesize /*ystride*/);
+            (void)out->write_tiles(outspec.x, outspec.x + outspec.width,
+                                   y + outspec.y, y + outspec.y + outspec.tile_height,
+                                   z + outspec.z, z + outspec.z + outspec.tile_depth,
+                                   bufspec.format, &buffer[scanlinesize * y],
+                                   pixelsize /*xstride*/, scanlinesize /*ystride*/);
         }
     }
 }

--- a/src/libOpenImageIO/imagespeed_test.cpp
+++ b/src/libOpenImageIO/imagespeed_test.cpp
@@ -187,7 +187,8 @@ time_write_image()
     OIIO_ASSERT(out);
     bool ok = out->open(output_filename, outspec);
     OIIO_ASSERT(ok);
-    (void)out->write_image(bufspec.format, &buffer[0]);
+    ok = out->write_image(bufspec.format, &buffer[0]);
+    OIIO_CONTRACT_ASSERT(ok);
 }
 
 
@@ -202,9 +203,10 @@ time_write_scanline_at_a_time()
 
     size_t pixelsize         = outspec.nchannels * sizeof(float);
     imagesize_t scanlinesize = outspec.width * pixelsize;
+    bool ok                  = true;
     for (int y = 0; y < outspec.height; ++y) {
-        (void)out->write_scanline(y + outspec.y, outspec.z, bufspec.format,
-                            &buffer[scanlinesize * y]);
+        ok = out->write_scanline(y + outspec.y, outspec.z, bufspec.format,
+                                 &buffer[scanlinesize * y]);
     }
 }
 
@@ -222,10 +224,10 @@ time_write_64_scanlines_at_a_time()
     imagesize_t scanlinesize = outspec.width * pixelsize;
     for (int y = 0; y < outspec.height; y += 64) {
         (void)out->write_scanlines(y + outspec.y,
-                             std::min(y + outspec.y + 64,
-                                      outspec.y + outspec.height),
-                             outspec.z, bufspec.format,
-                             &buffer[scanlinesize * y]);
+                                   std::min(y + outspec.y + 64,
+                                            outspec.y + outspec.height),
+                                   outspec.z, bufspec.format,
+                                   &buffer[scanlinesize * y]);
     }
 }
 
@@ -242,13 +244,14 @@ time_write_tile_at_a_time()
     size_t pixelsize         = outspec.nchannels * sizeof(float);
     imagesize_t scanlinesize = outspec.width * pixelsize;
     imagesize_t planesize    = outspec.height * scanlinesize;
+    bool ok                  = true;
     for (int z = 0; z < outspec.depth; z += outspec.tile_depth) {
         for (int y = 0; y < outspec.height; y += outspec.tile_height) {
             for (int x = 0; x < outspec.width; x += outspec.tile_width) {
-                (void)out->write_tile(x + outspec.x, y + outspec.y, z + outspec.z,
-                                       bufspec.format,
-                                       &buffer[scanlinesize * y + pixelsize * x],
-                                       pixelsize, scanlinesize, planesize);
+                ok = out->write_tile(x + outspec.x, y + outspec.y,
+                                     z + outspec.z, bufspec.format,
+                                     &buffer[scanlinesize * y + pixelsize * x],
+                                     pixelsize, scanlinesize, planesize);
             }
         }
     }
@@ -266,13 +269,17 @@ time_write_tiles_row_at_a_time()
 
     size_t pixelsize         = outspec.nchannels * sizeof(float);
     imagesize_t scanlinesize = outspec.width * pixelsize;
+    bool ok                  = true;
     for (int z = 0; z < outspec.depth; z += outspec.tile_depth) {
         for (int y = 0; y < outspec.height; y += outspec.tile_height) {
-            (void)out->write_tiles(outspec.x, outspec.x + outspec.width,
-                                   y + outspec.y, y + outspec.y + outspec.tile_height,
-                                   z + outspec.z, z + outspec.z + outspec.tile_depth,
-                                   bufspec.format, &buffer[scanlinesize * y],
-                                   pixelsize /*xstride*/, scanlinesize /*ystride*/);
+            ok = out->write_tiles(outspec.x, outspec.x + outspec.width,
+                                  y + outspec.y,
+                                  y + outspec.y + outspec.tile_height,
+                                  z + outspec.z,
+                                  z + outspec.z + outspec.tile_depth,
+                                  bufspec.format, &buffer[scanlinesize * y],
+                                  pixelsize /*xstride*/,
+                                  scanlinesize /*ystride*/);
         }
     }
 }

--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -792,7 +792,9 @@ write_mipmap(ImageBufAlgo::MakeTextureMode mode, std::shared_ptr<ImageBuf>& img,
         // ImageBuf::write transfers any errors from the ImageOutput to
         // the ImageBuf.
         errorfmt("Write failed: {}", img->geterror());
-        out->close();
+        if (!out->close()) {
+            errorfmt("Close failed: {}", out->geterror());
+        }
         return false;
     }
 
@@ -965,7 +967,9 @@ write_mipmap(ImageBufAlgo::MakeTextureMode mode, std::shared_ptr<ImageBuf>& img,
                 // ImageOutput to the ImageBuf.
                 errorfmt("Error writing \"{}\" : {}", outputfilename,
                          small->geterror());
-                out->close();
+                if (!out->close()) {
+                    errorfmt("Close failed: {}", out->geterror());
+                }
                 return false;
             }
             double wtime = writetimer();

--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -189,9 +189,9 @@ interppixel_NDC(const ImageBuf& buf, float x, float y, span<float> pixel,
         int ynext = OIIO::clamp(ytexel + 1, ymin, ymax);
         ytexel    = OIIO::clamp(ytexel, ymin, ymax);
         float w0  = (1.0f - yfrac)
-                    * sinf((float)M_PI * (ytexel + 0.5f) / (float)fh);
-        float w1  = yfrac * sinf((float)M_PI * (ynext + 0.5f) / (float)fh);
-        yfrac     = w1 / (w0 + w1);
+                   * sinf((float)M_PI * (ytexel + 0.5f) / (float)fh);
+        float w1 = yfrac * sinf((float)M_PI * (ynext + 0.5f) / (float)fh);
+        yfrac    = w1 / (w0 + w1);
     }
 
     // Bilinearly interpolate
@@ -658,7 +658,9 @@ fix_latl_edges(ImageBuf& buf)
 
 inline std::string
 formatres(const ImageSpec& spec)
-{ return Strutil::fmt::format("{}x{}", spec.width, spec.height); }
+{
+    return Strutil::fmt::format("{}x{}", spec.width, spec.height);
+}
 
 
 
@@ -1239,7 +1241,7 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
     int local_mb_thresh = configspec.get_int_attribute("maketx:read_local_MB",
                                                        1024);
     bool read_local     = (src->spec().image_bytes()
-                           < imagesize_t(local_mb_thresh * 1024 * 1024));
+                       < imagesize_t(local_mb_thresh * 1024 * 1024));
 
     bool verbose       = configspec.get_int_attribute("maketx:verbose") != 0;
     double misc_time_1 = alltime.lap();
@@ -1360,10 +1362,10 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
             // the Gaussian inverse CDF to transform the uniform distribution
             // to Gaussian.
             for (uint64_t j = 0; j < bins; j++) {
-                float u   = float(hist[j]) / hist[bins - 1];
-                float g   = 0.5f
-                            + cdf_sigma * M_SQRT2
-                                  * fast_ierf(c_sigma_inv * (2.0f * u - 1.0f));
+                float u = float(hist[j]) / hist[bins - 1];
+                float g = 0.5f
+                          + cdf_sigma * M_SQRT2
+                                * fast_ierf(c_sigma_inv * (2.0f * u - 1.0f));
                 invCDF[j] = std::min(1.0f, std::max(0.0f, g));
             }
             configspec.attribute("invCDF_" + std::to_string(i),
@@ -1927,8 +1929,8 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
     const int sha1_blocksize = 256;
     std::string hash_digest  = configspec.get_int_attribute("maketx:hash", 1)
                                    ? ImageBufAlgo::computePixelHashSHA1(
-                                         *toplevel, addlHashData.str(),
-                                         ROI::All(), sha1_blocksize, nthreads)
+                                      *toplevel, addlHashData.str(), ROI::All(),
+                                      sha1_blocksize, nthreads)
                                    : "";
     if (hash_digest.length()) {
         if (out->supports("arbitrary_metadata")) {

--- a/src/libOpenImageIO/maketexture.cpp
+++ b/src/libOpenImageIO/maketexture.cpp
@@ -189,9 +189,9 @@ interppixel_NDC(const ImageBuf& buf, float x, float y, span<float> pixel,
         int ynext = OIIO::clamp(ytexel + 1, ymin, ymax);
         ytexel    = OIIO::clamp(ytexel, ymin, ymax);
         float w0  = (1.0f - yfrac)
-                   * sinf((float)M_PI * (ytexel + 0.5f) / (float)fh);
-        float w1 = yfrac * sinf((float)M_PI * (ynext + 0.5f) / (float)fh);
-        yfrac    = w1 / (w0 + w1);
+                    * sinf((float)M_PI * (ytexel + 0.5f) / (float)fh);
+        float w1  = yfrac * sinf((float)M_PI * (ynext + 0.5f) / (float)fh);
+        yfrac     = w1 / (w0 + w1);
     }
 
     // Bilinearly interpolate
@@ -658,9 +658,7 @@ fix_latl_edges(ImageBuf& buf)
 
 inline std::string
 formatres(const ImageSpec& spec)
-{
-    return Strutil::fmt::format("{}x{}", spec.width, spec.height);
-}
+{ return Strutil::fmt::format("{}x{}", spec.width, spec.height); }
 
 
 
@@ -1241,7 +1239,7 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
     int local_mb_thresh = configspec.get_int_attribute("maketx:read_local_MB",
                                                        1024);
     bool read_local     = (src->spec().image_bytes()
-                       < imagesize_t(local_mb_thresh * 1024 * 1024));
+                           < imagesize_t(local_mb_thresh * 1024 * 1024));
 
     bool verbose       = configspec.get_int_attribute("maketx:verbose") != 0;
     double misc_time_1 = alltime.lap();
@@ -1362,10 +1360,10 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
             // the Gaussian inverse CDF to transform the uniform distribution
             // to Gaussian.
             for (uint64_t j = 0; j < bins; j++) {
-                float u = float(hist[j]) / hist[bins - 1];
-                float g = 0.5f
-                          + cdf_sigma * M_SQRT2
-                                * fast_ierf(c_sigma_inv * (2.0f * u - 1.0f));
+                float u   = float(hist[j]) / hist[bins - 1];
+                float g   = 0.5f
+                            + cdf_sigma * M_SQRT2
+                                  * fast_ierf(c_sigma_inv * (2.0f * u - 1.0f));
                 invCDF[j] = std::min(1.0f, std::max(0.0f, g));
             }
             configspec.attribute("invCDF_" + std::to_string(i),
@@ -1929,8 +1927,8 @@ make_texture_impl(ImageBufAlgo::MakeTextureMode mode, const ImageBuf* input,
     const int sha1_blocksize = 256;
     std::string hash_digest  = configspec.get_int_attribute("maketx:hash", 1)
                                    ? ImageBufAlgo::computePixelHashSHA1(
-                                      *toplevel, addlHashData.str(), ROI::All(),
-                                      sha1_blocksize, nthreads)
+                                         *toplevel, addlHashData.str(),
+                                         ROI::All(), sha1_blocksize, nthreads)
                                    : "";
     if (hash_digest.length()) {
         if (out->supports("arbitrary_metadata")) {

--- a/src/python/py_imagebuf.cpp
+++ b/src/python/py_imagebuf.cpp
@@ -154,7 +154,9 @@ ImageBuf_setpixel(ImageBuf& buf, int x, int y, int z, py::object p)
 
 void
 ImageBuf_setpixel2(ImageBuf& buf, int x, int y, py::object p)
-{ ImageBuf_setpixel(buf, x, y, 0, p); }
+{
+    ImageBuf_setpixel(buf, x, y, 0, p);
+}
 
 
 void
@@ -192,12 +194,16 @@ ImageBuf_get_pixels(const ImageBuf& buf, TypeDesc format, ROI roi = ROI::All())
 void
 ImageBuf_set_deep_value(ImageBuf& buf, int x, int y, int z, int c, int s,
                         float value)
-{ buf.set_deep_value(x, y, z, c, s, value); }
+{
+    buf.set_deep_value(x, y, z, c, s, value);
+}
 
 void
 ImageBuf_set_deep_value_uint(ImageBuf& buf, int x, int y, int z, int c, int s,
                              uint32_t value)
-{ buf.set_deep_value(x, y, z, c, s, value); }
+{
+    buf.set_deep_value(x, y, z, c, s, value);
+}
 
 
 

--- a/src/python/py_imagebuf.cpp
+++ b/src/python/py_imagebuf.cpp
@@ -273,7 +273,9 @@ ImageBuf_repr_png(const ImageBuf& self)
     if (!out || !out->open("temp.png", altered_spec))
         return py::bytes();
     self.write(out.get());
-    out->close();
+    if (!out->close()) {
+        return py::bytes();
+    }
 
     // Cast to const char* and return as python bytes
     const char* char_ptr = reinterpret_cast<const char*>(file_buffer.data());

--- a/src/python/py_imagebuf.cpp
+++ b/src/python/py_imagebuf.cpp
@@ -154,9 +154,7 @@ ImageBuf_setpixel(ImageBuf& buf, int x, int y, int z, py::object p)
 
 void
 ImageBuf_setpixel2(ImageBuf& buf, int x, int y, py::object p)
-{
-    ImageBuf_setpixel(buf, x, y, 0, p);
-}
+{ ImageBuf_setpixel(buf, x, y, 0, p); }
 
 
 void
@@ -194,16 +192,12 @@ ImageBuf_get_pixels(const ImageBuf& buf, TypeDesc format, ROI roi = ROI::All())
 void
 ImageBuf_set_deep_value(ImageBuf& buf, int x, int y, int z, int c, int s,
                         float value)
-{
-    buf.set_deep_value(x, y, z, c, s, value);
-}
+{ buf.set_deep_value(x, y, z, c, s, value); }
 
 void
 ImageBuf_set_deep_value_uint(ImageBuf& buf, int x, int y, int z, int c, int s,
                              uint32_t value)
-{
-    buf.set_deep_value(x, y, z, c, s, value);
-}
+{ buf.set_deep_value(x, y, z, c, s, value); }
 
 
 


### PR DESCRIPTION
### Description

- Annotate all ImageOutput write methods (write_image, write_scanline, write_scanlines, write_tile, write_tiles, write_rectangle, write_deep_scanlines, write_deep_tiles, write_deep_image), as well as open, close, and copy_image, with OIIO_NODISCARD_ERROR.
- Also fix the handful of internal callsites (imagebuf.cpp, maketexture.cpp, py_imagebuf.cpp, iconvert.cpp, imagebufalgo_test.cpp, and imagespeed_test.cpp) that were previously ignoring the return value of close(), either by propagating the error or by casting to void where the error path is already being handled.
- Assisted-by: Claude Sonnet 4.6
- Reference: #4781 

### Tests

- tested against unit_imageinout, unit_imagebuf, unit_imagebufalgo

### Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [X] **I have read the guidelines** on [contributions](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md) and [code review procedures](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/CodeReview.md).
- [X] **I have read the [Policy on AI Coding Assistants](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/AI_Policy.md)**
  and if I used AI coding assistants, I have an `Assisted-by: TOOL / MODEL`
  line in the pull request description above.
- [ ] **I have updated the documentation** if my PR adds features or changes
  behavior.
- [ ] **I am sure that this PR's changes are tested in the testsuite**.
- [ ] **I have run and passed the testsuite in CI** *before* submitting the
  PR, by pushing the changes to my fork and seeing that the automated CI
  passed there. (Exceptions: If most tests pass and you can't figure out why
  the remaining ones fail, it's ok to submit the PR and ask for help. Or if
  any failures seem entirely unrelated to your change; sometimes things break
  on the GitHub runners.)
- [X] **My code follows the prevailing code style of this project** and I
  fixed any problems reported by the clang-format CI test.
- [ ] If I added or modified a public C++ API call, I have also amended the
  corresponding Python bindings. If altering ImageBufAlgo functions, I also
  exposed the new functionality as oiiotool options.
