### PR TITLE
api(deepdata): change merge_deep_pixels return type, add OIIO_NODISCARD_ERROR

### DIFF
--- a/src/include/OpenImageIO/deepdata.h
+++ b/src/include/OpenImageIO/deepdata.h
@@ -158,14 +158,16 @@ public:
     /// Copy a deep sample from `src` to this `DeepData`. They must have the
     /// same channel layout. Return `true` if ok, `false` if the operation
     /// could not be performed.
-    bool copy_deep_sample(int64_t pixel, int sample, const DeepData& src,
-                          int64_t srcpixel, int srcsample);
+    OIIO_NODISCARD_ERROR bool copy_deep_sample(int64_t pixel, int sample,
+                                               const DeepData& src,
+                                               int64_t srcpixel, int srcsample);
 
     /// Copy an entire deep pixel from `src` to this `DeepData`, completely
     /// replacing any pixel data for that pixel. They must have the same
     /// channel layout. Return `true` if ok, `false` if the operation could
     /// not be performed.
-    bool copy_deep_pixel(int64_t pixel, const DeepData& src, int64_t srcpixel);
+    OIIO_NODISCARD_ERROR bool
+    copy_deep_pixel(int64_t pixel, const DeepData& src, int64_t srcpixel);
 
     /// Split all samples of that pixel at the given depth zsplit. Samples
     /// that span z (i.e. z < zsplit < zback) will be split into two samples
@@ -188,8 +190,8 @@ public:
     /// Merge the samples of `src`'s pixel into this `DeepData`'s pixel.
     /// Return `true` if ok, `false` if the operation could not be
     /// performed.
-    void merge_deep_pixels(int64_t pixel, const DeepData& src,
-                           int64_t srcpixel);
+    OIIO_NODISCARD_ERROR bool
+    merge_deep_pixels(int64_t pixel, const DeepData& src, int64_t srcpixel);
 
 #ifdef OIIO_INTERNAL
     // DEPRECATED(3.2): use the version with int64_t

--- a/src/libOpenImageIO/deepdata.cpp
+++ b/src/libOpenImageIO/deepdata.cpp
@@ -209,7 +209,8 @@ DeepData::DeepData(const DeepData& src, cspan<TypeDesc> channeltypes)
     set_all_samples(src.all_samples());
     // Copy the data from src to this
     for (int64_t p = 0, np = pixels(); p < np; ++p) {
-        copy_deep_pixel(p, src, p);
+        bool ok = copy_deep_pixel(p, src, p);
+        OIIO_CONTRACT_ASSERT(ok);
     }
 }
 
@@ -974,7 +975,9 @@ DeepData::split(int64_t pixel, float depth)
             // See https://openexr.com/en/latest/InterpretingDeepPixels.html
             splits_occurred = true;
             insert_samples(pixel, s + 1);
-            copy_deep_sample(pixel, s + 1, *this, pixel, s);
+            // copy_deep_sample at this point with these arguments likely returns true
+            bool ok = copy_deep_sample(pixel, s + 1, *this, pixel, s);
+            OIIO_CONTRACT_ASSERT(ok);
             set_deep_value(pixel, zbackchan, s, depth);
             set_deep_value(pixel, zchan, s + 1, depth);
             // We have to proceed in two passes, since we may reuse the
@@ -1166,26 +1169,28 @@ DeepData::merge_overlaps(int64_t pixel)
 
 
 
