### PR TITLE
fix(cmake): Make the cmake config files always pull in the required libraries

### DIFF
--- a/src/cmake/Config.cmake.in
+++ b/src/cmake/Config.cmake.in
@@ -16,26 +16,29 @@ if (NOT @fmt_LOCAL_BUILD@ AND NOT @OIIO_INTERNALIZE_FMT@)
     find_dependency(fmt)
 endif ()
 
+find_dependency(OpenColorIO)
+find_dependency(OpenEXR)
+if (@OIIO_TBB@)
+    find_dependency(TBB)
+endif ()
+if (@JPEG_FOUND@)
+    find_dependency(JPEG)
+endif()
+if (@WebP_FOUND@)
+    find_dependency(WebP)
+endif()
+
 if (NOT @BUILD_SHARED_LIBS@)
     # This is required in static library builds, as e.g. PNG::PNG appears among
     # INTERFACE_LINK_LIBRARIES. If the project does not know about PNG target, it will cause
     # configuration error about unknown targets being linked in.
     find_dependency(TIFF)
-    find_dependency(OpenColorIO)
-    if (@JPEG_FOUND@)
-        find_dependency(JPEG)
-    endif()
     if (@PNG_FOUND@)
         find_dependency(PNG)
     endif()
     if (@DCMTK_FOUND@)
         find_dependency(DCMTK)
     endif()
-    # The following have the same problem except that INTERFACE_LINK_LIBRARIES use
-    # TARGET_NAME_IF_EXISTS, so the error only happens on link time.
-    if (@OIIO_TBB@)
-        find_dependency(TBB)
-    endif ()
 endif ()
 
 # Compute the installation prefix relative to this file. Note that cmake files are installed


### PR DESCRIPTION
Without these changes, we could get link time errors as openimageio doesn't pull in the libraries correctly when using modern cmake targets. It would work when libraries have been installed globally on the system. But I don't think we should rely on the linker automagically finding the libraries in `/usr/lib` for example.

Especially because we can make this a lot better by warning/erroring out in the cmake setup step when we can't find all required libraries.

I added the libraries that I saw show up in `OpenImageIOTargets-release.cmake` under the `OpenImageIO::OpenImageIO` target properties on my system.

### Minimal test example

Create a text project with this C++ file called `main.cxx`:

``` cpp

#include <OpenImageIO/imagebuf.h>

int main() {
  OIIO::ImageBuf image("test.tiff");
  image.write("output.exr");
  return 0;
}
```
And this `CMakeLists.txt` file:

``` cmake
cmake_minimum_required(VERSION 3.23)

project(test_oiio_proj)

set(Imath_ROOT ${CMAKE_SOURCE_DIR}/libs/imath)
set(OpenEXR_ROOT ${CMAKE_SOURCE_DIR}/libs/openexr)
set(openjph_ROOT ${CMAKE_SOURCE_DIR}/libs/openjph)
set(TBB_ROOT ${CMAKE_SOURCE_DIR}/libs/tbb)
set(OpenColorIO_ROOT ${CMAKE_SOURCE_DIR}/libs/opencolorio)
set(OpenImageIO_ROOT ${CMAKE_SOURCE_DIR}/libs/openimageio)
find_package(OpenImageIO REQUIRED)

add_executable(test_oiio)

target_sources(test_oiio
  PRIVATE
    main.cxx
)

target_link_libraries(test_oiio OpenImageIO::OpenImageIO)
```

**ENSURE** that you do not have OpenColorIO or OpenEXR installed globally on your system.

Make sure that you have `git-lfs` installed and configured on your system and then clone the precompiled linux libraries from blender into a `libs` directory next to the other files:
`git clone https://projects.blender.org/blender/lib-linux_x64.git libs`

Now if you run cmake and then try to build you will get a lot of errors like the ones below at link time:
```
/usr/x86_64-pc-linux-gnu/binutils-bin/2.46.0/ld: libOpenImageIO.so.3.1.13: undefined reference to `ojph::get_error()'
/usr/x86_64-pc-linux-gnu/binutils-bin/2.46.0/ld: libOpenImageIO.so.3.1.13: undefined reference to `Imf_3_4::Header::dwaCompressionLevel()
/usr/x86_64-pc-linux-gnu/binutils-bin/2.46.0/ld: libOpenImageIO.so.3.1.13: undefined reference to `exr_get_user_data'

```

Go and edit the `libs/openimageio/lib/cmake/OpenImageIO/OpenImageIOConfig.cmake` file and add the following on line 42:

``` cmake

find_dependency(OpenColorIO)
find_dependency(OpenEXR)
if (TRUE)
    find_dependency(TBB)
endif ()
```

Clean out the cmake build files and rerun cmake and try to build again.

Notice that the build finishes without any linker errors.

I don't know if there is any easy way to add tests for this in the test suite, so that is why I left that box unchecked.

### Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] **I have read the guidelines** on [contributions](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md) and [code review procedures](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/CodeReview.md).
- [x] **I have read the [Policy on AI Coding Assistants](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/AI_Policy.md)**
  and if I used AI coding assistants, I have an `Assisted-by: TOOL / MODEL`
  line in the pull request description above.
- [x] **I have updated the documentation** if my PR adds features or changes
  behavior.
- [ ] **I am sure that this PR's changes are tested in the testsuite**.
- [x] **I have run and passed the testsuite in CI** *before* submitting the
  PR, by pushing the changes to my fork and seeing that the automated CI
  passed there. (Exceptions: If most tests pass and you can't figure out why
  the remaining ones fail, it's ok to submit the PR and ask for help. Or if
  any failures seem entirely unrelated to your change; sometimes things break
  on the GitHub runners.)
- [x] **My code follows the prevailing code style of this project** and I
  fixed any problems reported by the clang-format CI test.
- [x] If I added or modified a public C++ API call, I have also amended the
  corresponding Python bindings. If altering ImageBufAlgo functions, I also
  exposed the new functionality as oiiotool options.
