### PR TITLE
fix(gif): avoid int32 overflow in palette-split pixel-count math

### DIFF
--- a/src/gif.imageio/gif.h
+++ b/src/gif.imageio/gif.h
@@ -340,7 +340,11 @@ void GifSplitPalette(uint8_t* image, int numPixels, int firstElt, int lastElt, i
     if(bRange > gRange) splitCom = 2;
     if(rRange > bRange && rRange > gRange) splitCom = 0;
 
-    int subPixelsA = numPixels * (splitElt - firstElt) / (lastElt - firstElt);
+    // numPixels*(splitElt-firstElt) can overflow int32 for images beyond
+    // about 16.9M pixels (e.g. 4117x4117); do the multiply in 64 bits. The
+    // final quotient is always <= numPixels, so it safely narrows back.
+    int subPixelsA = (int)((int64_t)numPixels * (splitElt - firstElt)
+                           / (lastElt - firstElt));
     int subPixelsB = numPixels-subPixelsA;
 
     GifPartitionByMedian(image, 0, numPixels, splitCom, subPixelsA);


### PR DESCRIPTION
## Summary
- `GifSplitPalette()` computed `numPixels * (splitElt - firstElt)` as a 32-bit `int` before dividing. For any image over roughly 16.9M pixels (e.g. 4117x4117), that intermediate multiplication overflows `INT_MAX` (UBSan-detected undefined behavior); in practice it produced a bogus split count that could drive later indexing into `image` out of its bounds.
- Do the multiply in 64 bits and narrow back afterward -- the quotient is always `<= numPixels`, so the narrowing itself is safe.

## Test plan
- [x] Verified a legitimate 4200x4200 constant-color image now writes to GIF cleanly under ASan/UBSan (previously triggered the signed-overflow UB at this line).
- [x] `ctest -R gif` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
