### PR TITLE
build(tiff): recommend libtiff 4.5+ for security fixes

### DIFF
--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -92,8 +92,8 @@ checked_find_package (libuhdr
 
 checked_find_package (TIFF REQUIRED
                       VERSION_MIN 4.0
-                      RECOMMEND_MIN 4.2
-                      RECOMMEND_MIN_REASON "4.2 for GPS support")
+                      RECOMMEND_MIN 4.5
+                      RECOMMEND_MIN_REASON "4.2+ for GPS, 4.5+ various security fixes")
 alias_library_if_not_exists (TIFF::TIFF TIFF::tiff)
 
 # JPEG XL


### PR DESCRIPTION
Circular IFD chain loop detection (identified by for CVE-2022-3970) was fixed in libtiff by MR 386
(https://gitlab.com/libtiff/libtiff/-/merge_requests/386), released in libtiff 4.5.0.

Raise the recommended minimum from 4.2 to 4.5 so users on older installations get a build-time advisory. The hard minimum stays at 4.0 (for now) to preserve compatibility.
