### PR TITLE
build(cmake): guard libtiff's missing Deflate target

### DIFF
--- a/src/cmake/Config.cmake.in
+++ b/src/cmake/Config.cmake.in
@@ -20,6 +20,16 @@ if (NOT @BUILD_SHARED_LIBS@)
     # This is required in static library builds, as e.g. PNG::PNG appears among
     # INTERFACE_LINK_LIBRARIES. If the project does not know about PNG target, it will cause
     # configuration error about unknown targets being linked in.
+    # Static libtiff configs may reference this target without importing it.
+    # https://gitlab.com/libtiff/libtiff/-/work_items/871
+    if (NOT TARGET Deflate::Deflate)
+        find_package (libdeflate CONFIG QUIET)
+        if (TARGET libdeflate::libdeflate_static)
+            add_library (Deflate::Deflate ALIAS libdeflate::libdeflate_static)
+        elseif (TARGET libdeflate::libdeflate_shared)
+            add_library (Deflate::Deflate ALIAS libdeflate::libdeflate_shared)
+        endif ()
+    endif ()
     find_dependency(TIFF)
     find_dependency(OpenColorIO)
     if (@JPEG_FOUND@)

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -91,7 +91,7 @@ checked_find_package (libuhdr
                       VERSION_MIN 1.3)
 
 # Static libtiff configs may reference this target without importing it.
-# https://github.com/AcademySoftwareFoundation/OpenImageIO/issues/4439
+# https://gitlab.com/libtiff/libtiff/-/work_items/871
 if (NOT TARGET Deflate::Deflate)
     find_package (libdeflate CONFIG QUIET)
     alias_library_if_not_exists (Deflate::Deflate libdeflate::libdeflate_static)

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -90,6 +90,14 @@ endif ()
 checked_find_package (libuhdr
                       VERSION_MIN 1.3)
 
+# Static libtiff configs may reference this target without importing it.
+# https://github.com/AcademySoftwareFoundation/OpenImageIO/issues/4439
+if (NOT TARGET Deflate::Deflate)
+    find_package (libdeflate CONFIG QUIET)
+    alias_library_if_not_exists (Deflate::Deflate libdeflate::libdeflate_static)
+    alias_library_if_not_exists (Deflate::Deflate libdeflate::libdeflate_shared)
+endif ()
+
 checked_find_package (TIFF REQUIRED
                       VERSION_MIN 4.0
                       RECOMMEND_MIN 4.5

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -90,10 +90,14 @@ endif ()
 checked_find_package (libuhdr
                       VERSION_MIN 1.3)
 
-# Static libtiff configs may reference this target without importing it.
-# https://gitlab.com/libtiff/libtiff/-/work_items/871
+# Static libtiff configs may reference Deflate::Deflate without importing it
+# (https://gitlab.com/libtiff/libtiff/-/work_items/871), so libdeflate must be
+# located before TIFF discovery. In particular, a previously auto-built static
+# TIFF rediscovered from the local deps cache needs this; the libdeflate found
+# during build_TIFF.cmake does not carry over to later reconfigures.
 if (NOT TARGET Deflate::Deflate)
-    find_package (libdeflate CONFIG QUIET)
+    checked_find_package (libdeflate
+                          VERSION_MIN 1.18)
     alias_library_if_not_exists (Deflate::Deflate libdeflate::libdeflate_static)
     alias_library_if_not_exists (Deflate::Deflate libdeflate::libdeflate_shared)
 endif ()


### PR DESCRIPTION
## Description

Fixes configuration failures when OIIO finds a previously autobuilt static libtiff package whose exported `TIFF::tiff` target references `Deflate::Deflate` without importing or defining that target.

Before TIFF discovery, this adds a narrow compatibility guard that quietly loads libdeflate's config package and aliases its static or shared target as `Deflate::Deflate` when necessary.

Fixes #4439.

## Root cause

libtiff links static TIFF builds against `Deflate::Deflate`, causing the installed `TIFF::tiff` target to export `$<LINK_ONLY:Deflate::Deflate>`.

However, libtiff's installed `tiff-config.cmake` loads that exported target without importing its dependencies. The corresponding upstream template still contains `# TODO: import dependencies`.

Upstream report: https://gitlab.com/libtiff/libtiff/-/work_items/871

OIIO encounters this during `checked_find_package(TIFF)`. CMake's `FindTIFF` module first attempts libtiff's config package, which exposes the malformed export. This is not specific to CMake 4.3: I reproduced it with CMake 3.29.6 and 4.3.1. Issue #4439 likewise originally reported CMake 3.29+ on Linux and macOS rather than a Homebrew-specific failure.

## Why fix this in OIIO?

The underlying package-export defect belongs in libtiff, but an upstream fix will not repair already-installed libtiff releases or OIIO dependency caches. OIIO also builds the affected static libtiff configuration itself. 

This also breaks OIIO's ability to self-build (some) dependencies that [in]directly depend on libtiff or deflate. (Not for any dependencies for which we currently have self-building recipes so far; but this has blocked me in the past from submitting PRs for some of the more complex (sub)dependencies (libheif comes to mind; maybe jxl...? can't remember, it was more than a year ago when I last looked into this)

The guard is intentionally defensive:

- it runs only when `Deflate::Deflate` does not already exist;
- libdeflate is searched quietly in config mode;
- it does not make libdeflate a new required dependency;
- it does not change TIFF's config-mode or module-mode selection;
- it does not hide an actually missing library if a TIFF export requires one.

## Testing

Tested on:

- macOS 26.3.1, Apple Silicon
- AppleClang 21.0.0
- Homebrew 6.0.9
- libtiff 4.7.1
- libdeflate 1.23
- CMake 4.3.1 and 3.29.6

Verification performed:

- reproduced the original generation failure before the change;
- fresh config-mode configure with CMake 4.3.1 against the defective static TIFF export;
- build completed successfully: 126/126 targets;
- module-mode configure with Homebrew libtiff and libdeflate discovery explicitly disabled;
- configure with CMake 3.29.6 against the same defective static TIFF export.

Steps taken to verify:

- Built the wheel twice with the same persistent `SKBUILD_BUILD_DIR`, `IGNORE_HOMEBREWED_DEPS=1`, and without forcing a local TIFF rebuild. The first build autobuilt static TIFF 4.7.1 and libdeflate 1.23; the second found the cached TIFF package and completed without the previous `Deflate::Deflate` error.


### No robots worth speaking of were harmed in the making of this PR

Assisted-by: Codex / GPT-5

Codex was used to trace the CMake package-discovery chain, inspect the libtiff exports, reproduce the failure, prepare the compatibility guard, and run the verification described above.