### PR TITLE
fix: Remove redundant declarations

### DIFF
--- a/src/libOpenImageIO/CMakeLists.txt
+++ b/src/libOpenImageIO/CMakeLists.txt
@@ -299,12 +299,10 @@ if (OIIO_BUILD_TESTS AND BUILD_TESTING)
     add_test (unit_imageinout ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/imageinout_test)
     set_tests_properties (unit_imageinout PROPERTIES PROCESSORS 2 COST 30)
 
-    if (NOT DEFINED ENV{OpenImageIO_CI})
-        fancy_add_executable (NAME imagespeed_test SRC imagespeed_test.cpp
-                              LINK_LIBRARIES OpenImageIO
-                              FOLDER "Unit Tests" NO_INSTALL)
-        #add_test (imagespeed_test ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/imagespeed_test)
-    endif ()
+    fancy_add_executable (NAME imagespeed_test SRC imagespeed_test.cpp
+                          LINK_LIBRARIES OpenImageIO
+                          FOLDER "Unit Tests" NO_INSTALL)
+    #add_test (imagespeed_test ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/imagespeed_test)
 
     fancy_add_executable (NAME compute_test SRC compute_test.cpp
                           LINK_LIBRARIES OpenImageIO

--- a/src/libOpenImageIO/imagespeed_test.cpp
+++ b/src/libOpenImageIO/imagespeed_test.cpp
@@ -203,7 +203,6 @@ time_write_scanline_at_a_time()
 
     size_t pixelsize         = outspec.nchannels * sizeof(float);
     imagesize_t scanlinesize = outspec.width * pixelsize;
-    bool ok                  = true;
     for (int y = 0; y < outspec.height && ok; ++y) {
         ok = out->write_scanline(y + outspec.y, outspec.z, bufspec.format,
                                  &buffer[scanlinesize * y]);
@@ -220,7 +219,6 @@ time_write_64_scanlines_at_a_time()
     OIIO_ASSERT(out);
     bool ok = out->open(output_filename, outspec);
     OIIO_ASSERT(ok);
-    bool ok                  = true;
     size_t pixelsize         = outspec.nchannels * sizeof(float);
     imagesize_t scanlinesize = outspec.width * pixelsize;
     for (int y = 0; y < outspec.height && ok; y += 64) {
@@ -246,7 +244,6 @@ time_write_tile_at_a_time()
     size_t pixelsize         = outspec.nchannels * sizeof(float);
     imagesize_t scanlinesize = outspec.width * pixelsize;
     imagesize_t planesize    = outspec.height * scanlinesize;
-    bool ok                  = true;
     for (int z = 0; z < outspec.depth && ok; z += outspec.tile_depth) {
         for (int y = 0; y < outspec.height && ok; y += outspec.tile_height) {
             for (int x = 0; x < outspec.width && ok; x += outspec.tile_width) {
@@ -272,7 +269,6 @@ time_write_tiles_row_at_a_time()
 
     size_t pixelsize         = outspec.nchannels * sizeof(float);
     imagesize_t scanlinesize = outspec.width * pixelsize;
-    bool ok                  = true;
     for (int z = 0; z < outspec.depth && ok; z += outspec.tile_depth) {
         for (int y = 0; y < outspec.height && ok; y += outspec.tile_height) {
             ok = out->write_tiles(outspec.x, outspec.x + outspec.width,


### PR DESCRIPTION
This is an emergency fix on top of #5201.

PR 5201 passed CI completely.  Then I merged it, and now it fails. How did that happen?

OOOOOOH. The imagespeed_test.cpp is not compiled at all for CI! Only for local builds. So a build break in it will not be caught in CI. OK, fixing that, too. It doesn't run in CI, it's not that kind of test, it's a special benchmarking test meant to run locally and needs to be told a specific image file to test with.  But at least build it for CI so we can't inadvertently break it again.
