### PR TITLE
feat(iba): Remove 'experimental' guards around FLIP_diff

### DIFF
--- a/src/doc/pythonbindings.rst
+++ b/src/doc/pythonbindings.rst
@@ -3290,9 +3290,6 @@ Image comparison and statistics
 .. py:method:: ImageBuf ImageBufAlgo.FLIP_diff (ref, test, hdr=1, maxluminance=2.0, medianluminance=0.18, ppd=0.0, tonemapper="aces", roi=ROI.All, nthreads=0)
                bool ImageBufAlgo.FLIP_diff (dst, ref, test, hdr=1, maxluminance=2.0, medianluminance=0.18, ppd=0.0, tonemapper="aces", roi=ROI.All, nthreads=0)
 
-    WARNING: This is EXPERIMENTAL and may change at any time. Do not rely
-    on it prior to the release of OIIO 3.2.
-
     Compute the `FLIP <https://research.nvidia.com/publication/2020-07_flip-difference-evaluator-alternating-images>`_
     perceptual difference between images `ref` and `test`, returning a
     single-channel float error map whose pixel values lie in [0,1].  Higher

--- a/src/include/OpenImageIO/imagebufalgo.h
+++ b/src/include/OpenImageIO/imagebufalgo.h
@@ -1441,18 +1441,8 @@ int OIIO_API compare_Yee (const ImageBuf &A, const ImageBuf &B,
                           ROI roi={}, int nthreads=0);
 
 
