### PR TITLE
docs: Clarify plugin.h explanations by saying their Unix-like equivalents

### DIFF
--- a/src/include/OpenImageIO/plugin.h
+++ b/src/include/OpenImageIO/plugin.h
@@ -36,6 +36,7 @@ plugin_extension(void);
 /// an explanatory message.  If the 'global' parameter is true, all
 /// symbols from the plugin will be available to the app (on Unix-like
 /// platforms; this has no effect on Windows).
+/// Note: This is more or less dlopen() on Unix-like systems.
 OIIO_UTIL_API Handle
 open(const char* plugin_filename, bool global = true);
 
@@ -48,6 +49,7 @@ open(const std::string& plugin_filename, bool global = true)
 /// Close the open plugin with the given handle and return true upon
 /// success.  If some error occurred, return false and the next call to
 /// geterror() will contain an explanatory message.
+/// Note: This is more or less dlclose() on Unix-like systems.
 OIIO_UTIL_API bool
 close(Handle plugin_handle);
 
@@ -55,6 +57,7 @@ close(Handle plugin_handle);
 /// some error occurred, return nullptr and the next call to
 /// geterror() will contain an explanatory message (unless report_error
 /// is false, in which case the error message will be suppressed).
+/// Note: This is more or less dlsym() on Unix-like systems.
 OIIO_UTIL_API void*
 getsym(Handle plugin_handle, const char* symbol_name, bool report_error = true);
 
@@ -67,6 +70,8 @@ getsym(Handle plugin_handle, const std::string& symbol_name,
 
 /// Return any error messages associated with the last call to any of
 /// open, close, or getsym from the same thread.
+/// Note: This is more or less returning the last result of dlerror() on
+/// Unix-like systems.
 OIIO_UTIL_API std::string
 geterror(bool clear = true);
 


### PR DESCRIPTION
Mostly for the sake of bots (but also humans) reading plugin.h and trying to figure out exactly what each function does, just plainly state which Unix-like dlopen/dlsym/etc function it is the equivalent of.
