### PR TITLE
fix(raw): apply LibRaw memory cap before unpack to prevent OOM

### DIFF
--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -431,6 +431,13 @@ RawInput::open_raw(bool unpack, bool process, const std::string& name,
         return false;
     }
 
+#if LIBRAW_VERSION >= LIBRAW_MAKE_VERSION(0, 21, 0)
+    // Cap LibRaw's internal allocations. This must be set *before* unpack().
+    // Default max is 2048 MB.
+    m_processor->imgdata.rawparams.max_raw_memory_mb
+        = config.get_int_attribute("raw:max_raw_memory_mb", 2048);
+#endif
+
     OIIO_ASSERT(!m_unpacked);
     if (unpack) {
         if ((ret = m_processor->unpack()) != LIBRAW_SUCCESS) {
@@ -469,12 +476,6 @@ RawInput::open_raw(bool unpack, bool process, const std::string& name,
 
     // Output 16 bit images
     m_processor->imgdata.params.output_bps = 16;
-
-#if LIBRAW_VERSION >= LIBRAW_MAKE_VERSION(0, 21, 0)
-    // Exposing max_raw_memory_mb setting. Default max is 2048.
-    m_processor->imgdata.rawparams.max_raw_memory_mb
-        = config.get_int_attribute("raw:max_raw_memory_mb", 2048);
-#endif
 
     // Disable exposure correction (unless config "raw:auto_bright" == 1)
     m_processor->imgdata.params.no_auto_bright


### PR DESCRIPTION
open_raw set imgdata.rawparams.max_raw_memory_mb *after* calling m_processor->unpack(), so LibRaw's allocation cap never protected the unpack step -- which is exactly where LibRaw allocates the raw image buffer. A corrupt raw file claiming huge dimensions could therefore allocate unbounded and OOM (showing up on the fuzzer as a 0-length crash artifact from an out-of-memory trip rather than a normal reproducer).

Move the max_raw_memory_mb assignment to immediately after open_file succeeds, before unpack(), so the cap (default 2048 MB) actually bounds the allocation. LibRaw then fails the file cleanly instead of OOMing.

Assisted-by: Claude Code / Claude Opus 4.8
