### PR TITLE
int(webp, jpeg-xl): Added check_open for WebP and JPEG XL readers

### DIFF
--- a/src/jpegxl.imageio/jxlinput.cpp
+++ b/src/jpegxl.imageio/jxlinput.cpp
@@ -360,6 +360,10 @@ JxlInput::open(const std::string& name, ImageSpec& newspec)
 
     m_spec = ImageSpec(info.xsize, info.ysize, m_channels, m_data_type);
 
+    if (!check_open(m_spec,
+                    { 0, (1 << 30) - 1, 0, (1 << 30) - 1, 0, 1, 0, 4099 }))
+        return false;
+
     // Read ICC profile
     if (m_icc_profile.size() && m_icc_profile.data()) {
         m_spec.attribute("ICCProfile",

--- a/src/webp.imageio/webpinput.cpp
+++ b/src/webp.imageio/webpinput.cpp
@@ -233,6 +233,9 @@ WebpInput::open(const std::string& name, ImageSpec& spec,
             m_spec.attribute("oiio:UnassociatedAlpha", 1);
     }
 
+    if (!check_open(m_spec, { 0, (1 << 14) - 1, 0, (1 << 14) - 1, 0, 1, 0, 4 }))
+        return false;
+
     seek_subimage(0, 0);
     spec = m_spec;
     return true;


### PR DESCRIPTION
### Description

This PR addresses the feature request in issue https://github.com/AcademySoftwareFoundation/OpenImageIO/issues/3974 

Continuing from previous work done on this feature request, I have added `check_open` calls to two new format readers, using file format specs found online:
- WebP: https://developers.google.com/speed/webp/faq#what_is_the_maximum_size_a_webp_image_can_be 
- JPEG XL: https://jpegxl.info/resources/battle-of-codecs.html

I also cross-referenced this info with the corresponding ImageOutput::check_open calls for sanity, and they seemed to align.

### Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


### Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] **I have read the guidelines** on [contributions](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md) and [code review procedures](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/CodeReview.md).
- [x] **I have read the [Policy on AI Coding Assistants](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/AI_Policy.md)**
  and if I used AI coding assistants, I have an `Assisted-by: TOOL / MODEL`
  line in the pull request description above.
- [ ] **I have updated the documentation** if my PR adds features or changes
  behavior.
- [ ] **I am sure that this PR's changes are tested in the testsuite**.
- [x] **I have run and passed the testsuite in CI** *before* submitting the
  PR, by pushing the changes to my fork and seeing that the automated CI
  passed there. (Exceptions: If most tests pass and you can't figure out why
  the remaining ones fail, it's ok to submit the PR and ask for help. Or if
  any failures seem entirely unrelated to your change; sometimes things break
  on the GitHub runners.)
- [x] **My code follows the prevailing code style of this project** and I
  fixed any problems reported by the clang-format CI test.
- [ ] If I added or modified a public C++ API call, I have also amended the
  corresponding Python bindings. If altering ImageBufAlgo functions, I also
  exposed the new functionality as oiiotool options.
