### PR TITLE
fix(hdr): Make the HDR reader tolerant to CR in the ASCII header

### DIFF
--- a/src/hdr.imageio/hdrinput.cpp
+++ b/src/hdr.imageio/hdrinput.cpp
@@ -88,6 +88,15 @@ private:
         }
         sv = Strutil::parse_line(sv);
         m_io->seek(pos + sv.size());
+        // Tolerate DOS/Windows CRLF line endings: if the line ends in
+        // "\r\n", drop the '\r' so it collapses to a bare "\n", which is
+        // what the header comparisons below expect. The file pointer was
+        // already advanced past the full "\r\n" above.
+        if (sv.size() >= 2 && sv[sv.size() - 2] == '\r'
+            && sv[sv.size() - 1] == '\n') {
+            buf[sv.size() - 2] = '\n';
+            sv                 = string_view(buf.data(), sv.size() - 1);
+        }
         return sv;
     }
 };


### PR DESCRIPTION
Carelessly written hdr/rgbe files, or correctly written ones that are checked out by git on windows if you're not careful, might use Windows CRLF line endings. Be silently tolerant of that.

Assisted-by: Claude Code / opus-4.8
