### PR TITLE
fix(deepdata): correct Zback channel in sort(), change int pixel to int64_t

### DIFF
--- a/src/libOpenImageIO/deepdata.cpp
+++ b/src/libOpenImageIO/deepdata.cpp
@@ -1033,7 +1033,8 @@ namespace {
 // Comparator functor for depth sorting sample indices of a deep pixel.
 class SampleComparator {
 public:
-    SampleComparator(const DeepData& dd, int pixel, int zchan, int zbackchan)
+    SampleComparator(const DeepData& dd, int64_t pixel, int zchan,
+                     int zbackchan)
         : deepdata(dd)
         , pixel(pixel)
         , zchan(zchan)
@@ -1057,7 +1058,7 @@ public:
 
 private:
     const DeepData& deepdata;
-    int pixel;
+    int64_t pixel;
     int zchan, zbackchan;
 };
 
@@ -1071,7 +1072,7 @@ DeepData::sort(int64_t pixel)
     int zchan = m_impl->m_z_channel;
     if (zchan < 0)
         return;  // No channel labeled Z -- we don't know what to do
-    int zbackchan = m_impl->m_z_channel;
+    int zbackchan = m_impl->m_zback_channel;
     if (zbackchan < 0)
         zbackchan = zchan;
     int nsamples = samples(pixel);
@@ -1121,14 +1122,9 @@ DeepData::merge_overlaps(int64_t pixel)
                     continue;  // Not color or alpha
                 if (alphachan == c)
                     continue;  // Adjust the alphas in a second pass below
-                float a1 = (alphachan < 0)
-                               ? 1.0f
-                               : clamp(deep_value(pixel, alphachan, s - 1),
-                                       0.0f, 1.0f);
-                float a2 = (alphachan < 0)
-                               ? 1.0f
-                               : clamp(deep_value(pixel, alphachan, s), 0.0f,
-                                       1.0f);
+                float a1 = clamp(deep_value(pixel, alphachan, s - 1), 0.0f,
+                                 1.0f);
+                float a2 = clamp(deep_value(pixel, alphachan, s), 0.0f, 1.0f);
                 float c1 = deep_value(pixel, c, s - 1);
                 float c2 = deep_value(pixel, c, s);
                 float am = a1 + a2 - a1 * a2;
@@ -1155,14 +1151,9 @@ DeepData::merge_overlaps(int64_t pixel)
                 int alphachan = m_impl->m_myalphachannel[c];
                 if (alphachan != c)
                     continue;  // This pass is only for alphas
-                float a1 = (alphachan < 0)
-                               ? 1.0f
-                               : clamp(deep_value(pixel, alphachan, s - 1),
-                                       0.0f, 1.0f);
-                float a2 = (alphachan < 0)
-                               ? 1.0f
-                               : clamp(deep_value(pixel, alphachan, s), 0.0f,
-                                       1.0f);
+                float a1 = clamp(deep_value(pixel, alphachan, s - 1), 0.0f,
+                                 1.0f);
+                float a2 = clamp(deep_value(pixel, alphachan, s), 0.0f, 1.0f);
                 float am = a1 + a2 - a1 * a2;
                 set_deep_value(pixel, c, s - 1, am);  // setting alpha
             }

--- a/testsuite/python-deep/ref/out.txt
+++ b/testsuite/python-deep/ref/out.txt
@@ -104,19 +104,19 @@ Testing sort...
 Before z sort, dd has 2 pixels, 6 channels.
   Channel indices: Z= 4 Zback= 5 A= 3 AR= 3 AG= 3 AB= 3
   Nsamples[ 0 ] = 4  (capacity= 4 ) samples:
-  sample 0 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 20.00 /  [5 Zback] 20.50 / 
+  sample 0 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 19.00 /  [5 Zback] 20.50 / 
   sample 1 :  [0 R] 0.10 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 19.00 /  [5 Zback] 19.50 / 
   sample 2 :  [0 R] 0.20 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 18.00 /  [5 Zback] 18.50 / 
   sample 3 :  [0 R] 0.30 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 17.00 /  [5 Zback] 17.50 / 
   Nsamples[ 1 ] = 4  (capacity= 4 ) samples:
