### PR TITLE
fix(hdr): address conflict between hdr and raw with .hdr files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -534,7 +534,7 @@ jobs:
             # Use the oldest supported versions of required dependencies, and
             # disable most optional dependencies and features (no SSE or
             # OpenCV, don't embed plugins).
-            nametag: linux-disabled-ubuntu
+            nametag: linux-hobbled-ubuntu
             runner: ubuntu-22.04
             cc_compiler: gcc-9
             cxx_compiler: g++-9

--- a/src/raw.imageio/rawinput.cpp
+++ b/src/raw.imageio/rawinput.cpp
@@ -238,12 +238,17 @@ raw_input_imageio_create()
     return new RawInput;
 }
 
+// Note: intentionally NOT including "hdr" here. Although some Hasselblad raw
+// files use the .hdr extension, that collides with the far more common
+// Radiance HDR format handled by the hdr plugin. Let the Radiance hdr reader
+// get first crack at it. Genuine Hasselblad .hdr files are still detected via
+// the try_all_readers fallback (on by default).
 OIIO_EXPORT const char* raw_input_extensions[]
-    = { "bay", "bmq", "cr2", "cr3", "crw", "cs1", "dc2",  "dcr", "dng", "erf",
-        "fff", "hdr", "k25", "kdc", "mdc", "mos", "mrw",  "nef", "orf", "pef",
-        "pxn", "raf", "raw", "rdc", "sr2", "srf", "x3f",  "arw", "3fr", "cine",
-        "ia",  "kc2", "mef", "nrw", "qtk", "rw2", "sti",  "rwl", "srw", "drf",
-        "dsc", "ptx", "cap", "iiq", "rwz", "cr3", nullptr };
+    = { "bay", "bmq", "cr2", "cr3", "crw", "cs1",  "dc2", "dcr", "dng",  "erf",
+        "fff", "k25", "kdc", "mdc", "mos", "mrw",  "nef", "orf", "pef",  "pxn",
+        "raf", "raw", "rdc", "sr2", "srf", "x3f",  "arw", "3fr", "cine", "ia",
+        "kc2", "mef", "nrw", "qtk", "rw2", "sti",  "rwl", "srw", "drf",  "dsc",
+        "ptx", "cap", "iiq", "rwz", "cr3", nullptr };
 
 OIIO_PLUGIN_EXPORTS_END
 


### PR DESCRIPTION
There is a confluence of unfortunate events:

- The .hdr extension is used by both Radiance hdr files, and actual raw files from Hasselblad cameras (rare).
- When EMBEDPLUGINS=0, the order that the plugins are declared are such that an .hdr file will get opened by the raw reader first.
- Certain old versions of libraw will crash when trying to open files it thinks are invalid (like Radiance hdr files).

This is causing our CI to fail the hdr test (because of the raw reader!) ever since we merged the fix that made EMBEDPLUGINS=0 really work (it had been subtly broken before). It only fails the "hobbled" test, because that's the only one with EMBEDPLUGINS=0.

The fix here is to remove the very-rarely-used .hdr extenion from the RAW extension list. If we really do encounter an Hasselblad raw file, it just means that the Radiance HDR reader will try it first, fail (safely), and then as long as try_all_readers is still enabled (it is the default), the raw reader will still get a crack at it.

Assisted-by: Copilot / Opus 4.8 (but only for investigation).

