### PR TITLE
fix(openexr): Add check_open to exrinput_c

### DIFF
--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -1125,7 +1125,7 @@ OpenEXRInput::seek_subimage(int subimage, int miplevel)
     // if (m_miplevel == 0 && part.nmiplevels > 1)
     //     m_spec.attribute("oiio:miplevels", part.nmiplevels);
 
-    if (!check_open(m_spec, { 0, 1 << 20, 0, 1 << 20, 0, 1 << 16, 0, 1 << 12 }))
+    if (!check_open(m_spec, { 0, 1 << 20, 0, 1 << 20, 0, 1, 0, 1 << 12 }))
         return false;
 
     if (miplevel == 0 && part.levelmode == Imf::ONE_LEVEL) {

--- a/src/openexr.imageio/exrinput_c.cpp
+++ b/src/openexr.imageio/exrinput_c.cpp
@@ -1118,6 +1118,9 @@ OpenEXRCoreInput::seek_subimage(int subimage, int miplevel)
     // if (m_miplevel == 0 && part.nmiplevels > 1)
     //     m_spec.attribute("oiio:miplevels", part.nmiplevels);
 
+    if (!check_open(m_spec, { 0, 1 << 20, 0, 1 << 20, 0, 1, 0, 1 << 12 }))
+        return false;
+
     if (miplevel == 0 && part.levelmode == EXR_TILE_ONE_LEVEL) {
         return true;
     }


### PR DESCRIPTION
Somehow the check_open validation was only in exrinput.cpp (using the old C++ AP), but not exrinput_c.cpp (using the C "Core API").

Also adjust the allowable z resolution to reflect that OpenEXR doesn't support volumetric images. (This was obviously a cut and paste error long ago.)
