### PR TITLE
raw: pass the bad pixels param to libraw

### DIFF
--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -2333,7 +2333,11 @@ options are supported:
        initialization. This populates the image attributes which depend on the
        pixel values.
        (Default: 0)
-
+   * - ``raw:bad_pixels``
+     - string
+     - A path to a file containing the list of bad pixels in libraw format:
+       a plain text where each line describes a single bad pixel using three
+       numbers separated by whitespace for the column, row and UNIX timestamp.
 |
 
 .. _sec-bundledplugins-rla:

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -417,6 +417,13 @@ RawInput::open_raw(bool unpack, bool process, const std::string& name,
     m_processor->imgdata.params.user_flip
         = config.get_int_attribute("raw:user_flip", -1);
 
+    const ParamValue* bad_pixels_attr = config.find_attribute("raw:bad_pixels",
+                                                              TypeDesc::STRING);
+    if (bad_pixels_attr) {
+        m_processor->imgdata.params.bad_pixels
+            = (char*)bad_pixels_attr->get_ustring().c_str();
+    }
+
 #ifdef _WIN32
     // Convert to wide chars, just on Windows.
     int ret = m_processor->open_file(


### PR DESCRIPTION


### Description

Adds a hint "raw:bad_pixels" which passes a filename for bad pixel data to libraw.

### Tests

I haven't added any tests, can't think of a good way of testing this. Open to suggestions.
This functionality has been tested in a client code.


### Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] **I have read the guidelines** on [contributions](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md) and [code review procedures](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/CodeReview.md).
- [x] **I have read the [Policy on AI Coding Assistants](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/AI_Policy.md)**
  and if I used AI coding assistants, I have an `Assisted-by: TOOL / MODEL`
  line in the pull request description above.
- [x] **I have updated the documentation** if my PR adds features or changes
  behavior.
- [ ] **I am sure that this PR's changes are tested in the testsuite**.
- [x] **I have run and passed the testsuite in CI** *before* submitting the
  PR, by pushing the changes to my fork and seeing that the automated CI
  passed there. (Exceptions: If most tests pass and you can't figure out why
  the remaining ones fail, it's ok to submit the PR and ask for help. Or if
  any failures seem entirely unrelated to your change; sometimes things break
  on the GitHub runners.)
- [x] **My code follows the prevailing code style of this project** and I
  fixed any problems reported by the clang-format CI test.
- [ ] If I added or modified a public C++ API call, I have also amended the
  corresponding Python bindings. If altering ImageBufAlgo functions, I also
  exposed the new functionality as oiiotool options.
