### PR TITLE
api: add OIIO_NODISCARD_ERROR to Imageio.h

### DIFF
--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -456,7 +456,7 @@ public:
     /// whole image.  If this returns false, the image is much too big
     /// to allocate and read all at once, so client apps beware and check
     /// these routines for overflows!
-    bool size_t_safe() const noexcept {
+    OIIO_NODISCARD_ERROR bool size_t_safe() const noexcept {
         const imagesize_t big = std::numeric_limits<size_t>::max();
         return image_bytes() < big && scanline_bytes() < big &&
             tile_bytes() < big;
@@ -775,7 +775,7 @@ public:
     /// Helper function to verify that the given pixel range exactly covers a
     /// set of 2D tiles.  Also returns false if the spec indicates that the
     /// image isn't tiled at all.
-    bool valid_tile_range (int xbegin, int xend, int ybegin, int yend) noexcept {
+    OIIO_NODISCARD_ERROR bool valid_tile_range (int xbegin, int xend, int ybegin, int yend) noexcept {
         return (tile_width &&
                 ((xbegin-x) % tile_width)  == 0 &&
                 ((ybegin-y) % tile_height) == 0 &&
@@ -786,7 +786,7 @@ public:
     /// Helper function to verify that the given pixel range exactly covers a
     /// set of 3D tiles.  Also returns false if the spec indicates that the
     /// image isn't tiled at all.
-    bool valid_tile_range (int xbegin, int xend, int ybegin, int yend,
+    OIIO_NODISCARD_ERROR bool valid_tile_range (int xbegin, int xend, int ybegin, int yend,
                            int zbegin, int zend) noexcept {
         return (tile_width &&
                 ((xbegin-x) % tile_width)  == 0 &&

--- a/src/include/OpenImageIO/imageio.h
+++ b/src/include/OpenImageIO/imageio.h
@@ -456,7 +456,7 @@ public:
     /// whole image.  If this returns false, the image is much too big
     /// to allocate and read all at once, so client apps beware and check
     /// these routines for overflows!
-    OIIO_NODISCARD_ERROR bool size_t_safe() const noexcept {
+    OIIO_NODISCARD bool size_t_safe() const noexcept {
         const imagesize_t big = std::numeric_limits<size_t>::max();
         return image_bytes() < big && scanline_bytes() < big &&
             tile_bytes() < big;
@@ -775,7 +775,7 @@ public:
     /// Helper function to verify that the given pixel range exactly covers a
     /// set of 2D tiles.  Also returns false if the spec indicates that the
     /// image isn't tiled at all.
-    OIIO_NODISCARD_ERROR bool valid_tile_range (int xbegin, int xend, int ybegin, int yend) noexcept {
+    OIIO_NODISCARD bool valid_tile_range (int xbegin, int xend, int ybegin, int yend) noexcept {
         return (tile_width &&
                 ((xbegin-x) % tile_width)  == 0 &&
                 ((ybegin-y) % tile_height) == 0 &&
@@ -786,7 +786,7 @@ public:
     /// Helper function to verify that the given pixel range exactly covers a
     /// set of 3D tiles.  Also returns false if the spec indicates that the
     /// image isn't tiled at all.
-    OIIO_NODISCARD_ERROR bool valid_tile_range (int xbegin, int xend, int ybegin, int yend,
+    OIIO_NODISCARD bool valid_tile_range (int xbegin, int xend, int ybegin, int yend,
                            int zbegin, int zend) noexcept {
         return (tile_width &&
                 ((xbegin-x) % tile_width)  == 0 &&


### PR DESCRIPTION

### Description
 
Add OIIO_NODISCARD_ERROR to make sure callers check their bool return values

Assisted by: Claude Sonnet 4.6
Reference: https://github.com/AcademySoftwareFoundation/OpenImageIO/issues/4781

### Tests

No new test suite case added


### Checklist:

- [x] **I have read the guidelines** on [contributions](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md) and [code review procedures](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/CodeReview.md).
- [x] **I have read the [Policy on AI Coding Assistants](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/AI_Policy.md)**
  and if I used AI coding assistants, I have an `Assisted-by: TOOL / MODEL`
  line in the pull request description above.
- [x] **I have updated the documentation** if my PR adds features or changes
  behavior.
- [x] **I am sure that this PR's changes are tested in the testsuite**.
- [x] **I have run and passed the testsuite in CI** *before* submitting the
  PR, by pushing the changes to my fork and seeing that the automated CI
  passed there. (Exceptions: If most tests pass and you can't figure out why
  the remaining ones fail, it's ok to submit the PR and ask for help. Or if
  any failures seem entirely unrelated to your change; sometimes things break
  on the GitHub runners.)
- [x] **My code follows the prevailing code style of this project** and I
  fixed any problems reported by the clang-format CI test.
- [x] If I added or modified a public C++ API call, I have also amended the
  corresponding Python bindings. If altering ImageBufAlgo functions, I also
  exposed the new functionality as oiiotool options.
