### PR TITLE
fix(ico,png): avoid leaking error string across png_chunk_error longjmp

### DIFF
--- a/src/ico.imageio/icoinput.cpp
+++ b/src/ico.imageio/icoinput.cpp
@@ -84,7 +84,13 @@ private:
         OIIO_DASSERT(icoinput);
         if (!icoinput->ioread(data, length)) {
             icoinput->m_err = true;
-            png_chunk_error(png_ptr, icoinput->geterror(false).c_str());
+            // png_chunk_error() does not return -- it longjmps back to
+            // libpng's setjmp point, which skips C++ destructors. Copy the
+            // message into a plain stack buffer so no heap-allocated
+            // std::string is left alive (and leaked) across the longjmp.
+            char msg[256];
+            Strutil::safe_strcpy(msg, icoinput->geterror(false), sizeof(msg));
+            png_chunk_error(png_ptr, msg);
         }
     }
 };

--- a/src/png.imageio/pnginput.cpp
+++ b/src/png.imageio/pnginput.cpp
@@ -92,7 +92,13 @@ private:
         OIIO_DASSERT(pnginput);
         if (!pnginput->ioread(data, length)) {
             pnginput->m_err = true;
-            png_chunk_error(png_ptr, pnginput->geterror(false).c_str());
+            // png_chunk_error() does not return -- it longjmps back to
+            // libpng's setjmp point, which skips C++ destructors. Copy the
+            // message into a plain stack buffer so no heap-allocated
+            // std::string is left alive (and leaked) across the longjmp.
+            char msg[256];
+            Strutil::safe_strcpy(msg, pnginput->geterror(false), sizeof(msg));
+            png_chunk_error(png_ptr, msg);
         }
     }
 


### PR DESCRIPTION
PngReadCallback passed input->geterror(false).c_str() to png_chunk_error() when a PNG read failed. png_chunk_error() does not return -- it longjmp's back to libpng's setjmp point, which skips C++ destructors, so the temporary std::string returned by geterror() was never freed. The fuzzer surfaced this as a small, intermittent leak (a few KB across hundreds of thousands of runs).

Copy the message into a plain stack buffer (no destructor) before calling png_chunk_error, so nothing heap-allocated is alive across the longjmp.

Assisted-by: Claude Code / Claude Opus 4.8
