### PR TITLE
build: Support gcc-16 and test it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,12 +298,12 @@ jobs:
                             EXTRA_DEP_PACKAGES="clang-format-17"
                             CLANG_FORMAT_EXE=clang-format-17
 
-          - desc: latest releases gcc13 C++20 py3.12 avx2 exr3.4 ocio2.4
+          - desc: latest releases gcc15 C++20 py3.12 avx2 exr3.4 ocio2.4
             nametag: linux-latest-releases
             oiio_python_bindings_backend: both
             runner: ubuntu-24.04
-            cc_compiler: gcc-13
-            cxx_compiler: g++-13
+            # cc_compiler: gcc-13
+            # cxx_compiler: g++-13
             cxx_std: 20
             fmt_ver: 12.1.0
             fmt_commit: 407c905e45ad75fc29bf0f9bb7c5c2fd3475976f
@@ -312,7 +312,9 @@ jobs:
             pybind11_ver: v3.0.2
             python_ver: "3.12"
             simd: avx2,f16c
-            setenvs: export LIBJPEGTURBO_VERSION=3.1.2
+            gcc_action_ver: 15
+            setenvs: export OIIO_CC=gcc-15 OIIO_CXX=g++-15
+                            LIBJPEGTURBO_VERSION=3.1.2
                             LIBPNG_VERSION=v1.6.50
                             LIBRAW_VERSION=0.22.0
                             LIBTIFF_VERSION=v4.7.1
@@ -322,11 +324,14 @@ jobs:
                             WEBP_VERSION=v1.6.0
                             FREETYPE_VERSION=VER-2-14-1
                             USE_OPENVDB=0
+                            UHDR_CMAKE_C_COMPILER=gcc
+                            UHDR_CMAKE_CXX_COMPILER=g++
+                            OPENCOLORIO_CXX=c++
             # Ensure we are testing all the deps we think we are. We would
             # like this test to have minimal missing dependencies.
             required_deps: all
             optional_deps: 'CUDAToolkit;DCMTK;JXL;Nuke;OpenCV;OpenGL;OpenVDB;R3DSDK'
-          - desc: bleeding edge gcc15 C++23 py3.12 OCIO/libtiff/exr-main avx2
+          - desc: bleeding edge gcc16 C++23 py3.12 OCIO/libtiff/exr-main avx2
             nametag: linux-bleeding-edge
             runner: ubuntu-24.04
             # cc_compiler: gcc-15
@@ -339,8 +344,8 @@ jobs:
             python_ver: "3.12"
             simd: avx2,f16c
             benchmark: 1
-            gcc_action_ver: 15
-            setenvs: export OIIO_CC=gcc-15 OIIO_CXX=g++-15
+            gcc_action_ver: 16
+            setenvs: export OIIO_CC=gcc-16 OIIO_CXX=g++-16
                             LIBJPEGTURBO_VERSION=main
                             LIBPNG_VERSION=master
                             LIBRAW_VERSION=master
@@ -357,7 +362,6 @@ jobs:
                             UHDR_CMAKE_C_COMPILER=gcc
                             UHDR_CMAKE_CXX_COMPILER=g++
                             OPENCOLORIO_CXX=c++
-                            # The installed OpenVDB has a TLS conflict with Python 3.8
             # Ensure we are testing all the deps we think we are. We would
             # like this test to have minimal missing dependencies.
             required_deps: all

--- a/src/libOpenImageIO/printinfo.cpp
+++ b/src/libOpenImageIO/printinfo.cpp
@@ -221,11 +221,10 @@ print_deep_stats(std::ostream& out, string_view indent, const ImageBuf& input,
     int xend = spec.x + spec.width;
     int yend = spec.y + spec.height;
     int zend = spec.z + spec.depth;
-    size_t p = 0;
     std::vector<size_t> nsamples_histogram;
     for (int z = spec.z; z < zend; ++z) {
         for (int y = spec.y; y < yend; ++y) {
-            for (int x = spec.x; x < xend; ++x, ++p) {
+            for (int x = spec.x; x < xend; ++x) {
                 size_t samples = input.deep_samples(x, y, z);
                 totalsamples += samples;
                 if (samples == maxsamples)


### PR DESCRIPTION
Bump the "bleeding edge" variant to gcc-16, and the "latest releases" variant to gcc-15.

One minor fix needed to make gcc16 happy -- it is better than earlier versions at discovering variables whose values are not used.
