### PR TITLE
build: Support C++26, and test it in CI in the bleeding edge test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,13 +298,13 @@ jobs:
                             EXTRA_DEP_PACKAGES="clang-format-17"
                             CLANG_FORMAT_EXE=clang-format-17
 
-          - desc: latest releases gcc15 C++20 py3.12 avx2 exr3.4 ocio2.4
+          - desc: latest releases gcc15 C++23 py3.12 avx2 exr3.4 ocio2.4
             nametag: linux-latest-releases
             oiio_python_bindings_backend: both
             runner: ubuntu-24.04
             # cc_compiler: gcc-13
             # cxx_compiler: g++-13
-            cxx_std: 20
+            cxx_std: 23
             fmt_ver: 12.1.0
             fmt_commit: 407c905e45ad75fc29bf0f9bb7c5c2fd3475976f
             opencolorio_ver: v2.5.0
@@ -331,12 +331,12 @@ jobs:
             # like this test to have minimal missing dependencies.
             required_deps: all
             optional_deps: 'CUDAToolkit;DCMTK;JXL;Nuke;OpenCV;OpenGL;OpenVDB;R3DSDK'
-          - desc: bleeding edge gcc16 C++23 py3.12 OCIO/libtiff/exr-main avx2
+          - desc: bleeding edge gcc16 C++26 py3.12 OCIO/libtiff/exr-main avx2
             nametag: linux-bleeding-edge
             runner: ubuntu-24.04
             # cc_compiler: gcc-15
             # cxx_compiler: g++-15
-            cxx_std: 23
+            cxx_std: 26
             fmt_ver: main
             opencolorio_ver: main
             openexr_ver: main

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,9 +14,11 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
 
 ### Required dependencies -- OIIO will not build at all without these
 
- * C++17 or higher (also builds with C++20 and C++23)
+ * C++17 or higher (also builds with C++20, C++23, and C++26)
      * The default build mode is C++17. This can be controlled by via the
        CMake configuration flag: `-DCMAKE_CXX_STANDARD=20`, etc.
+     * Note that no matter which version you compile with internally,
+       OIIO's public APIs only require C++17 features.
  * Compilers: gcc 9.3 - 15.2, clang 10 - 22, MSVS 2017 - 2026 (v19.14
    and up), Intel OneAPI C++ compiler 2022+.
  * CMake >= 3.18.2 (tested through 4.3)

--- a/src/include/OpenImageIO/platform.h
+++ b/src/include/OpenImageIO/platform.h
@@ -174,8 +174,10 @@
 // See https://en.cppreference.com/w/cpp/compiler_support
 //
 // OIIO_CPLUSPLUS_VERSION : which C++ standard is compiling (14, 17, ...)
-// OIIO_CONSTEXPR17 :
-// OIIO_CONSTEXPR20 : constexpr for C++ >= the designated version, otherwise
+// OIIO_CONSTEXPR17 : depreated, always `constexpr`
+// OIIO_CONSTEXPR20 :
+// OIIO_CONSTEXPR23 :
+// OIIO_CONSTEXPR26 : constexpr for C++ >= the designated version, otherwise
 //                    nothing (this is useful for things that can only be
 //                    constexpr for particular versions or greater).
 //
@@ -187,18 +189,26 @@
 // package is compiling against OIIO and using these headers (OIIO may be
 // C++17 but the client package may be newer, or vice versa -- use these two
 // symbols to differentiate these cases, when important).
-#if (__cplusplus >= 202302L)
+#if (__cplusplus >= 202603L)
+#    define OIIO_CPLUSPLUS_VERSION 26
+#    define OIIO_CONSTEXPR20 constexpr
+#    define OIIO_CONSTEXPR23 constexpr
+#    define OIIO_CONSTEXPR26 constexpr
+#elif (__cplusplus >= 202302L)
 #    define OIIO_CPLUSPLUS_VERSION 23
 #    define OIIO_CONSTEXPR20 constexpr
 #    define OIIO_CONSTEXPR23 constexpr
+#    define OIIO_CONSTEXPR26 /* not constexpr before C++26 */
 #elif (__cplusplus >= 202001L)
 #    define OIIO_CPLUSPLUS_VERSION 20
 #    define OIIO_CONSTEXPR20 constexpr
 #    define OIIO_CONSTEXPR23 /* not constexpr before C++23 */
+#    define OIIO_CONSTEXPR26 /* not constexpr before C++26 */
 #elif (__cplusplus >= 201703L) || (defined(_MSC_VER) && _MSC_VER >= 1914)
 #    define OIIO_CPLUSPLUS_VERSION 17
 #    define OIIO_CONSTEXPR20 /* not constexpr before C++20 */
 #    define OIIO_CONSTEXPR23 /* not constexpr before C++23 */
+#    define OIIO_CONSTEXPR26 /* not constexpr before C++26 */
 #else
 #    error "This version of OIIO is meant to work only with C++17 and above"
 #endif

--- a/src/include/OpenImageIO/strongparam.h
+++ b/src/include/OpenImageIO/strongparam.h
@@ -107,7 +107,9 @@ template<typename Tag, typename Basetype> struct StrongParam {
 
 private:
     Basetype m_val;
-    static_assert(std::is_trivial<Basetype>::value, "Need trivial type");
+    static_assert(std::is_trivially_copyable_v<Basetype>
+                      && std::is_trivially_copyable_v<Basetype>,
+                  "Need trivial type");
 };
 
 OIIO_NAMESPACE_3_1_END

--- a/src/include/OpenImageIO/strongparam.h
+++ b/src/include/OpenImageIO/strongparam.h
@@ -107,9 +107,8 @@ template<typename Tag, typename Basetype> struct StrongParam {
 
 private:
     Basetype m_val;
-    static_assert(std::is_trivially_copyable_v<Basetype>
-                      && std::is_trivially_copyable_v<Basetype>,
-                  "Need trivial type");
+    static_assert(std::is_trivially_copyable_v<Basetype>,
+                  "Need trivially copyable type");
 };
 
 OIIO_NAMESPACE_3_1_END


### PR DESCRIPTION
Bump the "bleeding edge" test to C++26 (from 23), and the "latest releases" Linux test to C++23 (from 20). There are still other variants that test C++20 including anything based on the VFX2026 platform.

Just one tiny change needed to compile in C++26 mode, related to a deprecated std type_traits template.
