### PR TITLE
fix(tiff): avoid use-after-scope in multithreaded scanline reads

### DIFF
--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -2232,7 +2232,6 @@ TIFFInput::read_native_scanlines(int subimage, int miplevel, int ybegin,
     // Make room for, and read the raw (still compressed) strips. As each
     // one is read, kick off the decompress and any other extras, to execute
     // in parallel.
-    task_set tasks(pool);
     bool ok        = true;  // failed compression will stash a false here
     int y          = ybegin;
     size_t ystride = m_spec.scanline_bytes(true);
@@ -2246,6 +2245,12 @@ TIFFInput::read_native_scanlines(int subimage, int miplevel, int ybegin,
     std::unique_ptr<char[]> compressed_scratch;
     std::unique_ptr<char[]> separate_tmp(
         m_separate ? new char[strip_bytes * nstrips * planes] : nullptr);
+    // Declare `tasks` last among the locals the queued lambdas capture (`ok`,
+    // `compressed_scratch`, and the buffers they point into). Locals are
+    // destroyed in reverse declaration order, and ~task_set() waits for all
+    // queued work; declaring it here guarantees that wait happens while those
+    // captured objects are still alive, even on the early-return paths below.
+    task_set tasks(pool);
 
     if (read_raw_strips) {
         // Make room for, and read the raw (still compressed) strips. As each
@@ -2330,13 +2335,17 @@ TIFFInput::read_native_scanlines(int subimage, int miplevel, int ybegin,
     // If we have left over scanlines, read them serially
     m_next_scanline = y - m_spec.y;
     for (; y < yend; ++y) {
-        bool ok = read_native_scanline_locked(subimage, miplevel, y, data);
-        if (!ok)
-            return false;
+        // Note: a false return here leaves the loop (and function) before the
+        // explicit tasks.wait() below; ~task_set() still waits, and the
+        // declaration order above ensures the captured locals outlive it.
+        if (!read_native_scanline_locked(subimage, miplevel, y, data)) {
+            ok = false;
+            break;
+        }
         data = data.subspan(ystride);
     }
     tasks.wait();
-    return true;
+    return ok;
 }
 
 

--- a/src/tiff.imageio/tiffinput.cpp
+++ b/src/tiff.imageio/tiffinput.cpp
@@ -2245,11 +2245,8 @@ TIFFInput::read_native_scanlines(int subimage, int miplevel, int ybegin,
     std::unique_ptr<char[]> compressed_scratch;
     std::unique_ptr<char[]> separate_tmp(
         m_separate ? new char[strip_bytes * nstrips * planes] : nullptr);
-    // Declare `tasks` last among the locals the queued lambdas capture (`ok`,
-    // `compressed_scratch`, and the buffers they point into). Locals are
-    // destroyed in reverse declaration order, and ~task_set() waits for all
-    // queued work; declaring it here guarantees that wait happens while those
-    // captured objects are still alive, even on the early-return paths below.
+    // It's important to declare tasks last so everything else captured by the
+    // lambda will survive the ~task_set() wait for the queued work.
     task_set tasks(pool);
 
     if (read_raw_strips) {
@@ -2335,12 +2332,11 @@ TIFFInput::read_native_scanlines(int subimage, int miplevel, int ybegin,
     // If we have left over scanlines, read them serially
     m_next_scanline = y - m_spec.y;
     for (; y < yend; ++y) {
-        // Note: a false return here leaves the loop (and function) before the
-        // explicit tasks.wait() below; ~task_set() still waits, and the
-        // declaration order above ensures the captured locals outlive it.
         if (!read_native_scanline_locked(subimage, miplevel, y, data)) {
             ok = false;
             break;
+            // Note: it's important to break and not return here, so that we
+            // don't bypass the tasks.wait().
         }
         data = data.subspan(ystride);
     }


### PR DESCRIPTION
read_native_scanlines declared task_set before the locals its queued decompression lambdas capture (ok, compressed_scratch). On the leftover-scanline early-return path those locals were destroyed before ~task_set() waited for the queued work, so workers could write through a dangling ok and hand a freed compressed buffer to zlib.

Declare task_set after the captured locals so its destructor wait runs while they are still alive, and propagate async decompression failures via return ok instead of unconditionally returning true.

Assisted-by: Claude Code / opus-4.8
