### PR TITLE
fix(iff): reject implausible image dimensions before allocating tile buffer

### DIFF
--- a/src/iff.imageio/iffinput.cpp
+++ b/src/iff.imageio/iffinput.cpp
@@ -3,6 +3,8 @@
 // https://github.com/AcademySoftwareFoundation/OpenImageIO
 #include "iff_pvt.h"
 
+#include <OpenImageIO/memory.h>
+
 #include <cmath>
 
 OIIO_PLUGIN_NAMESPACE_BEGIN
@@ -30,7 +32,7 @@ public:
 private:
     std::string m_filename;
     iff_pvt::IffFileHeader m_header;
-    std::vector<uint8_t> m_buf;
+    default_init_vector<uint8_t> m_buf;
 
     uint32_t m_tbmp_start;
 
@@ -607,6 +609,25 @@ IffInput::readimg()
     // seek pos
     // set position tile may be called randomly
     ioseek(m_tbmp_start);
+
+    // The TBHD width/height/channel fields are not otherwise cross-checked
+    // against how much tile data the file actually contains, so a corrupt
+    // header can claim an arbitrarily large image (e.g. 16k x 16k) backed by
+    // only a few hundred bytes of real data. Reject implausible claims
+    // before committing to a potentially huge allocation. RLE can expand at
+    // most 128x (a 2-byte run encodes up to 128 output bytes), so give a
+    // generous bound based on how much tile data remains in the file.
+    uint64_t filesize = uint64_t(ioproxy()->size());
+    uint64_t avail    = filesize > m_tbmp_start ? filesize - m_tbmp_start : 0;
+    uint64_t max_plausible_bytes = (m_header.compression == iff_pvt::RLE)
+                                       ? avail * 128
+                                       : avail;
+    if (m_header.image_bytes() > max_plausible_bytes) {
+        errorfmt(
+            "IFF error: header claims image size {} bytes, implausible for {} bytes of remaining tile data",
+            m_header.image_bytes(), avail);
+        return false;
+    }
 
     // resize buffer
     m_buf.resize(m_header.image_bytes());

--- a/src/iff.imageio/iffinput.cpp
+++ b/src/iff.imageio/iffinput.cpp
@@ -610,13 +610,9 @@ IffInput::readimg()
     // set position tile may be called randomly
     ioseek(m_tbmp_start);
 
-    // The TBHD width/height/channel fields are not otherwise cross-checked
-    // against how much tile data the file actually contains, so a corrupt
-    // header can claim an arbitrarily large image (e.g. 16k x 16k) backed by
-    // only a few hundred bytes of real data. Reject implausible claims
-    // before committing to a potentially huge allocation. RLE can expand at
-    // most 128x (a 2-byte run encodes up to 128 output bytes), so give a
-    // generous bound based on how much tile data remains in the file.
+    // Check that the image size claimed is plausible for the size of the
+    // remainder of the file. RLE can expand at most 128x (a 2-byte run
+    // encodes up to 128 output bytes).
     uint64_t filesize = uint64_t(ioproxy()->size());
     uint64_t avail    = filesize > m_tbmp_start ? filesize - m_tbmp_start : 0;
     uint64_t max_plausible_bytes = (m_header.compression == iff_pvt::RLE)


### PR DESCRIPTION
TBHD width/height/channel fields were never cross-checked against how much tile data the file actually contains, so a corrupt header could claim an arbitrarily large image (e.g. 16k x 16k) backed by only a few hundred bytes of real data. readimg() would then resize() a multi-gigabyte buffer for a tiny malformed file, hanging (or very slowly succeeding) instead of failing -- a resource-exhaustion DoS on untrusted input, found via fuzzing.

Bound the claimed image size against how much tile data remains in the file, generously allowing for RLE's worst-case 128x expansion ratio, and fail fast if it's implausible.

Assisted-by: Claude Code / claude-sonnet-5

