### PR TITLE
fix(fmath.h): typo in convert_type default argument, min() to max()

### DIFF
--- a/src/include/OpenImageIO/fmath.h
+++ b/src/include/OpenImageIO/fmath.h
@@ -992,7 +992,7 @@ inline void convert_type (const S *src, D *dst, size_t n)
 template<typename S, typename D>
 void convert_type (cspan<S> src, span<D> dst,
                    D min = std::numeric_limits<D>::min(),
-                   D max = std::numeric_limits<D>::min())
+                   D max = std::numeric_limits<D>::max())
 {
     OIIO_DASSERT(src.size() == dst.size());
     convert_type(src.data(), dst.data(), std::min(src.size(), dst.size()),


### PR DESCRIPTION
### Description
Fix typo in convert_type default argument. Fixes #5223


### Tests
N/A


### Checklist:
- [x] **I have read the guidelines** on [contributions](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md) and [code review procedures](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/CodeReview.md).
- [x] **I have read the [Policy on AI Coding Assistants](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/AI_Policy.md)**
  and if I used AI coding assistants, I have an `Assisted-by: TOOL / MODEL`
  line in the pull request description above.
- [ ] **(N/A)** **I have updated the documentation** if my PR adds features or changes
  behavior.
- [ ] **(N/A)** **I am sure that this PR's changes are tested in the testsuite**.
- [x] **I have run and passed the testsuite in CI** *before* submitting the
  PR, by pushing the changes to my fork and seeing that the automated CI
  passed there. (Exceptions: If most tests pass and you can't figure out why
  the remaining ones fail, it's ok to submit the PR and ask for help. Or if
  any failures seem entirely unrelated to your change; sometimes things break
  on the GitHub runners.)
- [x] **My code follows the prevailing code style of this project** and I
  fixed any problems reported by the clang-format CI test.
- [ ] **(N/A)** If I added or modified a public C++ API call, I have also amended the
  corresponding Python bindings. If altering ImageBufAlgo functions, I also
  exposed the new functionality as oiiotool options.