-  sample 0 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 20.00 /  [5 Zback] 20.50 / 
+  sample 0 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 19.00 /  [5 Zback] 20.50 / 
   sample 1 :  [0 R] 0.10 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 19.00 /  [5 Zback] 19.50 / 
   sample 2 :  [0 R] 0.20 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 18.00 /  [5 Zback] 18.50 / 
   sample 3 :  [0 R] 0.30 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 17.00 /  [5 Zback] 17.50 / 
 After z sort of pixel 1, dd has 2 pixels, 6 channels.
   Channel indices: Z= 4 Zback= 5 A= 3 AR= 3 AG= 3 AB= 3
   Nsamples[ 0 ] = 4  (capacity= 4 ) samples:
-  sample 0 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 20.00 /  [5 Zback] 20.50 / 
+  sample 0 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 19.00 /  [5 Zback] 20.50 / 
   sample 1 :  [0 R] 0.10 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 19.00 /  [5 Zback] 19.50 / 
   sample 2 :  [0 R] 0.20 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 18.00 /  [5 Zback] 18.50 / 
   sample 3 :  [0 R] 0.30 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 17.00 /  [5 Zback] 17.50 / 
@@ -124,7 +124,7 @@ After z sort of pixel 1, dd has 2 pixels, 6 channels.
   sample 0 :  [0 R] 0.30 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 17.00 /  [5 Zback] 17.50 / 
   sample 1 :  [0 R] 0.20 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 18.00 /  [5 Zback] 18.50 / 
   sample 2 :  [0 R] 0.10 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 19.00 /  [5 Zback] 19.50 / 
-  sample 3 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 20.00 /  [5 Zback] 20.50 / 
+  sample 3 :  [0 R] 0.00 /  [1 G] 0.00 /  [2 B] 0.00 /  [3 A] 0.50 /  [4 Z] 19.00 /  [5 Zback] 20.50 / 
 
 Testing merge_overlaps...
 Before merge_overlaps, dd has 2 pixels, 6 channels.

--- a/testsuite/python-deep/src/test_deep.py
+++ b/testsuite/python-deep/src/test_deep.py
@@ -134,6 +134,8 @@ def test_sample_sort () :
             dd.set_deep_value (p, 3, s, 0.5)   # A
             dd.set_deep_value (p, 4, s, 20.0 - s)  # Z: decreasing!
             dd.set_deep_value (p, 5, s, 20.0 - s + 0.5)  # Zback
+        # Make sample 0's Z tie with sample 1's so that sort falls back to Zback
+        dd.set_deep_value (p, 4, 0, 19)     # sample 0, Z=19 (was 20)
     print_deep_image (dd, "Before z sort,")
     dd.sort (1)
     print_deep_image (dd, "After z sort of pixel 1,")


### PR DESCRIPTION
### Description

- Fix sort(), incorrectly using the front Z channel instead of Zback channel.
- Widen pixel indices from int to int64_t (internal only, follow-up to #2363).
- Cleanup unreachable branches in merge_overlaps().

### Tests
Modified the `DeepData::sort` test to include samples with a tied front Z, so it verifies the Zback fallback.

### Checklist:

- [x] **I have read the guidelines** on [contributions](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md) and [code review procedures](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/CodeReview.md).
- [x] **I have read the [Policy on AI Coding Assistants](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/AI_Policy.md)**
  and if I used AI coding assistants, I have an `Assisted-by: TOOL / MODEL`
  line in the pull request description above.
- [ ] **(N/A)** **I have updated the documentation** if my PR adds features or changes
  behavior.
- [x] **I am sure that this PR's changes are tested in the testsuite**.
- [x] **I have run and passed the testsuite in CI** *before* submitting the
  PR, by pushing the changes to my fork and seeing that the automated CI
  passed there. (Exceptions: If most tests pass and you can't figure out why
  the remaining ones fail, it's ok to submit the PR and ask for help. Or if
  any failures seem entirely unrelated to your change; sometimes things break
  on the GitHub runners.)
- [x] **My code follows the prevailing code style of this project** and I
  fixed any problems reported by the clang-format CI test.
- [ ] **(N/A)** If I added or modified a public C++ API call, I have also amended the
  corresponding Python bindings. If altering ImageBufAlgo functions, I also
  exposed the new functionality as oiiotool options.
