### PR TITLE
admin: Update security alerts and clarify security policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,10 +68,14 @@ following your instructions. Please quote the exact error message you
 received. If you are having trouble building, please post the full cmake
 output of a fresh VERBOSE=1 build.
 
-Suspected security vulnerabilities should be reported by the same process.
-
-If confidentiality precludes a public question or issue for any reason, you
-may contact us privately at [security@openimageio.org](security@openimageio.org).
+[SECURITY.md](SECURITY.md) details our security policies and lists prior security advisories. True exploitable security vulnerabilities
+that should be fixed before disclosure should be reported by filing a GitHub
+[security advisory](https://github.com/AcademySoftwareFoundation/OpenImageIO/security/advisories/new).
+If that is not possible, it is also fine to email your report to
+security@openimageio.org. Only the project administrators have access to these
+reports. For problems that you don't think are really exploitable
+vulnerabilities, you are encouraged to just file a regular issue, as described
+above.
 
 
 Policy on AI Tools

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,8 +26,24 @@ security@openimageio.org. Only the project administrators have access to these
 reports.
 
 Our policy is to respond to vulnerability reports within 14 days, and to
-address critical security vulnerabilities rapidly and post patches as quickly
-as possible.
+address critical security vulnerabilities rapidly and post patches quickly,
+usually at the next scheduled patch release at the beginning of every month.
+For especially severe vulnerabilities, or when a flaw is believed to be
+exploited in the wild, we will try to make a special patch release as soon as
+possible.
+
+
+## What do we consider a vulnerability?
+
+We only consider a situation to be a security vulnerability if an untrusted
+party can plausibly trigger the flaw through normal product inputs (for
+example, a maliciously crafted input image). We do not support requesting a
+CVE for API-only or caller-controlled failures with no realistic adversarial
+path.
+
+Flaws whose root cause lies in a dependency should be reported and fixed
+upstream; the upstream project owns the CVE when one is warranted.
+
 
 ## Other security features
 
@@ -50,6 +66,7 @@ None known
 
 Most recent fixes listed first, more or less:
 
+- CVE-2026-50291: Segmentation Fault in BmpInput::read_native_scanline / [advisory](https://github.com/AcademySoftwareFoundation/OpenImageIO/security/advisories/GHSA-q3c7-3225-66h7) / [Fix: PR #5030](https://github.com/AcademySoftwareFoundation/OpenImageIO/pull/5030) (Fixed in 3.0.16.0, 3.1.11.0)
 - CVE-2026-43909: Signed integer overflow in SwapRGBABytes loop index leads to out-of-bounds read/write in DPX ABGR decoder / [advisory](https://github.com/AcademySoftwareFoundation/OpenImageIO/security/advisories/GHSA-g267-j53j-5258) / [Fix: PR5170](https://github.com/AcademySoftwareFoundation/OpenImageIO/pull/5170) (Fixed in 3.0.18.1, 3.1.13.1)
 - CVE-2026-43908: Signed integer overflow in ConvertCbYCrYToRGB leads to heap out-of-bounds write in DPX 4:2:2 decoder / [advisory](https://github.com/AcademySoftwareFoundation/OpenImageIO/security/advisories/GHSA-2jr5-q49v-3858) / [Fix: PR5170](https://github.com/AcademySoftwareFoundation/OpenImageIO/pull/5170) (Fixed in 3.0.18.1, 3.1.13.1)
 - CVE-2026-43907: Integer overflow in QueryRGBBufferSizeInternal leads to heap out-of-bounds write in DPX decoder (kCbYCr and kABGR) / [advisory](https://github.com/AcademySoftwareFoundation/OpenImageIO/security/advisories/GHSA-cq46-hp4h-cvfr) / [Fix: PR5170](https://github.com/AcademySoftwareFoundation/OpenImageIO/pull/5170) (Fixed in 3.0.18.1, 3.1.13.1)
@@ -58,7 +75,7 @@ Most recent fixes listed first, more or less:
 - CVE-2026-43905: JPEG2000 (OpenJPH) signed integer overflow in buffer allocation / [advisory](https://github.com/AcademySoftwareFoundation/OpenImageIO/security/advisories/GHSA-pj45-cf3g-28gq) / [Fix: PR5143](https://github.com/AcademySoftwareFoundation/OpenImageIO/pull/5143) (Fixed in 3.2.0.1, 3.1.13.0, 3.0.18.0)
 - CVE-2026-43904: Softimage PIC RLE decoder heap buffer overflow — longCount not clamped to image width / [advisory](https://github.com/AcademySoftwareFoundation/OpenImageIO/security/advisories/GHSA-4499-j545-7q33) / [Fix: PR5142](https://github.com/AcademySoftwareFoundation/OpenImageIO/pull/5142) (Fixed in 3.2.0.1, 3.1.13.0, 3.0.18.0)
 - CVE-2026-43903: SGI RLE decoder heap buffer overflow — OIIO_DASSERT bounds checks are no-ops in release builds / [advisory](https://github.com/AcademySoftwareFoundation/OpenImageIO/security/advisories/GHSA-jg3q-vm3q-2j35) / [#5141](https://github.com/AcademySoftwareFoundation/OpenImageIO/pull/5141) (Fixed in 3.2.0.1, 3.1.13.0, 3.0.18.0)
-- CVE-2026-7582: DDS Image ddsinput.cpp out-of-bounds write. [#5131](https://github.com/AcademySoftwareFoundation/OpenImageIO/pull/5131) (Fixed in 3.2.0.1, 3.1.13.0, 3.0.18.0)
+- CVE-2026-7582: DDS Image ddsinput.cpp out-of-bounds write / [advisory](https://github.com/AcademySoftwareFoundation/OpenImageIO/security/advisories/GHSA-5pm7-8r3j-2x67). [Fix: #5131](https://github.com/AcademySoftwareFoundation/OpenImageIO/pull/5131) (Fixed in 3.2.0.1, 3.1.13.0, 3.0.18.0)
 - CVE-2024-55194: Broken pgm had memory access error leading to heap overflow / [advisory](https://github.com/AcademySoftwareFoundation/OpenImageIO/security/advisories/GHSA-583r-43f7-cw8w) / [#4559](https://github.com/AcademySoftwareFoundation/OpenImageIO/pull/4559) (Fixed in 3.0.2.0, 3.1.4.0)
 - CVE-2024-40630: Fixed incorrect image size for certain HEIC files.
   [advisory](https://github.com/AcademySoftwareFoundation/OpenImageIO/security/advisories/GHSA-jjm9-9m4m-c8p2) (Fixed in 2.5.13.1)
@@ -66,7 +83,7 @@ Most recent fixes listed first, more or less:
 - CVE-2023-36183: Heap-buffer-overflow while reading ICO files [#3872](https://github.com/AcademySoftwareFoundation/OpenImageIO/pull/3872)  (by xiaoxiaoafeifei)
 - TALOS-2023-1709 / CVE-2023-24472: Race condition in TIFF reader. [#3772](https://github.com/AcademySoftwareFoundation/OpenImageIO/pull/3772) (2.5.1.0/2.4.8.1)
 - TALOS-2023-1707 / CVE-2023-24473, TALOS-2023-1708 / CVE-2023-22845: Guard against corrupted Targa. [#3768](https://github.com/AcademySoftwareFoundation/OpenImageIO/pull/3768) (2.5.1.0/2.4.8.1)
-- TALOS-2022-1654 / CVE-2022-43596, TALOS-2022-1655 / CVE-2022-43597 CVE-2022-43598, TALOS-2022-1656 / CVE-2022-43599 CVE-2022-43600 CVE-2022-43601 CVE-2022-43602: Fix possible IFF write errors [#6876](https://github.com/AcademySoftwareFoundation/OpenImageIO/pull/3676) (2.4.6/2.5.0.0)
+- TALOS-2022-1654 / CVE-2022-43596, TALOS-2022-1655 / CVE-2022-43597 CVE-2022-43598, TALOS-2022-1656 / CVE-2022-43599 CVE-2022-43600 CVE-2022-43601 CVE-2022-43602: Fix possible IFF write errors [#3676](https://github.com/AcademySoftwareFoundation/OpenImageIO/pull/3676) (2.4.6/2.5.0.0)
 - TALOS-2022-1653 / CVE-2022-43594: Fix possible errors when writing BMP files. [#3673](https://github.com/AcademySoftwareFoundation/OpenImageIO/pull/3673) (by lgritz) (2.4.6/2.5.0.0)
 - TALOS-2022-1651 / CVE-2022-43592, TALOS-2022-1652 / CVE-2022-4359: Fix possible DPX write errors. [#3672](https://github.com/AcademySoftwareFoundation/OpenImageIO/pull/3672) (2.4.6/2.5.0.0)
 - TALOS-2022-1657 / CVE-2022-43603: Zfile write safety. [#3670](https://github.com/AcademySoftwareFoundation/OpenImageIO/pull/3670) (2.4.6/2.5.0.0)


### PR DESCRIPTION
Also make our CONTRIBUTING guide link to, and be consistent with,
our SECURITY.md policy file.

Follow OpenEXR's lead by explaining briefly that we only consider
something to be a security issue if it can plausibly be triggered by
ordinary inputs coming from untrusted parties. For example, a
maliciously crafted input image may be a vulnerability, but incorrect
use of an API call is not, because only trusted parties should have
direct access to the APIs.