-void
+bool
 DeepData::merge_deep_pixels(int64_t pixel, const DeepData& src,
                             int64_t srcpixel)
 {
     int srcsamples = src.samples(srcpixel);
     if (srcsamples == 0)
-        return;  // No samples to merge
+        return true;  // No samples to merge
     int dstsamples = samples(pixel);
     if (dstsamples == 0) {
         // Nothing in our pixel yet, so just copy src's pixel
-        copy_deep_pixel(pixel, src, srcpixel);
-        return;
+        return copy_deep_pixel(pixel, src, srcpixel);
     }
 
     // Need to merge the pixels
 
     // First, merge all of src's samples into our pixel
     set_samples(pixel, dstsamples + srcsamples);
-    for (int i = 0; i < srcsamples; ++i)
-        copy_deep_sample(pixel, dstsamples + i, src, srcpixel, i);
+    for (int i = 0; i < srcsamples; ++i) {
+        bool ok = copy_deep_sample(pixel, dstsamples + i, src, srcpixel, i);
+        if (!ok)
+            return false;
+    }
 
     // Now ALL the samples from both images are in our pixel.
     // Mutually split the samples against each other.
@@ -1202,6 +1207,7 @@ DeepData::merge_deep_pixels(int64_t pixel, const DeepData& src,
 
     // Now merge the overlaps
     merge_overlaps(pixel);
+    return true;
 }
 
 
@@ -1210,7 +1216,9 @@ DeepData::merge_deep_pixels(int64_t pixel, const DeepData& src,
 void
 DeepData::merge_deep_pixels(int64_t pixel, const DeepData& src, int srcpixel)
 {
-    merge_deep_pixels(pixel, src, int64_t(srcpixel));
+    // Deprecated overload stays void, so discard the bool status from
+    // the int64_t version.
+    (void)merge_deep_pixels(pixel, src, int64_t(srcpixel));
 }
 
 

--- a/src/libOpenImageIO/imagebufalgo_deep.cpp
+++ b/src/libOpenImageIO/imagebufalgo_deep.cpp
@@ -338,7 +338,13 @@ ImageBufAlgo::deep_merge(ImageBuf& dst, const ImageBuf& A, const ImageBuf& B,
                 int Bpixel   = B.pixelindex(x, y, z, true);
                 OIIO_DASSERT(dstpixel >= 0);
                 // OIIO_UNUSED_OK int oldcap = dstdd.capacity (dstpixel);
-                dstdd.merge_deep_pixels(dstpixel, Bdd, Bpixel);
+
+                // Cast to int64_t so this calls the bool overload,
+                // not the DEPRECATED(3.2) void one.
+                bool ok_dd = dstdd.merge_deep_pixels(int64_t(dstpixel), Bdd,
+                                                     int64_t(Bpixel));
+                if (!ok_dd)
+                    return false;
                 // OIIO_DASSERT (oldcap == dstdd.capacity(dstpixel) &&
                 //          "Broken: we did not preallocate enough capacity");
                 if (occlusion_cull)
@@ -402,7 +408,9 @@ ImageBufAlgo::deep_holdout(ImageBuf& dst, const ImageBuf& src,
         if (srcpixel < 0)
             continue;  // Nothing in this pixel
         int dstpixel = dst.pixelindex(x, y, z, true);
-        dstdd.copy_deep_pixel(dstpixel, srcdd, srcpixel);
+        bool ok      = dstdd.copy_deep_pixel(dstpixel, srcdd, srcpixel);
+        if (!ok)
+            return false;
         int threshpixel = thresh.pixelindex(x, y, z, true);
         if (threshpixel < 0)
             continue;  // No threshold mask for this pixel

--- a/src/python/py_deepdata.cpp
+++ b/src/python/py_deepdata.cpp
@@ -59,11 +59,11 @@ DeepData_set_deep_value_uint(DeepData& dd, int64_t pixel, int channel,
 // merge_deep_pixels is overloaded: the public int64_t version and an
 // internal-only int version (DEPRECATED(3.2)) which is kept for ABI.
 // To avoid ambiguity, wrap it to specify the int64_t version.
-void
+bool
 DeepData_merge_deep_pixels(DeepData& dd, int64_t pixel, const DeepData& src,
                            int64_t srcpixel)
 {
-    dd.merge_deep_pixels(pixel, src, srcpixel);
+    return dd.merge_deep_pixels(pixel, src, srcpixel);
 }
 
 


### PR DESCRIPTION
`merge_deep_pixels()` calls `copy_deep_sample()`, which has an error status return, so change `merge_deep_pixels()`'s return type from void to bool.
    
For OIIO_NODISCARD_ERROR, all internal calls that previously ignored return values are handled:
 - OIIO_CONTRACT_ASSERT where the call can't fail in context, or the caller is a void function or a constructor.
 - `return false` where the caller already returns a bool error state.
 - `(void)` cast for the deprecated internal overload.
    
Follow-up to #5252
Part of #4781

### Tests
N/A

### Checklist:

- [x] **I have read the guidelines** on [contributions](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md) and [code review procedures](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/CodeReview.md).
- [x] **I have read the [Policy on AI Coding Assistants](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/AI_Policy.md)**
  and if I used AI coding assistants, I have an `Assisted-by: TOOL / MODEL`
  line in the pull request description above.
- [ ] **(N/A)** **I have updated the documentation** if my PR adds features or changes
  behavior.
- [ ] **(N/A)** **I am sure that this PR's changes are tested in the testsuite**.
- [x] **I have run and passed the testsuite in CI** *before* submitting the
  PR, by pushing the changes to my fork and seeing that the automated CI
  passed there. (Exceptions: If most tests pass and you can't figure out why
  the remaining ones fail, it's ok to submit the PR and ask for help. Or if
  any failures seem entirely unrelated to your change; sometimes things break
  on the GitHub runners.)
- [x] **My code follows the prevailing code style of this project** and I
  fixed any problems reported by the clang-format CI test.
- [X] If I added or modified a public C++ API call, I have also amended the
  corresponding Python bindings. If altering ImageBufAlgo functions, I also
  exposed the new functionality as oiiotool options.
