### PR TITLE
docs: fix typos in fmath.h comments

### DIFF
--- a/src/include/OpenImageIO/fmath.h
+++ b/src/include/OpenImageIO/fmath.h
@@ -404,7 +404,7 @@ lerp (const T& v0, const T& v1, const Q& x)
 
 
 
-/// Bilinearly interoplate values v0-v3 (v0 upper left, v1 upper right,
+/// Bilinearly interpolate values v0-v3 (v0 upper left, v1 upper right,
 /// v2 lower left, v3 lower right) at coordinates (s,t) and return the
 /// result.  This is a template, and so should work for any types.
 template <class T, class Q>
@@ -418,7 +418,7 @@ bilerp(const T& v0, const T& v1, const T& v2, const T& v3, const Q& s, const Q& 
 
 
 
-/// Bilinearly interoplate arrays of values v0-v3 (v0 upper left, v1
+/// Bilinearly interpolate arrays of values v0-v3 (v0 upper left, v1
 /// upper right, v2 lower left, v3 lower right) at coordinates (s,t),
 /// storing the results in 'result'.  These are all vectors, so do it
 /// for each of 'n' contiguous values (using the same s,t interpolants).
@@ -436,7 +436,7 @@ bilerp (const T *v0, const T *v1,
 
 
 
-/// Bilinearly interoplate arrays of values v0-v3 (v0 upper left, v1
+/// Bilinearly interpolate arrays of values v0-v3 (v0 upper left, v1
 /// upper right, v2 lower left, v3 lower right) at coordinates (s,t),
 /// SCALING the interpolated value by 'scale' and then ADDING to
 /// 'result'.  These are all vectors, so do it for each of 'n'
@@ -456,7 +456,7 @@ bilerp_mad (const T *v0, const T *v1,
 
 
 
-/// Trilinearly interoplate arrays of values v0-v7 (v0 upper left top, v1
+/// Trilinearly interpolate arrays of values v0-v7 (v0 upper left top, v1
 /// upper right top, ...) at coordinates (s,t,r), and return the
 /// result.  This is a template, and so should work for any types.
 template <class T, class Q>
@@ -473,7 +473,7 @@ trilerp (T v0, T v1, T v2, T v3, T v4, T v5, T v6, T v7, Q s, Q t, Q r)
 
 
 
-/// Trilinearly interoplate arrays of values v0-v7 (v0 upper left top, v1
+/// Trilinearly interpolate arrays of values v0-v7 (v0 upper left top, v1
 /// upper right top, ...) at coordinates (s,t,r),
 /// storing the results in 'result'.  These are all vectors, so do it
 /// for each of 'n' contiguous values (using the same s,t,r interpolants).
@@ -493,7 +493,7 @@ trilerp (const T *v0, const T *v1, const T *v2, const T *v3,
 
 
 
-/// Trilinearly interoplate arrays of values v0-v7 (v0 upper left top, v1
+/// Trilinearly interpolate arrays of values v0-v7 (v0 upper left top, v1
 /// upper right top, ...) at coordinates (s,t,r),
 /// SCALING the interpolated value by 'scale' and then ADDING to
 /// 'result'.  These are all vectors, so do it for each of 'n'
@@ -539,7 +539,7 @@ inline OIIO_HOSTDEVICE void evalBSplineWeightDerivs (T dw[4], T fraction)
 
 
 
-/// Bicubically interoplate arrays of pointers arranged in a 4x4 pattern
+/// Bicubically interpolate arrays of pointers arranged in a 4x4 pattern
 /// with val[0] pointing to the data in the upper left corner, val[15]
 /// pointing to the lower right) at coordinates (s,t), storing the
 /// results in 'result'.  These are all vectors, so do it for each of
@@ -575,7 +575,7 @@ ifloor (float x)
 /// Return (x-floor(x)) and put (int)floor(x) in *xint.  This is similar
 /// to the built-in modf, but returns a true int, always rounds down
 /// (compared to modf which rounds toward 0), and always returns
-/// frac >= 0 (comapred to modf which can return <0 if x<0).
+/// frac >= 0 (compared to modf which can return <0 if x<0).
 inline OIIO_HOSTDEVICE float
 floorfrac (float x, int *xint)
 {


### PR DESCRIPTION
### Description
Minor typo fixes in comments.

### Tests
N/A

### Checklist:
- [x] **I have read the guidelines** on [contributions](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md) and [code review procedures](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/CodeReview.md).
- [x] **I have read the [Policy on AI Coding Assistants](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/AI_Policy.md)**
  and if I used AI coding assistants, I have an `Assisted-by: TOOL / MODEL`
  line in the pull request description above.
- [ ] **(N/A)** **I have updated the documentation** if my PR adds features or changes
  behavior.
- [ ] **(N/A)** **I am sure that this PR's changes are tested in the testsuite**.
- [x] **I have run and passed the testsuite in CI** *before* submitting the
  PR, by pushing the changes to my fork and seeing that the automated CI
  passed there. (Exceptions: If most tests pass and you can't figure out why
  the remaining ones fail, it's ok to submit the PR and ask for help. Or if
  any failures seem entirely unrelated to your change; sometimes things break
  on the GitHub runners.)
- [x] **My code follows the prevailing code style of this project** and I
  fixed any problems reported by the clang-format CI test.
- [ ] **(N/A)** If I added or modified a public C++ API call, I have also amended the
  corresponding Python bindings. If altering ImageBufAlgo functions, I also
  exposed the new functionality as oiiotool options.
