### PR TITLE
docs: fix typos and update reference link in deepdata comments

### DIFF
--- a/src/include/OpenImageIO/deepdata.h
+++ b/src/include/OpenImageIO/deepdata.h
@@ -116,12 +116,12 @@ public:
     /// pixel index.
     int capacity(int64_t pixel) const;
 
-    /// Insert `n` samples of the specified pixel, betinning at the sample
+    /// Insert `n` samples of the specified pixel, beginning at the sample
     /// position index. After insertion, the new samples will have
     /// uninitialized values.
     void insert_samples(int64_t pixel, int samplepos, int n = 1);
 
-    /// Erase `n` samples of the specified pixel, betinning at the sample
+    /// Erase `n` samples of the specified pixel, beginning at the sample
     /// position index.
     void erase_samples(int64_t pixel, int samplepos, int n = 1);
 

--- a/src/libOpenImageIO/deepdata.cpp
+++ b/src/libOpenImageIO/deepdata.cpp
@@ -971,7 +971,7 @@ DeepData::split(int64_t pixel, float depth)
         float zb = deep_value(pixel, zbackchan, s);  // z back
         if (zf < depth && zb > depth) {
             // The sample spans depth, so split it.
-            // See http://www.openexr.com/InterpretingDeepPixels.pdf
+            // See https://openexr.com/en/latest/InterpretingDeepPixels.html
             splits_occurred = true;
             insert_samples(pixel, s + 1);
             copy_deep_sample(pixel, s + 1, *this, pixel, s);
@@ -1114,7 +1114,7 @@ DeepData::merge_overlaps(int64_t pixel)
         if (zf == deep_value(pixel, zchan, s - 1)
             && zb == deep_value(pixel, zbackchan, s - 1)) {
             // The samples overlap exactly, merge them per
-            // See http://www.openexr.com/InterpretingDeepPixels.pdf
+            // See https://openexr.com/en/latest/InterpretingDeepPixels.html
             for (int c = 0; c < nchans; ++c) {  // set the colors
                 int alphachan = m_impl->m_myalphachannel[c];
                 if (alphachan < 0)


### PR DESCRIPTION
### Description

The InterpretingDeepPixels reference link expired. It moved to an HTML page on the OpenEXR docs site, so update the comments to the working URL.

### Tests

N/A

### Checklist:

- [x] **I have read the guidelines** on [contributions](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md) and [code review procedures](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/CodeReview.md).
- [x] **I have read the [Policy on AI Coding Assistants](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/AI_Policy.md)**
  and if I used AI coding assistants, I have an `Assisted-by: TOOL / MODEL`
  line in the pull request description above.
- [ ] **(N/A)** **I have updated the documentation** if my PR adds features or changes
  behavior.
- [ ] **(N/A)**  **I am sure that this PR's changes are tested in the testsuite**.
- [x] **I have run and passed the testsuite in CI** *before* submitting the
  PR, by pushing the changes to my fork and seeing that the automated CI
  passed there. (Exceptions: If most tests pass and you can't figure out why
  the remaining ones fail, it's ok to submit the PR and ask for help. Or if
  any failures seem entirely unrelated to your change; sometimes things break
  on the GitHub runners.)
- [x] **My code follows the prevailing code style of this project** and I
  fixed any problems reported by the clang-format CI test.
- [ ] **(N/A)**  If I added or modified a public C++ API call, I have also amended the
  corresponding Python bindings. If altering ImageBufAlgo functions, I also
  exposed the new functionality as oiiotool options.
