### PR TITLE
webp: Improve valid_file to check the header for magic words

### DIFF
--- a/src/webp.imageio/webpinput.cpp
+++ b/src/webp.imageio/webpinput.cpp
@@ -15,6 +15,15 @@ OIIO_PLUGIN_NAMESPACE_BEGIN
 namespace webp_pvt {
 
 
+// Layout of the start of any webp file
+struct WebpHead {
+    char RIFF[4];  // should contain "RIFF"
+    uint32_t file_size;
+    char WEBP[4];  // should contain "WEBP"
+};
+
+
+
 static bool
 webp_exif_payload_has_tiff_header(cspan<uint8_t> exif)
 {
@@ -99,9 +108,12 @@ WebpInput::valid_file(Filesystem::IOProxy* ioproxy) const
     if (!ioproxy || ioproxy->mode() != Filesystem::IOProxy::Mode::Read)
         return false;
 
-    uint8_t header[64] {};
-    const size_t numRead = ioproxy->pread(header, sizeof(header), 0);
-    return WebPGetInfo(header, numRead, nullptr, nullptr);
+    WebpHead head;
+    return ioproxy->pread(&head, sizeof(head), 0) == sizeof(head)
+           && head.RIFF[0] == 'R' && head.RIFF[1] == 'I'  //
+           && head.RIFF[2] == 'F' && head.RIFF[3] == 'F'  //
+           && head.WEBP[0] == 'W' && head.WEBP[1] == 'E'  //
+           && head.WEBP[2] == 'B' && head.WEBP[3] == 'P';
 }
 
 


### PR DESCRIPTION
This is MUCH faster than asking libwebp to open the file!
