### PR TITLE
build: openjph auto-build and better exception handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
       # Override required_deps to be 'all' and explicitly list as optional
       # only the ones we are intentionally not testing for those jobs.
       required_deps: ${{ matrix.required_deps || 'all' }}
-      optional_deps: ${{ matrix.optional_deps || 'DCMTK;FFmpeg;JXL;Libheif;Nuke;OpenCV;openjph;OpenVDB;Qt5;R3DSDK;'}}${{matrix.optional_deps_append}}
+      optional_deps: ${{ matrix.optional_deps || 'DCMTK;FFmpeg;JXL;Libheif;Nuke;OpenCV;OpenVDB;Qt5;R3DSDK;'}}${{matrix.optional_deps_append}}
       build_local_deps: ${{ matrix.build_local_deps }}
     strategy:
       fail-fast: false
@@ -123,6 +123,8 @@ jobs:
             fmt_commit: f5e54359df4c26b6230fc61d38aa294581393084
             pybind11_ver: v2.12.0
             setenvs: export PUGIXML_VERSION=v1.14
+                            openjph_CMAKE_C_COMPILER=gcc
+                            openjph_CMAKE_CXX_COMPILER=g++
             optional_deps_append: "LibRaw"
           - desc: VFX2025 gcc11/C++17 py3.11 exr3.3 ocio2.4
             nametag: linux-vfx2025
@@ -136,7 +138,7 @@ jobs:
             pybind11_ver: v2.13.6
             benchmark: 1
             setenvs: export PUGIXML_VERSION=v1.15
-            optional_deps_append: "openjph;Qt6"
+            optional_deps_append: "Qt6"
           - desc: VFX2025 Debug gcc11/C++17 py3.11 exr3.3 ocio2.4
             nametag: linux-vfx2025-debug
             runner: ubuntu-latest
@@ -150,7 +152,7 @@ jobs:
             fmt_commit: 40626af88bd7df9a5fb80be7b25ac85b122d6c21
             pybind11_ver: v2.13.6
             setenvs: export PUGIXML_VERSION=v1.15
-            optional_deps_append: "openjph;Qt6"
+            optional_deps_append: "Qt6"
           # - desc: VFX2025 Static gcc11/C++17 py3.11 exr3.3 ocio2.4
           #   nametag: linux-vfx2025-static
           #   runner: ubuntu-latest
@@ -163,7 +165,7 @@ jobs:
           #   benchmark: 1
           #   setenvs: export PUGIXML_VERSION=v1.15
           #                   BUILD_SHARED_LIBS=OFF
-          #   optional_deps_append: "openjph;Qt6"
+          #   optional_deps_append: "Qt6"
           - desc: VFX2025 icx/C++17 py3.11 exr3.3 ocio2.4 qt5.15
             nametag: linux-vfx2025.icx
             runner: ubuntu-latest
@@ -179,8 +181,10 @@ jobs:
             setenvs: export USE_OPENVDB=0 USE_OPENCV=0
                             UHDR_CMAKE_C_COMPILER=gcc
                             UHDR_CMAKE_CXX_COMPILER=g++
+                            openjph_CMAKE_C_COMPILER=gcc
+                            openjph_CMAKE_CXX_COMPILER=g++
             # Building libuhdr with icx results in test failures
-            optional_deps_append: "LibRaw;Ptex;openjph;Qt6"
+            optional_deps_append: "LibRaw;Ptex;Qt6"
           - desc: VFX2026 gcc14/C++20 py3.13 exr3.4 ocio2.5
             nametag: linux-vfx2026
             runner: ubuntu-latest
@@ -226,7 +230,7 @@ jobs:
             abi_check: d4c8024633dba8bb3c01d22b65ce9bc7a1ae215e
             setenvs: export OIIO_CMAKE_FLAGS="-DOIIO_BUILD_TOOLS=0 -DOIIO_BUILD_TESTS=0 -DUSE_PYTHON=0"
                             USE_OPENCV=0 USE_FFMPEG=0 USE_PYTHON=0 USE_FREETYPE=0
-            optional_deps_append: "openjph;Qt6"
+            optional_deps_append: "Qt6"
 
 
   #
