### PR TITLE
fix: ImageBuf error message with too few format arguments aborts

### DIFF
--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -1184,8 +1184,8 @@ ImageBufImpl::init_spec(string_view filename, int subimage, int miplevel,
                                                  miplevel);
         if (!ok || m_nativespec.format == TypeUnknown) {
             std::string cacheerr = m_imagecache->geterror();
-            error("Unable to find subimage={}, miplevel={}{}{}",
-                  cacheerr.size() ? ": " : "", cacheerr);
+            error("Unable to find subimage={}, miplevel={}{}{}", subimage,
+                  miplevel, cacheerr.size() ? ": " : "", cacheerr);
             return false;
         }
 


### PR DESCRIPTION
While fixing something entirely different, CC spotted this bug.

Assisted-by: Claude Code / claude-opus-5
