### PR TITLE
build: remove -Wno-unused-result from gcc options

### DIFF
--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -185,7 +185,6 @@ endif ()
 if (CMAKE_COMPILER_IS_GNUCC AND NOT (CMAKE_COMPILER_IS_CLANG OR CMAKE_COMPILER_IS_APPLECLANG))
     # gcc specific options
     add_compile_options ("-Wno-unused-local-typedefs")
-    add_compile_options ("-Wno-unused-result")
     add_compile_options ("-Wno-aligned-new")
     add_compile_options ("-Wno-noexcept-type")
 endif ()


### PR DESCRIPTION
### Description
Background: this flag was originally added in commit c5494ac06 (2015-11-24) with the message "...now builds linux+gcc...". It was later refactored in commit 62d7164d3 (2017-01-23). From investigation, it seems to be preventative rather than reactive because it does not actively suppress warnings, but `-Werror` is enabled under the condition NOT MSVC + STOP_ON_WARNING (originally in CMakeLists.txt, now in compiler.cmake:126).

Compile tests without `-Wno-unused-result` but with `-Wunused-result` explicitly enabled were conducted on the following commits, and all compiled successfully without unused result warnings. Also, tests confirmed that the warning triggers if there is an unused return value. 
- 312793af4 (2026-01-01)
- 682825f9d (2025-01-01)
- 48362b26c (2024-01-01)
- 3b8807df8 (2023-01-01)
- 62d7164d3 (2017-01-23): refactored
- c5494ac06 (2015-11-24): originally added

Decision: the flag can be safely removed. Removing it allows gcc to catch unused return values, which is required for the `OIIO_NODISCARD` and `OIIO_NODISCARD_ERROR` macros to work as intended.

Related: #5196
Assisted-by: Claude / Opus 4.7



-----
### Tests
N/A

### Checklist:
- [x] **I have read the guidelines** on [contributions](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md) and [code review procedures](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/CodeReview.md).
- [x] **I have read the [Policy on AI Coding Assistants](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/AI_Policy.md)**
  and if I used AI coding assistants, I have an `Assisted-by: TOOL / MODEL`
  line in the pull request description above.
- [ ] (N/A) **I have updated the documentation** if my PR adds features or changes
  behavior.
- [ ] (N/A) **I am sure that this PR's changes are tested in the testsuite**.
- [x] **I have run and passed the testsuite in CI** *before* submitting the
  PR, by pushing the changes to my fork and seeing that the automated CI
  passed there. (Exceptions: If most tests pass and you can't figure out why
  the remaining ones fail, it's ok to submit the PR and ask for help. Or if
  any failures seem entirely unrelated to your change; sometimes things break
  on the GitHub runners.)
- [x] **My code follows the prevailing code style of this project** and I
  fixed any problems reported by the clang-format CI test.
- [ ] (N/A) If I added or modified a public C++ API call, I have also amended the
  corresponding Python bindings. If altering ImageBufAlgo functions, I also
  exposed the new functionality as oiiotool options.