### PR TITLE
fix(python): update getattribute one-arg test for unified bindings

### DIFF
--- a/testsuite/python-oiio/ref/out.txt
+++ b/testsuite/python-oiio/ref/out.txt
@@ -51,8 +51,8 @@ Testing global get_*_attribute defaults:
 Testing getattribute() with TypeUnknown:
   getattribute(missing, TypeUnknown): None
 
-Testing getattribute() one-arg (pybind default):
-  one-arg: TypeError
+Testing getattribute() one-arg (default type):
+  one-arg: no exception
 
 Testing attribute() type error:
   attribute bad type: TypeError

--- a/testsuite/python-oiio/src/test_oiio.py
+++ b/testsuite/python-oiio/src/test_oiio.py
@@ -119,7 +119,7 @@ try:
            oiio.getattribute ("not_a_real_attr", oiio.TypeUnknown))
     print ("")
 
-    print ("Testing getattribute() one-arg (pybind default):")
+    print ("Testing getattribute() one-arg (default type):")
     try:
         oiio.getattribute ("not_a_real_attr")
         print ("  one-arg: no exception")


### PR DESCRIPTION
PRs #5260 and #5254 interact: #5254 exposed the default type arg on the module getattribute (`"type"_a = TypeUnknown`), so a one-arg call now returns None instead of raising TypeError. #5260's test still expected the old pybind behavior. Update the test and ref to the intended new behavior.

Assisted-by: Claude Code / Claude Opus 4.8
