### PR TITLE
build: Improve error message about mismatching git tags

### DIFF
--- a/src/cmake/dependency_utils.cmake
+++ b/src/cmake/dependency_utils.cmake
@@ -680,7 +680,8 @@ macro (build_dependency_with_cmake pkgname)
             message (FATAL_ERROR
                 "${pkgname}: Tag ${_pkg_GIT_TAG} resolved to commit "
                 "${_pkg_actual_commit}, but expected ${_pkg_GIT_COMMIT}. "
-                "This may indicate the tag was tampered with or moved.")
+                "This may indicate the tag was tampered with or moved. "
+                "Setting ${PROJECT_NAME}_DEPENDENCY_BUILD_ALLOW_UNVERIFIED_TAGS=ON will disable this check.")
         endif ()
     elseif (NOT "${_pkg_GIT_COMMIT}" STREQUAL "")
         # Only commit hash specified: checkout that commit directly.


### PR DESCRIPTION
This message is triggered by the check that the tag of an auto-build dependency matches the SHA hash we use as a cross-check. This patch is just amending the error message to reveal the way to override the check, so people (like me) don't have to go hunting for it if they are purposely trying to build from a nonstandard commit of a dependency.

