### PR TITLE
fix(dds): clamp pixel memcpy to sizeof(uint32_t) to prevent stack overflow

### DIFF
--- a/src/dds.imageio/ddsinput.cpp
+++ b/src/dds.imageio/ddsinput.cpp
@@ -997,7 +997,8 @@ DDSInput::internal_readimg(unsigned char* dst, size_t w, size_t h, size_t d)
                 size_t k = (z * h * w + y * w) * m_spec.nchannels;
                 for (size_t x = 0; x < w; x++, k += m_spec.nchannels) {
                     uint32_t pixel = 0;
-                    memcpy(&pixel, tmp.get() + x * m_Bpp, m_Bpp);
+                    memcpy(&pixel, tmp.get() + x * m_Bpp,
+                           std::min(m_Bpp, (int)sizeof(pixel)));
                     for (int ch = 0; ch < m_spec.nchannels; ++ch) {
                         dst[k + ch]
                             = bit_range_convert((pixel & m_dds.fmt.masks[ch])


### PR DESCRIPTION
The mask-based uncompressed decode path copies m_Bpp bytes into a uint32_t pixel variable. m_Bpp is validated up to 16 (for 128-bit DXGI formats), but the legacy fmt.masks[] are uint32_t and can only address 32 bits. A corrupt file with m_Bpp > 4 caused a stack-buffer-overflow. Clamp the copy to sizeof(pixel) = 4 bytes, which is all the masks can reference anyway.

Assisted-by: Claude Code / claude-sonnet-4-6