@@ -271,7 +275,7 @@ jobs:
       # Override required_deps to be 'all' and explicitly list as optional
       # only the ones we are intentionally not testing for those jobs.
       required_deps: ${{ matrix.required_deps || 'all' }}
-      optional_deps: ${{ matrix.optional_deps || 'CUDAToolkit;DCMTK;JXL;Nuke;OpenGL;openjph;OpenVDB;Ptex;pystring;Qt5;R3DSDK;Libheif;' }}${{matrix.optional_deps_append}}
+      optional_deps: ${{ matrix.optional_deps || 'CUDAToolkit;DCMTK;JXL;Nuke;OpenGL;OpenVDB;Ptex;pystring;Qt5;R3DSDK;Libheif;' }}${{matrix.optional_deps_append}}
       build_local_deps: ${{ matrix.build_local_deps }}
       oiio_python_bindings_backend: ${{ matrix.oiio_python_bindings_backend || '' }}
     strategy:
@@ -365,7 +369,7 @@ jobs:
             # Ensure we are testing all the deps we think we are. We would
             # like this test to have minimal missing dependencies.
             required_deps: all
-            optional_deps: 'CUDAToolkit;DCMTK;JXL;libuhdr;Nuke;OpenCV;OpenGL;openjph;R3DSDK;'
+            optional_deps: 'CUDAToolkit;DCMTK;JXL;libuhdr;Nuke;OpenCV;OpenGL;R3DSDK;'
           - desc: all local builds gcc12 C++17 avx2 exr3.2 ocio2.3
             nametag: linux-local-builds
             runner: ubuntu-22.04
@@ -395,6 +399,8 @@ jobs:
             python_ver: "3.12"
             simd: avx2,f16c
             setenvs: export USE_OPENVDB=0
+                            openjph_CMAKE_C_COMPILER=gcc
+                            openjph_CMAKE_CXX_COMPILER=g++
           - desc: Linux ARM latest releases gcc14 C++20 py3.12 exr3.4 ocio2.4
             nametag: linux-arm-latest-releases
             runner: ubuntu-24.04-arm
@@ -483,19 +489,21 @@ jobs:
             python_ver: "3.9"
             python_action_ver: "3.9"
             llvm_action_ver: "11"
-            setenvs: export  CMAKE_VERSION=3.18.2
-                             PTEX_VERSION=v2.3.2
-                             WEBP_VERSION=v1.1.0
-                             PUGIXML_VERSION=v1.8
-                             BUILD_PNG_VERSION=1.6.0
-                             PIP_SUFFIX=.9
-                             PIP_INSTALLS=numpy
-                             OIIO_CC=clang
-                             OIIO_CXX=clang++
-                             Robinmap_BUILD_VERSION=1.2.0
-                             Robinmap_GIT_COMMIT=68ff7325b3898fca267a103bad5c509e8861144d
-                             TIFF_BUILD_VERSION=4.0.0
-                             TIFF_GIT_COMMIT=f7b79dc7dc86ccbaabe9882e2b9ffa5ee8dac917
+            setenvs: export CMAKE_VERSION=3.18.2
+                            PTEX_VERSION=v2.3.2
+                            WEBP_VERSION=v1.1.0
+                            PUGIXML_VERSION=v1.8
+                            BUILD_PNG_VERSION=1.6.0
+                            PIP_SUFFIX=.9
+                            PIP_INSTALLS=numpy
+                            OIIO_CC=clang
+                            OIIO_CXX=clang++
+                            Robinmap_BUILD_VERSION=1.2.0
+                            Robinmap_GIT_COMMIT=68ff7325b3898fca267a103bad5c509e8861144d
+                            TIFF_BUILD_VERSION=4.0.0
+                            TIFF_GIT_COMMIT=f7b79dc7dc86ccbaabe9882e2b9ffa5ee8dac917
+                            openjph_CMAKE_C_COMPILER=gcc
+                            openjph_CMAKE_CXX_COMPILER=g++
                             #  OpenJPEG_BUILD_VERSION=2.2.0
                             #  OpenJPEG_GIT_COMMIT=3d7cde5fc9fbc5618d02160900d32e02ed12a00e
             optional_deps_append: 'FFmpeg;LibRaw;Ptex;Qt6'
@@ -663,7 +671,7 @@ jobs:
       # built. But we would like to add more dependencies and reduce this list
       # of exceptions in the future.
       required_deps: ${{ matrix.required_deps || 'all' }}