-#if OIIO_VERSION_GREATER_EQUAL(3, 2, 0) || defined(OIIO_INTERNAL)
-namespace experimental {
-// These FLIP_diff functions are EXPERIMENTAL and subject to change without
-// breaking our rules about backward compatibility. They are present for our
-// own experimentation but not exposed to external users for versions earlier
-// than 3.2, so far.
-
 /// @defgroup FLIP_diff (FLIP perceptual image difference)
 /// @{
-///
-/// WARNING: This is EXPERIMENTAL and may change at any time. Do not rely
-/// on it prior to the release of OIIO 3.2.
 ///
 /// Compute the FLIP perceptual difference between a reference image and a
 /// test image, returning an error map whose pixel values are in [0,1]. FLIP
@@ -1577,10 +1567,6 @@ inline constexpr float FLIP_ppd(float monitor_distance_m = 0.7f,
 {
     return radians(monitor_distance_m * (screen_width_px / screen_width_m));
 }
-
-}  // namespace experimental
-
-#endif
 
 /// @}
 

--- a/src/libOpenImageIO/imagebufalgo_flip.cpp
+++ b/src/libOpenImageIO/imagebufalgo_flip.cpp
@@ -119,17 +119,7 @@
 //   where the guess of 2.0 max luminance is worse than a more knowlegable
 //   setting, in a way that makes any practical difference.
 //
-// For now, this is all marked as "experimental": The C++ API calls are within
-// the `ImageBufAlgo::experimental` namespace, and the oiiotool `--flipdiff`
-// command will issue an error if the `--experimental` flag is not also used.
-// This should allow people to try it out, and even for us to backport it to
-// 3.1, while making it very clear that it's not officially a part of the
-// public API, and thus exempt from our usual promise not to break back
-// compatibility except at major release boundaries. We intend to remove the
-// experimental designation by the time 3.2 is released in Fall, 2026.
-//
-// List of things still to be done before it's taken out of experimental
-// designation, and beyond:
+// Ideas for future improvement:
 //
 // - [ ] Find a strategy for handling alpha, additional color channels,
 //       additional non-color channels. (And: should that be handled by
@@ -1213,9 +1203,9 @@ flip_impl(ImageBuf& dst, ImageBuf* exposuremap, FLIPResults* result,
 // ---------------------------------------------------------------------------
 
 bool
-ImageBufAlgo::experimental::FLIP_diff(ImageBuf& dst, const ImageBuf& ref,
-                                      const ImageBuf& test, KWArgs options,
-                                      ROI roi, int nthreads)
+ImageBufAlgo::FLIP_diff(ImageBuf& dst, const ImageBuf& ref,
+                        const ImageBuf& test, KWArgs options, ROI roi,
+                        int nthreads)
 {
     FLIPResults flipresults;
     bool ok = flip_impl(dst, nullptr, &flipresults, ref, test, options, roi,
@@ -1238,8 +1228,8 @@ ImageBufAlgo::experimental::FLIP_diff(ImageBuf& dst, const ImageBuf& ref,
 
 
 ImageBuf
-ImageBufAlgo::experimental::FLIP_diff(const ImageBuf& ref, const ImageBuf& test,
-                                      KWArgs options, ROI roi, int nthreads)
+ImageBufAlgo::FLIP_diff(const ImageBuf& ref, const ImageBuf& test,
+                        KWArgs options, ROI roi, int nthreads)
 {
     ImageBuf dst;
     (void)FLIP_diff(dst, ref, test, options, roi, nthreads);

--- a/src/libOpenImageIO/imagebufalgo_test.cpp
+++ b/src/libOpenImageIO/imagebufalgo_test.cpp
@@ -1336,7 +1336,7 @@ test_FLIP()
     ImageSpec spec(32, 32, 3, TypeDesc::FLOAT);
     ImageBuf img(spec);
     ImageBufAlgo::fill(img, { 0.3f, 0.5f, 0.7f });
-    ImageBuf result = ImageBufAlgo::experimental::FLIP_diff(img, img);
+    ImageBuf result = ImageBufAlgo::FLIP_diff(img, img);
     OIIO_CHECK_ASSERT(!result.has_error());
     OIIO_CHECK_EQUAL(result.nchannels(), 1);
     OIIO_CHECK_EQUAL_THRESH(result.spec().get_float_attribute("FLIP:maxerror"),
@@ -1346,7 +1346,7 @@ test_FLIP()
     ImageBuf black(spec), white(spec);
     ImageBufAlgo::fill(black, { 0.0f, 0.0f, 0.0f });
     ImageBufAlgo::fill(white, { 1.0f, 1.0f, 1.0f });
-    ImageBuf bw = ImageBufAlgo::experimental::FLIP_diff(black, white);
+    ImageBuf bw = ImageBufAlgo::FLIP_diff(black, white);
     OIIO_CHECK_ASSERT(!bw.has_error());
     OIIO_CHECK_EQUAL(bw.nchannels(), 1);
     // Max error should be positive and in range [0,1].
@@ -1358,7 +1358,7 @@ test_FLIP()
     OIIO_CHECK_ASSERT(maxerror <= 1.0);
 
     // Test FLIP_ppd helper.
-    float ppd = ImageBufAlgo::experimental::FLIP_ppd(0.7f, 3840.0f, 0.7f);
+    float ppd = ImageBufAlgo::FLIP_ppd(0.7f, 3840.0f, 0.7f);
     OIIO_CHECK_ASSERT(ppd > 60.0f && ppd < 80.0f);
 
     // Benchmarking
@@ -1381,14 +1381,14 @@ test_FLIP()
     ImageBufAlgo::noise(noisy, "gaussian", 0.0, 0.001f);
     ImageBuf flipresult(ImageSpec(xres, yres, 1, TypeFloat));
     bench(Strutil::format("FLIP_diff() LDR {}", xres), [&]() {
-        auto buf OIIO_MAYBE_UNUSED
-            = ImageBufAlgo::experimental::FLIP_diff(flipresult, noisy, ramp,
-                                                    { { "hdr", 0 } });
+        auto buf OIIO_MAYBE_UNUSED = ImageBufAlgo::FLIP_diff(flipresult, noisy,
+                                                             ramp,
+                                                             { { "hdr", 0 } });
     });
     bench(Strutil::format("FLIP_diff() HDR {}", xres), [&]() {
-        auto buf OIIO_MAYBE_UNUSED
-            = ImageBufAlgo::experimental::FLIP_diff(flipresult, noisy, ramp,
-                                                    { { "hdr", 1 } });
+        auto buf OIIO_MAYBE_UNUSED = ImageBufAlgo::FLIP_diff(flipresult, noisy,
+                                                             ramp,
+                                                             { { "hdr", 1 } });
     });
 }
 

--- a/src/oiiotool/oiiotool.cpp
+++ b/src/oiiotool/oiiotool.cpp
@@ -3352,13 +3352,6 @@ action_flipdiff(Oiiotool& ot, cspan<const char*> argv)
     string_view command = ot.express(argv[0]);
     OTScopedTimer timer(ot, command);
 
-    if (!ot.experimental) {
-        ot.errorfmt(
-            command,
-            "--flipdiff cannot be used without the --experimental flag.");
-        return;
-    }
-
     // Pop reference (deeper) and test (top) images.
     ImageRecRef test = ot.pop();
     ImageRecRef ref  = ot.pop();
@@ -3377,8 +3370,7 @@ action_flipdiff(Oiiotool& ot, cspan<const char*> argv)
     bool do_print        = options.get_int("print", 1);
 
     ImageBuf dst;
-    bool ok = ImageBufAlgo::experimental::FLIP_diff(dst, img_ref, img_test,
-                                                    options);
+    bool ok = ImageBufAlgo::FLIP_diff(dst, img_ref, img_test, options);
     if (!ok) {
         ot.error(command, dst.geterror());
         return;
@@ -7110,7 +7102,7 @@ Oiiotool::getargs(int argc, char* argv[])
       .help("Print report on the Yee perceptual difference of two images (modified by --fail, --failpercent, --hardfail, --warn, --warnpercent --hardwarn)")
       .OTACTION(action_pdiff);
     ap.arg("--flipdiff")
-      .help("[EXPERIMENTAL] Compute FLIP perceptual difference of two images (options: hdr=1, colormap=NAME, ppd=67.02, maxluminance=2.0)")
+      .help("Compute FLIP perceptual difference of two images (options: hdr=1, colormap=NAME, ppd=67.02, maxluminance=2.0)")
       .OTACTION(action_flipdiff);
     ap.arg("--add")
       .help("Add two images")

--- a/src/python/py_imagebufalgo.cpp
+++ b/src/python/py_imagebufalgo.cpp
@@ -1339,8 +1339,7 @@ IBA_FLIP_diff_ret(const ImageBuf& ref, const ImageBuf& test, int hdr = 1,
     if (ppd > 0.0f)
         opts["ppd"] = ppd;
     py::gil_scoped_release gil;
-    return ImageBufAlgo::experimental::FLIP_diff(ref, test, opts, roi,
-                                                 nthreads);
+    return ImageBufAlgo::FLIP_diff(ref, test, opts, roi, nthreads);
 }
 
 static bool
@@ -1358,17 +1357,15 @@ IBA_FLIP_diff(ImageBuf& dst, const ImageBuf& ref, const ImageBuf& test,
     if (ppd > 0.0f)
         opts["ppd"] = ppd;
     py::gil_scoped_release gil;
-    return ImageBufAlgo::experimental::FLIP_diff(dst, ref, test, opts, roi,
-                                                 nthreads);
+    return ImageBufAlgo::FLIP_diff(dst, ref, test, opts, roi, nthreads);
 }
 
 float
 IBA_FLIP_ppd(float monitor_distance_m = 0.7f, float screen_width_px = 3840.0f,
              float screen_width_m = 0.7f)
 {
-    return ImageBufAlgo::experimental::FLIP_ppd(monitor_distance_m,
-                                                screen_width_px,
-                                                screen_width_m);
+    return ImageBufAlgo::FLIP_ppd(monitor_distance_m, screen_width_px,
+                                  screen_width_m);
 }
 
 

--- a/testsuite/flip/run.py
+++ b/testsuite/flip/run.py
@@ -10,23 +10,23 @@ command += oiiotool("-pattern fill:color=0.1,0.1,0.1 64x64 3 -d half -o dark.exr
 command += oiiotool("-pattern fill:color=0.9,0.9,0.9 64x64 3 -d half -o light.exr")
 
 # Same images shoudl report 0.0 difference
-command += oiiotool("--experimental --echo \"Same image test\" dark.exr dark.exr --flipdiff:hdr=0")
+command += oiiotool("--echo \"Same image test\" dark.exr dark.exr --flipdiff:hdr=0")
 
 # Two images that differ -- FLIP should report nonzero difference.
-command += oiiotool("--experimental --echo \"Differing images, LDR\" dark.exr light.exr --flipdiff:hdr=0")
-command += oiiotool("--experimental --echo \"Differing images, HDR\" dark.exr light.exr --flipdiff:hdr=1:maxluminance=0")
+command += oiiotool("--echo \"Differing images, LDR\" dark.exr light.exr --flipdiff:hdr=0")
+command += oiiotool("--echo \"Differing images, HDR\" dark.exr light.exr --flipdiff:hdr=1:maxluminance=0")
 
 # Test against a small crop of the NVIDIA test image from the FLIP repo,
 # just like NVIDIA with automatic selection of exposures.
-command += oiiotool("--experimental src/reference-crop.exr src/test-crop.exr --flipdiff:hdr=1:maxluminance=0.0 -o reference-test-flip-auto.exr")
+command += oiiotool("src/reference-crop.exr src/test-crop.exr --flipdiff:hdr=1:maxluminance=0.0 -o reference-test-flip-auto.exr")
 command += oiiotool("reference-test-flip-auto.exr --colormap magma -o reference-test-flip-colormapped.exr")
 
 # Test against a small crop of the NVIDIA test image from the FLIP repo,
 # the "OIIO way" of a standard max luminance.
-command += oiiotool("--experimental src/reference-crop.exr src/test-crop.exr --flipdiff:hdr=1:maxluminance=2.0 -o reference-test-flip-oiio.exr")
+command += oiiotool("src/reference-crop.exr src/test-crop.exr --flipdiff:hdr=1:maxluminance=2.0 -o reference-test-flip-oiio.exr")
 
 # Test LDR, also suppress print, and setting variables
-command += oiiotool("--experimental src/reference-crop.exr src/test-crop.exr " +
+command += oiiotool("src/reference-crop.exr src/test-crop.exr " +
                     "--flipdiff:hdr=0:print=0 " +
                     "--echo \"LDR FLIP mean {TOP.'FLIP:meanerror'} max {TOP.'FLIP:maxerror'} max location ({TOP.'FLIP:maxx'}, {TOP.'FLIP:maxy'})\" " +
                     "-o reference-test-flip-ldr.exr")


### PR DESCRIPTION
Approaching release, we haven't had anybody request breaking change to the FLIP_diff APIs, so I think that in main we can remove the 'experimental' namespace guards. It's possible that we'll add features or controls to the behavior, but probably not break the ABI.
