### PR TITLE
api(deepdata): widen merge_deep_pixels srcpixel to int64_t

### DIFF
--- a/src/include/OpenImageIO/deepdata.h
+++ b/src/include/OpenImageIO/deepdata.h
@@ -188,7 +188,13 @@ public:
     /// Merge the samples of `src`'s pixel into this `DeepData`'s pixel.
     /// Return `true` if ok, `false` if the operation could not be
     /// performed.
+    void merge_deep_pixels(int64_t pixel, const DeepData& src,
+                           int64_t srcpixel);
+
+#ifdef OIIO_INTERNAL
+    // DEPRECATED(3.2): use the version with int64_t
     void merge_deep_pixels(int64_t pixel, const DeepData& src, int srcpixel);
+#endif
 
     /// Return the z depth at which the pixel reaches full opacity.
     float opaque_z(int64_t pixel) const;

--- a/src/libOpenImageIO/deepdata.cpp
+++ b/src/libOpenImageIO/deepdata.cpp
@@ -1167,7 +1167,8 @@ DeepData::merge_overlaps(int64_t pixel)
 
 
 void
-DeepData::merge_deep_pixels(int64_t pixel, const DeepData& src, int srcpixel)
+DeepData::merge_deep_pixels(int64_t pixel, const DeepData& src,
+                            int64_t srcpixel)
 {
     int srcsamples = src.samples(srcpixel);
     if (srcsamples == 0)
@@ -1201,6 +1202,15 @@ DeepData::merge_deep_pixels(int64_t pixel, const DeepData& src, int srcpixel)
 
     // Now merge the overlaps
     merge_overlaps(pixel);
+}
+
+
+
+// DEPRECATED(3.2): use the version with int64_t
+void
+DeepData::merge_deep_pixels(int64_t pixel, const DeepData& src, int srcpixel)
+{
+    merge_deep_pixels(pixel, src, int64_t(srcpixel));
 }
 
 

--- a/src/python/py_deepdata.cpp
+++ b/src/python/py_deepdata.cpp
@@ -8,7 +8,7 @@ namespace PyOpenImageIO {
 
 
 void
-DeepData_init(DeepData& dd, int npix, int nchan, py::object py_channeltypes,
+DeepData_init(DeepData& dd, int64_t npix, int nchan, py::object py_channeltypes,
               py::object py_channelnames)
 {
     std::vector<TypeDesc> chantypes;
@@ -31,7 +31,7 @@ DeepData_init_spec(DeepData& dd, const ImageSpec& spec)
 
 
 void
-DeepData_set_nsamples(DeepData& dd, int pixel, int nsamples)
+DeepData_set_nsamples(DeepData& dd, int64_t pixel, int nsamples)
 {
     dd.set_samples(pixel, uint32_t(nsamples));
 }
@@ -39,8 +39,8 @@ DeepData_set_nsamples(DeepData& dd, int pixel, int nsamples)
 
 
 void
-DeepData_set_deep_value_float(DeepData& dd, int pixel, int channel, int sample,
-                              float value)
+DeepData_set_deep_value_float(DeepData& dd, int64_t pixel, int channel,
+                              int sample, float value)
 {
     dd.set_deep_value(pixel, channel, sample, value);
 }
@@ -48,10 +48,22 @@ DeepData_set_deep_value_float(DeepData& dd, int pixel, int channel, int sample,
 
 
 void
-DeepData_set_deep_value_uint(DeepData& dd, int pixel, int channel, int sample,
-                             uint32_t value)
+DeepData_set_deep_value_uint(DeepData& dd, int64_t pixel, int channel,
+                             int sample, uint32_t value)
 {
     dd.set_deep_value(pixel, channel, sample, value);
+}
+
+
+
+// merge_deep_pixels is overloaded: the public int64_t version and an
+// internal-only int version (DEPRECATED(3.2)) which is kept for ABI.
+// To avoid ambiguity, wrap it to specify the int64_t version.
+void
+DeepData_merge_deep_pixels(DeepData& dd, int64_t pixel, const DeepData& src,
+                           int64_t srcpixel)
+{
+    dd.merge_deep_pixels(pixel, src, srcpixel);
 }
 
 
@@ -93,12 +105,14 @@ declare_deepdata(py::module& m)
 
         .def(
             "samples",
-            [](const DeepData& dd, int pixel) { return (int)dd.samples(pixel); },
+            [](const DeepData& dd, int64_t pixel) {
+                return (int)dd.samples(pixel);
+            },
             "pixel"_a)
         .def("set_samples", &DeepData::set_samples, "pixel"_a, "nsamples"_a)
         .def(
             "capacity",
-            [](const DeepData& dd, int pixel) {
+            [](const DeepData& dd, int64_t pixel) {
                 return (int)dd.capacity(pixel);
             },
             "pixel"_a)
@@ -129,7 +143,7 @@ declare_deepdata(py::module& m)
         .def("split", &DeepData::split, "pixel"_a, "depth"_a)
         .def("sort", &DeepData::sort, "pixel"_a)
         .def("merge_overlaps", &DeepData::merge_overlaps, "pixel"_a)
-        .def("merge_deep_pixels", &DeepData::merge_deep_pixels, "pixel"_a,
+        .def("merge_deep_pixels", &DeepData_merge_deep_pixels, "pixel"_a,
              "src"_a, "srcpixel"_a)
         .def("occlusion_cull", &DeepData::occlusion_cull, "pixel"_a)
         .def("opaque_z", &DeepData::opaque_z, "pixel"_a);


### PR DESCRIPTION
### Description
To avoid breaking ABI, the old int overload is kept, but its declaration is hidden behind `#ifdef OIIO_INTERNAL`. Downstream code only sees the int64_t version, but old binaries still work. The forwarding wrapper handles it until the next first-digit version changes.

Also, the Python binding is adjusted using a wrapper to resolve the overload ambiguity. While adding the wrapper, I noticed other bindings still took `int pixel`, so widened them to `int64_t` for consistency.

Follow-up to #2363
Fixes #5242

### Tests
N/A

### Checklist:

- [x] **I have read the guidelines** on [contributions](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md) and [code review procedures](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/CodeReview.md).
- [x] **I have read the [Policy on AI Coding Assistants](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/AI_Policy.md)**
  and if I used AI coding assistants, I have an `Assisted-by: TOOL / MODEL`
  line in the pull request description above.
- [ ] **(N/A)** **I have updated the documentation** if my PR adds features or changes
  behavior.
- [ ] **(N/A)** **I am sure that this PR's changes are tested in the testsuite**.
- [x] **I have run and passed the testsuite in CI** *before* submitting the
  PR, by pushing the changes to my fork and seeing that the automated CI
  passed there. (Exceptions: If most tests pass and you can't figure out why
  the remaining ones fail, it's ok to submit the PR and ask for help. Or if
  any failures seem entirely unrelated to your change; sometimes things break
  on the GitHub runners.)
- [x] **My code follows the prevailing code style of this project** and I
  fixed any problems reported by the clang-format CI test.
- [x] If I added or modified a public C++ API call, I have also amended the
  corresponding Python bindings. If altering ImageBufAlgo functions, I also
  exposed the new functionality as oiiotool options.
