### PR TITLE
Fix vcpkg install command syntax in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -118,7 +118,7 @@ build options), maybe one of these packages managers will do it for you:
 
 * vcpkg (https://github.com/Microsoft/vcpkg)
     * https://github.com/Microsoft/vcpkg/tree/master/ports/openimageio
-    * `vcpkg install openimageio [tools]`
+    * `vcpkg install openimageio[tools]`
     * For a full list of supported build features: `vcpkg search openimageio`
     * Instructions for building a Python wheel on Windows: 
       https://github.com/Correct-Syntax/py-oiio


### PR DESCRIPTION
I was looking into Windows build options and it seems vcpkg is a great choice now that it offers a more current version.

Just a very minor PR here: the syntax is `vcpkg install openimageio[tools]` (no space).