-      optional_deps: ${{ matrix.optional_deps || 'BZip2;CUDAToolkit;DCMTK;FFmpeg;GIF;JXL;Libheif;LibRaw;Nuke;OpenCV;OpenGL;OpenJPEG;openjph;OpenCV;OpenVDB;Ptex;pystring;Qt5;Qt6;TBB;R3DSDK;${{matrix.optional_deps_append}}' }}
+      optional_deps: ${{ matrix.optional_deps || 'BZip2;CUDAToolkit;DCMTK;FFmpeg;GIF;JXL;Libheif;LibRaw;Nuke;OpenCV;OpenGL;OpenJPEG;OpenCV;OpenVDB;Ptex;pystring;Qt5;Qt6;TBB;R3DSDK;${{matrix.optional_deps_append}}' }}
       build_local_deps: ${{ matrix.build_local_deps }}
       oiio_python_bindings_backend: ${{ matrix.oiio_python_bindings_backend || '' }}
     strategy:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -83,7 +83,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
  * If you want support for JPEG XL images:
      * libjxl >= 0.10.1 (tested through 0.11.2)
  * If you want support for j2c files:
-     * OpenJPH >= 0.21.2 (tested through 0.26)
+     * OpenJPH >= 0.21.2 (tested through 0.28)
  * We use PugiXML for XML parsing. There is a version embedded in the OIIO
    tree, but if you want to use an external, system-installed version (as
    may be required by some software distributions with policies against

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -83,7 +83,7 @@ NEW or CHANGED MINIMUM dependencies since the last major release are **bold**.
  * If you want support for JPEG XL images:
      * libjxl >= 0.10.1 (tested through 0.11.2)
  * If you want support for j2c files:
-     * OpenJPH >= 0.21.2 (tested through 0.28)
+     * OpenJPH >= 0.21.2 (tested through 0.30)
  * We use PugiXML for XML parsing. There is a version embedded in the OIIO
    tree, but if you want to use an external, system-installed version (as
    may be required by some software distributions with policies against

--- a/src/build-scripts/build_openjph.bash
+++ b/src/build-scripts/build_openjph.bash
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+# Utility script to download and build openjph
+#
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/AcademySoftwareFoundation/OpenImageIO
+
+# Exit the whole script if any command fails.
+set -ex
+
+# Repo and branch/tag/commit of openjph to download if we don't have it yet
+OPENJPH_REPO=${OPENJPH_REPO:=https://github.com/aous72/OpenJPH.git}
+OPENJPH_VERSION=${OPENJPH_VERSION:=0.28.1}
+
+# Where to put openjph repo source (default to the ext area)
+LOCAL_DEPS_DIR=${LOCAL_DEPS_DIR:=${PWD}/ext}
+OPENJPH_SRC_DIR=${OPENJPH_SRC_DIR:=${LOCAL_DEPS_DIR}/openjph}
+OPENJPH_BUILD_DIR=${OPENJPH_BUILD_DIR:=${OPENJPH_SRC_DIR}/build}
+OPENJPH_INSTALL_DIR=${OPENJPH_INSTALL_DIR:=${LOCAL_DEPS_DIR}/dist}
+OPENJPH_BUILD_TYPE=${OPENJPH_BUILD_TYPE:=${CMAKE_BUILD_TYPE:-Release}}
+#OPENJPH_CONFIG_OPTS=${OPENJPH_CONFIG_OPTS:=}
+
+pwd
+echo "openjph install dir will be: ${OPENJPH_INSTALL_DIR}"
+
+mkdir -p ./ext
+pushd ./ext
+
+# Clone openjph project from GitHub and build
+if [[ ! -e ${OPENJPH_SRC_DIR} ]] ; then
+    echo "git clone ${OPENJPH_REPO} ${OPENJPH_SRC_DIR}"
+    git clone ${OPENJPH_REPO} ${OPENJPH_SRC_DIR}
+fi
+cd ${OPENJPH_SRC_DIR}
+
+echo "git checkout ${OPENJPH_VERSION} --force"
+git checkout ${OPENJPH_VERSION} --force
+
+if [[ -z $DEP_DOWNLOAD_ONLY ]]; then
+    time cmake -S . -B ${OPENJPH_BUILD_DIR} -DCMAKE_BUILD_TYPE=${OPENJPH_BUILD_TYPE} \
+               -DCMAKE_INSTALL_PREFIX=${OPENJPH_INSTALL_DIR} \
+               -DOJPH_BUILD_EXECUTABLES=OFF \
+               -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+               -DBUILD_SHARED_LIBS=${OPENJPH_BUILD_SHARED_LIBS:-ON} \
+               ${OPENJPH_CONFIG_OPTS}
+    time cmake --build ${OPENJPH_BUILD_DIR} --target install
+fi
+
+# ls -R ${OPENJPH_INSTALL_DIR}
+popd
+
+
+# Set up paths. These will only affect the caller if this script is
+# run with 'source' rather than in a separate shell.
+export openjph_ROOT=$OPENJPH_INSTALL_DIR

--- a/src/build-scripts/build_openjph.bash
+++ b/src/build-scripts/build_openjph.bash
@@ -11,7 +11,7 @@ set -ex
 
 # Repo and branch/tag/commit of openjph to download if we don't have it yet
 OPENJPH_REPO=${OPENJPH_REPO:=https://github.com/aous72/OpenJPH.git}
-OPENJPH_VERSION=${OPENJPH_VERSION:=0.28.1}
+OPENJPH_VERSION=${OPENJPH_VERSION:=0.30.1}
 
 # Where to put openjph repo source (default to the ext area)
 LOCAL_DEPS_DIR=${LOCAL_DEPS_DIR:=${PWD}/ext}

--- a/src/build-scripts/gh-installdeps.bash
+++ b/src/build-scripts/gh-installdeps.bash
@@ -187,6 +187,10 @@ if [[ "$LIBRAW_VERSION" != "" ]] ; then
     source src/build-scripts/build_libraw.bash
 fi
 
+if [[ "$OPENJPH_VERSION" != "" ]] ; then
+    source src/build-scripts/build_openjph.bash
+fi
+
 if [[ "$OPENJPEG_VERSION" != "" ]] ; then
     source src/build-scripts/build_OpenJPEG.bash
 fi

--- a/src/cmake/build_openjph.cmake
+++ b/src/cmake/build_openjph.cmake
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://github.com/AcademySoftwareFoundation/OpenImageIO
 
-set_cache (openjph_BUILD_VERSION 0.28.1 "openjph version for local builds")
+set_cache (openjph_BUILD_VERSION 0.30.1 "openjph version for local builds")
 set (openjph_GIT_REPOSITORY "https://github.com/aous72/OpenJPH.git")
 set (openjph_GIT_TAG "${openjph_BUILD_VERSION}")
-set_cache (openjph_GIT_COMMIT "96996b055c39a6165ce5bc036d5ea77e24951008"
+set_cache (openjph_GIT_COMMIT "1ce857c7f14dd78dd8f4bdfabe43dc17f8408a42"
            "commit hash to verify tag against")
 set_cache (openjph_BUILD_SHARED_LIBS ${LOCAL_BUILD_SHARED_LIBS_DEFAULT}
            DOC "Should a local openjph build, if necessary, build shared libraries" ADVANCED)

--- a/src/cmake/build_openjph.cmake
+++ b/src/cmake/build_openjph.cmake
@@ -1,0 +1,42 @@
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/AcademySoftwareFoundation/OpenImageIO
+
+set_cache (openjph_BUILD_VERSION 0.28.1 "openjph version for local builds")
+set (openjph_GIT_REPOSITORY "https://github.com/aous72/OpenJPH.git")
+set (openjph_GIT_TAG "${openjph_BUILD_VERSION}")
+set_cache (openjph_GIT_COMMIT "96996b055c39a6165ce5bc036d5ea77e24951008"
+           "commit hash to verify tag against")
+set_cache (openjph_BUILD_SHARED_LIBS ${LOCAL_BUILD_SHARED_LIBS_DEFAULT}
+           DOC "Should a local openjph build, if necessary, build shared libraries" ADVANCED)
+set_cache (openjph_CMAKE_C_COMPILER ${CMAKE_C_COMPILER} "libopenjph build C compiler override" ADVANCED)
+set_cache (openjph_CMAKE_CXX_COMPILER ${CMAKE_CXX_COMPILER} "libopenjph build C++ compiler override" ADVANCED)
+
+
+string (MAKE_C_IDENTIFIER ${openjph_BUILD_VERSION} openjph_VERSION_IDENT)
+
+build_dependency_with_cmake(openjph
+    VERSION         ${openjph_BUILD_VERSION}
+    GIT_REPOSITORY  ${openjph_GIT_REPOSITORY}
+    GIT_TAG         ${openjph_GIT_TAG}
+    GIT_COMMIT      ${openjph_GIT_COMMIT}
+    CMAKE_ARGS
+        -D BUILD_SHARED_LIBS=${openjph_BUILD_SHARED_LIBS}
+        -D OJPH_BUILD_EXECUTABLES=OFF
+        -D CMAKE_POSITION_INDEPENDENT_CODE=ON
+        -D CMAKE_C_COMPILER=${openjph_CMAKE_C_COMPILER}
+        -D CMAKE_CXX_COMPILER=${openjph_CMAKE_CXX_COMPILER}
+    )
+
+# Set some things up that we'll need for a subsequent find_package to work
+set (openjph_ROOT ${openjph_LOCAL_INSTALL_DIR})
+set (openjph_VERSION ${openjph_BUILD_VERSION})
+
+# Signal to caller that we need to find again at the installed location
+set (openjph_REFIND TRUE)
+set (openjph_REFIND_VERSION ${openjph_BUILD_VERSION})
+set (openjph_REFIND_ARGS CONFIG)
+
+if (openjph_BUILD_SHARED_LIBS)
+    install_local_dependency_libs (openjph openjph)
+endif ()

--- a/src/jpeg2000.imageio/jpeg2000input.cpp
+++ b/src/jpeg2000.imageio/jpeg2000input.cpp
@@ -396,7 +396,11 @@ Jpeg2000Input::ojph_read_image()
         = clamped_mult64(clamped_mult64(uint64_t(w), uint64_t(h)),
                          clamped_mult64(uint64_t(ch), uint64_t(buffer_bpp)));
     m_buf.resize(bufsize);
-    codestream.create();
+    try {
+        codestream.create();
+    } catch (const std::runtime_error& e) {
+        errorfmt("openjph exception {}", e.what());
+    }
 
     int file_bit_depth = siz.get_bit_depth(0);  // Assuming RGBA are the same.
 
@@ -406,7 +410,13 @@ Jpeg2000Input::ojph_read_image()
         for (int c = 0; c < ch; ++c)
             for (int i = 0; i < h; ++i) {
                 ojph::ui32 comp_num;
-                ojph::line_buf* line = codestream.pull(comp_num);
+                ojph::line_buf* line = nullptr;
+                try {
+                    line = codestream.pull(comp_num);
+                } catch (const std::runtime_error& e) {
+                    errorfmt("openjph exception {}", e.what());
+                }
+
                 const ojph::si32* sp = line->i32;
                 OIIO_DASSERT(int(comp_num) == c);
                 if (m_spec.format == TypeDesc::UCHAR) {
@@ -430,7 +440,13 @@ Jpeg2000Input::ojph_read_image()
         for (int i = 0; i < h; ++i) {
             for (int c = 0; c < ch; ++c) {
                 ojph::ui32 comp_num;
-                ojph::line_buf* line = codestream.pull(comp_num);
+                ojph::line_buf* line = nullptr;
+                try {
+                    line = codestream.pull(comp_num);
+                } catch (const std::runtime_error& e) {
+                    errorfmt("openjph exception {}", e.what());
+                }
+
                 const ojph::si32* sp = line->i32;
                 OIIO_DASSERT(int(comp_num) == c);
                 if (m_spec.format == TypeDesc::UCHAR) {


### PR DESCRIPTION
Add scripts for openjph auto-build when not found (and OpenImageIO_BUILD_MISSING_DEPS specifies it, or "all"). Build openjph 0.30.1 when missing. 

Since we can build it when missing, take away the various missing openjph allowances from our CI; auto-build when needed for all variants.

More thorough exception catching for openjph in our jpeg2000input.cpp.

When I compile openjph with clang (including icx), I get some runtime exceptions.  Not when I build it with gcc! I don't have the time or inclination to investigate why, so for our CI, rig it to build openjph with gcc even when I'm building OIIO with clang/icx.
