### PR TITLE
api: span and string_view get extra contract asserts per std

### DIFF
--- a/src/include/OpenImageIO/span.h
+++ b/src/include/OpenImageIO/span.h
@@ -154,40 +154,51 @@ public:
     /// Assignment copies the pointer and length, not the data.
     constexpr span& operator= (const span &copy) = default;
 
-    /// Subspan containing the first Count elements of the span.
+    /// Subspan containing the first Count elements of the span. The count
+    /// must be be no more than the current size.
     template<size_type Count>
     constexpr span<element_type, Count> first () const {
+        OIIO_CONTRACT_ASSERT(Count <= m_size);
         return { m_data, Count };
     }
-    /// Subspan containing the last Count elements of the span.
+    /// Subspan containing the last Count elements of the span. The count must
+    /// be be no more than the current size.
     template<size_type Count>
     constexpr span<element_type, Count> last () const {
+        OIIO_CONTRACT_ASSERT(Count <= m_size);
         return { m_data + m_size - Count, Count };
     }
 
     /// Subspan starting at templated Offset and containing Count elements.
+    /// The requested subspan must lie within the current range of the span.
     template<size_type Offset, size_type Count = dynamic_extent>
     constexpr span<element_type, Count> subspan () const {
+        OIIO_CONTRACT_ASSERT(Offset <= m_size && (Count == dynamic_extent
+                                                  || Count <= m_size - Offset));
         return { m_data + Offset, Count != dynamic_extent ? Count : (Extent != dynamic_extent ? Extent - Offset : m_size - Offset) };
     }
 
-    /// Subspan containing just the first `count` elements. The count will be
-    /// clamped to be no more than the current size.
+    /// Subspan containing just the first `count` elements. The count must be
+    /// no more than the current size.
     constexpr span<element_type, dynamic_extent> first (size_type count) const {
+        OIIO_CONTRACT_ASSERT(count <= m_size);
         return { m_data, std::min(count, m_size) };
     }
 
-    /// Subspan containing just the last `count` elements. The count will be
-    /// clamped to be no more than the current size.
+    /// Subspan containing just the last `count` elements. The count must be
+    /// be no more than the current size.
     constexpr span<element_type, dynamic_extent> last (size_type count) const {
+        OIIO_CONTRACT_ASSERT(count <= m_size);
         count = std::min(count, m_size);
         return { m_data + ( m_size - count ), count };
     }
 
-    /// Subspan starting at offset and containing count elements. The range
-    /// requested will be clamped to the current size of the span.
+    /// Subspan starting at offset and containing count elements. The
+    /// requested subspan must lie within the current range of the span.
     constexpr span<element_type, dynamic_extent>
     subspan (size_type offset, size_type count = dynamic_extent) const {
+        OIIO_CONTRACT_ASSERT(offset <= m_size && (count == dynamic_extent
+                                                  || count <= m_size - offset));
         offset = std::min(offset, m_size);
         count = std::min(count, m_size - offset);
         return { m_data + offset, count };

--- a/src/include/OpenImageIO/string_view.h
+++ b/src/include/OpenImageIO/string_view.h
@@ -239,6 +239,7 @@ public:
     /// Remove the first n characters from the view.
     constexpr void remove_prefix(size_type n) noexcept
     {
+        OIIO_CONTRACT_ASSERT(n <= m_len);
         if (n > m_len)
             n = m_len;
         m_chars += n;
@@ -247,6 +248,7 @@ public:
     /// Remove the last n characters from the view.
     constexpr void remove_suffix(size_type n) noexcept
     {
+        OIIO_CONTRACT_ASSERT(n <= m_len);
         if (n > m_len)
             n = m_len;
         m_len -= n;

--- a/src/libutil/paramlist.cpp
+++ b/src/libutil/paramlist.cpp
@@ -9,6 +9,7 @@
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/half.h>
 #include <OpenImageIO/paramlist.h>
+#include <OpenImageIO/strutil.h>
 #include <OpenImageIO/ustring.h>
 
 
@@ -108,16 +109,16 @@ static void
 parse_elements(string_view value, ParamValue& p)
 {
     auto data = p.as_span<T>();
-    value.remove_prefix(value.find_first_not_of(" \t"));
     for (auto&& d : data) {
+        Strutil::skip_whitespace(value);
         // Make a temporary copy so we for sure have a 0-terminated string.
         std::string temp = value;
         // Grab the first value from it
         d = Strutil::from_string<T>(temp);
         // Skip the value (eat until we find a delimiter -- space, comma, tab)
-        value.remove_prefix(value.find_first_of(" ,\t"));
-        // Skip the delimiter
-        value.remove_prefix(value.find_first_not_of(" ,\t"));
+        (void)Strutil::parse_until(value, " ,\t");
+        // Skip the comma delimiter, if it exists (and any leading whitespace)
+        (void)Strutil::parse_char(value, ',');
         if (value.empty())
             break;  // done if nothing left to parse
     }


### PR DESCRIPTION
According to C++26, some newly required std container hardening for std::span and std::string_view were not reflected in our own analogous types. In particular, some more precondition checking was required for span::subspan, first, last, and string_view::remove_prefix and remove_suffix in order to match the expectations of true parity with with the std versions.

This is important because some day, we will probably discard our own string_view and span for the std ones (especially when we are using compilers in which they are fully hardened).

I found a couple spots where we used remove_prefix and remove_suffix that assumed the range would be clamped, as it is in our version, rather than contractually require them to be valid ranges as in std. This would eventually fail if replaced by std::string_view, so fixing now.

