### PR TITLE
docs: fix typos

### DIFF
--- a/src/doc/builtinplugins.rst
+++ b/src/doc/builtinplugins.rst
@@ -212,7 +212,7 @@ attributes are supported:
        example by reading from memory rather than the file system.    
 
 Additionally, an integer ``dds:bc5normal`` global attribute is supported
-to control behaviour of images compressed in BC5/ATI2 compression format.
+to control behavior of images compressed in BC5/ATI2 compression format.
 When the attribute value is set to non-zero (default is zero), any input
 image using BC5/ATI2 compression format is assumed to be a normal map,
 even if pixel format "normal map" flag is not set.
@@ -1134,7 +1134,7 @@ via the `ImageInput::set_ioproxy()` method and the special
 
 **Ultra HDR**
 
-JPEG input also suports Ultra HDR images.
+JPEG input also supports Ultra HDR images.
 Ultra HDR is an image format that encodes a high dynamic range image
 in a JPEG image file by including a gain map in addition to the
 primary image.
@@ -1393,7 +1393,7 @@ control aspects of the writing itself:
    * - ``jpegxl:jumb_box``
      - int (bool)
      - If nonzero, will enable JUMBF metadata writing to the output file.
-       Default is 0. (dows not supported at this moment in OIIO)
+       Default is 0. (This is not supported at this moment in OIIO.)
    * - ``jpegxl:iptc_box``
      - int (bool)
      - If nonzero, will enable IPTC metadata writing to the output file.
@@ -1856,7 +1856,7 @@ attributes are supported:
        example by reading from memory rather than the file system.
    * - ``png:linear_premult``
      - int
-     - If nonzero, will convert  or gamma-encoded values to linear color
+     - If nonzero, will convert sRGB or gamma-encoded values to linear color
        space for any premultiplication-by-alpha step done by the PNG reader.
        If zero (the default), any needed premultiplication will happen directly
        to the encoded values.
@@ -2302,7 +2302,7 @@ options are supported:
        (Default: 0)
    * - ``raw:camera_to_scene_linear_scale``
      - float
-     - Whilst the libraw pixel values are linear, they are normalized based on
+     - While the libraw pixel values are linear, they are normalized based on
        the whitepoint / sensor / ISO and shooting conditions. An additional multiplication
        is needed to bring exposure levels up so that a correctly photographed 18% grey card
        has pixel values at 0.18. Setting this metadata key implies ``raw:apply_scene_linear_scale``.
@@ -2735,7 +2735,7 @@ the `set_ioproxy()` methods.
   silently convert all output images to UINT8 (except if UINT16 is
   explicitly requested).
 * Targa only supports grayscale, RGB, and RGBA; the OpenImageIO TGA writer
-  will fail its call to ``open()`` if it is asked create a file with more
+  will fail its call to ``open()`` if it is asked to create a file with more
   than 4 color channels.
 
 
@@ -2791,7 +2791,7 @@ There's also a `256color` method that just uses the 6x6x6 color space in the
 256 color palette -- which looks horrible -- and an experimental `dither`
 which does a half-assed Floyd-Steinberg dithering, horizontally only, and
 frankly is not an improvement unless you squint really hard. These may
-change or be eliminted in the future.
+change or be eliminated in the future.
 
 In all cases, the image will automatically be resized to fit in the terminal
 and keep approximately the correct aspect ratio, as well as converted to
@@ -2909,7 +2909,7 @@ aspects of the writing itself:
      - Requests that the RGB image be converted and saved in the TIFF file in
        a non-RGB color space. Choices are ``RGB``, ``CMYK``.  (Note that
        ``YCbCr``, ``CIELAB``, ``ICCLAB``, ``ITULAB`` are not yet supported
-       for convertion. However, if the `oiio:ColorSpace` is one of those,
+       for conversion. However, if the `oiio:ColorSpace` is one of those,
        meaning that the image data is presumed to already be in that
        space, the TIFF PhotometricInterpretation tag will be set to convey
        this information.)

--- a/src/doc/idiff.rst
+++ b/src/doc/idiff.rst
@@ -139,7 +139,7 @@ General options
 
 .. describe:: -q
 
-    Quiet mode -- output nothing for successful match), output only minimal
+    Quiet mode -- output nothing for successful match, output only minimal
     error messages to stderr for failure / no match.  The shell return code
     also indicates success or failure (successful match returns 0, failure
     returns nonzero).

--- a/src/doc/imageinput.rst
+++ b/src/doc/imageinput.rst
@@ -893,7 +893,7 @@ hints are supported by each reader) are:
    * - ``oiio:reorient``
      - int
      - If zero, disables any automatic reorientation that the reader may
-       ordinarily do to present te pixels in the preferred display orientation.
+       ordinarily do to present the pixels in the preferred display orientation.
 
 Examples:
 

--- a/src/doc/imageioapi.rst
+++ b/src/doc/imageioapi.rst
@@ -323,7 +323,7 @@ inside the source code.
 .. cpp:var:: OPENIMAGEIO_PLUGIN_PATH
 
     A colon-separated list of directories to search for OpenImageIO plugins
-    (dynamicaly loadable libraries that implement image format readers
+    (dynamically loadable libraries that implement image format readers
     and writers).
 
     This is a new name beginning with OpenImageIO 2.6.3. The old name

--- a/src/doc/imageoutput.rst
+++ b/src/doc/imageoutput.rst
@@ -576,9 +576,9 @@ Here is a code example that opens an image file that will contain a 32x32
 pixel crop window within an abstract 640 x 480 full size image.
 Notice that the pixel indices (column, scanline, slice) passed to the
 "write" functions are the coordinates relative to the full image, not
-relative to the crop widow, but the data pointer passed to the "write"
+relative to the crop window, but the data pointer passed to the "write"
 functions should point to the beginning of the actual pixel data being
-passed (not the the hypothetical start of the full data, if it was all
+passed (not the hypothetical start of the full data, if it was all
 present).
 
 .. tabs::
@@ -1421,7 +1421,7 @@ identical to the original input.
 
 A special ``copy_image()`` method of ``ImageOutput`` is available that
 attempts to copy an image from an open ``ImageInput`` (of the same format)
-to the output as efficiently as possible with without altering pixel values,
+to the output as efficiently as possible without altering pixel values,
 if at all possible.
 
 Not all format plugins will provide an implementation of ``copy_image()``

--- a/src/doc/maketx.rst
+++ b/src/doc/maketx.rst
@@ -214,7 +214,7 @@ Command-line arguments are:
     features "pop" visually even at high MIP-map levels. The *contrast*
     controls the degree to which it does this. Probably a good value to
     enhance detail but not go overboard is 0.5 or even 0.25. A value of 1.0
-    may make strage artifacts at high MIP-map levels. Also, if you
+    may make strange artifacts at high MIP-map levels. Also, if you
     simultaneously use `--filter unsharp-median`, a slightly different
     variant of unsharp masking will be used that employs a median filter to
     separate out the low-frequencies, this may tend to help emphasize small
@@ -311,7 +311,7 @@ Command-line arguments are:
     texture at a reduced resolution equal to the tile size, rather than
     filling endless tiles with the same constant color.  That is, by
     substituting a low-res texture for a high-res texture if it's a constant
-    color, you could save a lot of save disk space, I/O, and texture cache
+    color, you could save a lot of disk space, I/O, and texture cache
     size. It also sets the `"ImageDescription"` to contain a special message
     of the form `ConstantColor=[r,g,...]`.
 

--- a/src/doc/oiiotool.rst
+++ b/src/doc/oiiotool.rst
@@ -947,7 +947,7 @@ subimage according to its metadata::
 
 .. option:: --create-dir
 
-    Create output directories if it doesn't exists already 
+    Create output directories if they don't exist already
     during the `-o` output action.
 
 .. option:: --threads <n>
@@ -1309,7 +1309,7 @@ These are all non-positional flags that affect how all images are read in the
       `:unpremult=` *int*
         If nonzero, when autocc is performed on an image containing an alpha
         channel, the image will first be unpremultiplied by alpha, then
-        color transformed, then re-premultipled by alpha, so that the
+        color transformed, then re-premultiplied by alpha, so that the
         color transformation is done with unassociated color values. The
         default is 0, meaning that the color transformation will be done
         directly on the associated color values.
@@ -1765,7 +1765,7 @@ Writing images
 
     When this flag is used, most image operations will try to merge the
     metadata found in all of their source input images into the output.
-    The default (if this is not used) is that image oprations with multiple
+    The default (if this is not used) is that image operations with multiple
     input images will just take metadata from the first source image.
 
     (This was added for OpenImageIO 2.1.)
@@ -1963,7 +1963,7 @@ Writing images
 
       `:hdr=` *int* (default: 1)
         If nonzero, computes the HDR FLIP comparison. If zero, computes
-        the LDR FLIP comparision. The default is 1, for HDR mode.
+        the LDR FLIP comparison. The default is 1, for HDR mode.
       `:maxluminance=` *float* (default: 2.0)
         The top of the expected luminance range, used to compute exposure
         settings. If set to 0.0, the "startExposure" and "stopExposure"
@@ -2459,7 +2459,7 @@ current top image.
 
 .. option:: --nchannels <n>
 
-    Replaces the top image with a new image whose channels are the the first *n*
+    Replaces the top image with a new image whose channels are the first *n*
     channels of the input image. If *n* is less than the number of
     channels in the input image, the extra channels will simply be ignored.
     If *n* is greater than the number of channels in the input image, the
@@ -2652,7 +2652,7 @@ current top image.
         .. code-block::
 
             oiiotool --pattern noise:type=uniform:min=1:max=1 256x256 3 -o colornoise.jpg
-            oiiotool --pattern noise:type=uniform:min=0:max=1:mono=1 256x256 3 -o greynoise.jpg}
+            oiiotool --pattern noise:type=uniform:min=0:max=1:mono=1 256x256 3 -o greynoise.jpg
         ..
 
             .. image:: figures/unifnoise3.jpg
@@ -3562,7 +3562,7 @@ current top image.
     previously did not exist in the old image, repositioning the cut region
     at the image origin (0,0) and resetting the full/display window to be
     identical to the new pixel data window.  (In other words, `--cut` is
-    equavalent to `--crop` followed by `--origin +0+0 --fullpixels`.)
+    equivalent to `--crop` followed by `--origin +0+0 --fullpixels`.)
 
     The size is in the form
 
@@ -4607,16 +4607,16 @@ will be printed with the command `oiiotool --colorconfiginfo`.
 
     - `key=` *name*, `value=` *str* :
 
-      Adds a key/value pair to the "context" that OpenColorIO will used
+      Adds a key/value pair to the "context" that OpenColorIO will use
       when applying the look. Multiple key/value pairs may be specified by
       making each one a comma-separated list.
 
     - `unpremult=` *val* :
 
       If the numeric *val* is nonzero, the pixel values will be
-      "un-premultipled" (divided by alpha) prior to the actual color
-      conversion, and then re-multipled by alpha afterwards. The default is
-      0, meaning the color transformation not will be automatically
+      "un-premultiplied" (divided by alpha) prior to the actual color
+      conversion, and then re-multiplied by alpha afterwards. The default is
+      0, meaning the color transformation will not be automatically
       bracketed by divide-by-alpha / mult-by-alpha operations.
 
     - `strict=` *val* :
@@ -4660,9 +4660,9 @@ will be printed with the command `oiiotool --colorconfiginfo`.
     - `unpremult=` *val* :
 
       If the numeric *val* is nonzero, the pixel values will be
-      "un-premultipled" (divided by alpha) prior to the actual color
-      conversion, and then re-multipled by alpha afterwards. The default is
-      0, meaning the color transformation not will be automatically
+      "un-premultiplied" (divided by alpha) prior to the actual color
+      conversion, and then re-multiplied by alpha afterwards. The default is
+      0, meaning the color transformation will not be automatically
       bracketed by divide-by-alpha / mult-by-alpha operations.
 
     - `invert=` *val* :
@@ -4672,7 +4672,7 @@ will be printed with the command `oiiotool --colorconfiginfo`.
 
     - `transpose=` *val* :
 
-      If nonzero, this will cause the matrix to be transposed (this allowing
+      If nonzero, this will cause the matrix to be transposed (thus allowing
       you to more easily specify it as if the color values were column
       vectors and the transformation as `M*C`).
 
@@ -4711,16 +4711,16 @@ will be printed with the command `oiiotool --colorconfiginfo`.
 
     - `key=` *name*, `value=` *str*
 
-      Adds a key/value pair to the "context" that OpenColorIO will used
+      Adds a key/value pair to the "context" that OpenColorIO will use
       when applying the look. Multiple key/value pairs may be specified by
       making each one a comma-separated list.
 
     - `unpremult=` *val* :
     
       If the numeric *val* is nonzero, the pixel values will be
-      "un-premultipled" (divided by alpha) prior to the actual color
-      conversion, and then re-multipled by alpha afterwards. The default is
-      0, meaning the color transformation not will be automatically
+      "un-premultiplied" (divided by alpha) prior to the actual color
+      conversion, and then re-multiplied by alpha afterwards. The default is
+      0, meaning the color transformation will not be automatically
       bracketed by divide-by-alpha / mult-by-alpha operations.
     
       `:subimages=` *indices-or-names*
@@ -4756,15 +4756,15 @@ will be printed with the command `oiiotool --colorconfiginfo`.
         scene-referred color space.
     
       `key=` *name*, `value=` *str*
-        Adds a key/value pair to the "context" that OpenColorIO will used
+        Adds a key/value pair to the "context" that OpenColorIO will use
         when applying the look. Multiple key/value pairs may be specified by
         making each one a comma-separated list.
     
       `unpremult=` *val* :
         If the numeric *val* is nonzero, the pixel values will be
-        "un-premultipled" (divided by alpha) prior to the actual color
-        conversion, and then re-multipled by alpha afterwards. The default
-        is 0, meaning the color transformation not will be automatically
+        "un-premultiplied" (divided by alpha) prior to the actual color
+        conversion, and then re-multiplied by alpha afterwards. The default
+        is 0, meaning the color transformation will not be automatically
         bracketed by divide-by-alpha / mult-by-alpha operations.
     
       `inverse=` *val* :
@@ -4797,9 +4797,9 @@ will be printed with the command `oiiotool --colorconfiginfo`.
     - `unpremult=` *val* :
 
       If the numeric *val* is nonzero, the pixel values will be
-      "un-premultipled" (divided by alpha) prior to the actual color
-      conversion, and then re-multipled by alpha afterwards. The default is
-      0, meaning the color transformation not will be automatically
+      "un-premultiplied" (divided by alpha) prior to the actual color
+      conversion, and then re-multiplied by alpha afterwards. The default is
+      0, meaning the color transformation will not be automatically
       bracketed by divide-by-alpha / mult-by-alpha operations.
 
       `:subimages=` *indices-or-names*
@@ -4818,7 +4818,7 @@ will be printed with the command `oiiotool --colorconfiginfo`.
 
     - `key=` *name*, `value=` *str*
 
-      Adds a key/value pair to the "context" that OpenColorIO will used
+      Adds a key/value pair to the "context" that OpenColorIO will use
       when applying the look. Multiple key/value pairs may be specified by
       making each one a comma-separated list.
     
@@ -4829,9 +4829,9 @@ will be printed with the command `oiiotool --colorconfiginfo`.
     - `unpremult=` *val* :
 
       If the numeric *val* is nonzero, the pixel values will be
-      "un-premultipled" (divided by alpha) prior to the actual color
-      conversion, and then re-multipled by alpha afterwards. The default is
-      0, meaning the color transformation not will be automatically
+      "un-premultiplied" (divided by alpha) prior to the actual color
+      conversion, and then re-multiplied by alpha afterwards. The default is
+      0, meaning the color transformation will not be automatically
       bracketed by divide-by-alpha / mult-by-alpha operations.
 
       `:subimages=` *indices-or-names*
@@ -4846,7 +4846,7 @@ will be printed with the command `oiiotool --colorconfiginfo`.
 
     Divide all color channels (those not alpha or z) of the current image by
     the alpha value, to "un-premultiply" them.  This presumes that the image
-    starts of as "associated alpha," a.k.a. "premultipled." Pixels in which
+    starts off as "associated alpha," a.k.a. "premultiplied." Pixels in which
     the alpha channel is 0 will not be modified (since the operation is
     undefined in that case).  This is a no-op if there is no identified
     alpha channel.
@@ -4860,7 +4860,7 @@ will be printed with the command `oiiotool --colorconfiginfo`.
 
     Multiply all color channels (those not alpha or z) of the current image
     by the alpha value, to "premultiply'' them.  This presumes that the
-    image starts of as "unassociated alpha,'' a.k.a. "non-premultipled."
+    image starts off as "unassociated alpha,'' a.k.a. "non-premultiplied."
 
     Optional appended modifiers include:
 

--- a/src/doc/pythonbindings.rst
+++ b/src/doc/pythonbindings.rst
@@ -298,7 +298,7 @@ explained in detail in Section :ref:`sec-ROI`, is replicated for Python.
 
 .. py:method:: ROI.contains (other)
 
-    Returns `True` if the ROI `other` is entirel contained within
+    Returns `True` if the ROI `other` is entirely contained within
     this ROI.
 
 
@@ -2329,13 +2329,13 @@ Pattern generation
                bool ImageBufAlgo.fill (dst, top, bottom, roi=ROI.All, nthreads=0)
                bool ImageBufAlgo.fill (dst, topleft, topright, bottomleft, bottomright, roi=ROI.All, nthreads=0)
 
-    Return a filled float image of size `roi`, or set the the pixels of
+    Return a filled float image of size `roi`, or set the pixels of
     image `dst` within the ROI to a color or gradient.
     
-    Three fill optins are available: (a) if one color tuple is supplied, the
+    Three fill options are available: (a) if one color tuple is supplied, the
     whole ROI will be filled with that constant value, (b) if two color
     tuples are supplied, a linear gradient will be applied from top to
-    bottom, (c) if four color cuples are supplied, the ROI will be be filled
+    bottom, (c) if four color tuples are supplied, the ROI will be filled
     with values bilinearly interpolated from the four corner colors
     supplied.
 
@@ -2651,7 +2651,7 @@ Image transformations and data movement
 .. py:method:: ImageBuf ImageBufAlgo.reorient (src, nthreads=0)
                bool ImageBufAlgo.reorient (dst, src, nthreads=0)
 
-    Copy `src`, applying whatever seties of rotations, flips,
+    Copy `src`, applying whatever series of rotations, flips,
     or flops are necessary to transform the pixels into the configuration
     suggested by the `"Orientation"` metadata of the image (and the
     `"Orientation"` metadata is then set to 1, ordinary orientation).
@@ -2685,7 +2685,7 @@ Image transformations and data movement
                bool ImageBufAlgo.rotate (dst, src, angle, filtername="", filtersize=0.0, recompute_roi=False, roi=ROI.All, nthreads=0)
                bool ImageBufAlgo.rotate (dst, src, angle, center_x, center_y, filtername="", filtersize=0.0, recompute_roi=False, roi=ROI.All, nthreads=0)
 
-    Copy arotated version of the corresponding portion of `src`.  The angle
+    Copy a rotated version of the corresponding portion of `src`.  The angle
     is in radians, with positive values indicating clockwise rotation. If
     the filter and size are not specified, an appropriate default will be
     chosen.
@@ -2759,7 +2759,7 @@ Image transformations and data movement
 
     Set `dst`, over the ROI, to be a low-quality (but fast) resized version
     of the corresponding portion of `src`, either using a simple "closest
-    pixel" choice or by bilinaerly interpolating (depending on
+    pixel" choice or by bilinearly interpolating (depending on
     `interpolate`).
 
     Example:
@@ -2858,7 +2858,7 @@ Image arithmetic
 .. py:method:: ImageBuf ImageBufAlgo.scale (A, B, roi=ROI.All, nthreads=0)
                bool ImageBufAlgo.scale (dst, A, B, roi=ROI.All, nthreads=0)
 
-    Per-pixel multiply all channels of one image by the single channle of the
+    Per-pixel multiply all channels of one image by the single channel of the
     other image. One of the input images must have only one channel.
 
     Example:
@@ -3229,7 +3229,7 @@ Image comparison and statistics
 .. py:method:: PixelStats ImageBufAlgo.computePixelStats (src, roi=ROI.All, nthreads=0)
 
     Compute statistics about the ROI of the image `src`. The `PixelStats`
-    structure is defined as contining the following data fields: `min`,
+    structure is defined as containing the following data fields: `min`,
     `max`, `avg`, `stddev`, `nancount`, `infcount`, `finitecount`, `sum`,
     `sum2`, each of which is a tuple with one value for each channel of the
     image.
@@ -3799,7 +3799,7 @@ Color manipulation
 
     `unpremult` divides colors by alpha, but preserves original color if
     alpha is 0. `premult` multiplies colors by alpha (even if alpha is 0).
-    `repreumlt` is the true inverse of `unpremult`, multiplying color by
+    `repremult` is the true inverse of `unpremult`, multiplying color by
     alpha, but preserving color values in the alpha = 0 case.
 
     Example:
@@ -4198,7 +4198,7 @@ following boilerplate:
 
 .. code-block:: python
 
-    # Create an ImageBuf holding a n image of constant color, given the
+    # Create an ImageBuf holding an image of constant color, given the
     # resolution, data format (defaulting to UINT8), fill value, and image
     # origin.
     def make_constimage (xres: int, yres: int, chans: int=3, format: TypeDesc=oiio.UINT8, value: tuple[int, int, int]=(0,0,0),

--- a/src/doc/stdmetadata.rst
+++ b/src/doc/stdmetadata.rst
@@ -231,11 +231,11 @@ Disk file format info/hints
     an example, the OpenEXR writer supports `none`, `rle`, `zip`, `zips`,
     `piz`, `pxr24`, `b44`, `b44a`, `dwaa`, or `dwab`.
 
-    he compression name is permitted to have a quality value to be appended
+    The compression name is permitted to have a quality value to be appended
     after a colon, for example `dwaa:60`.  The exact meaning and range of
-    he quality value can vary between different file formats and compression
-    odes, and some don't support quality values at all (it will be ignored if
-    ot supported, or if out of range).
+    The quality value can vary between different file formats and compression
+    modes, and some don't support quality values at all (it will be ignored if
+    not supported, or if out of range).
 
 .. option:: "CompressionQuality" : int
 
@@ -406,12 +406,12 @@ to be used as textures (especially for OpenImageIO's TextureSystem).
 
 .. option:: "oiio:SHA-1" : string
 
-    f present, is a 40-byte SHA-1 hash of the input image (possibly salted
-    with arious maketx options) that can serve to quickly compare two
-    separate extures to know if they contain the same pixels. While it's
-    not, echnically, 100% guaranteed that no separate textures will match,
-    it's so stronomically unlikely that we discount the possibility (you'd
-    be rendering ovies for centuries before finding a single match).
+    If present, is a 40-byte SHA-1 hash of the input image (possibly salted
+    with various maketx options) that can serve to quickly compare two
+    separate textures to know if they contain the same pixels. While it's
+    not, technically, 100% guaranteed that no separate textures will match,
+    it's so astronomically unlikely that we discount the possibility (you'd
+    be rendering movies for centuries before finding a single match).
 
 
 
@@ -540,7 +540,7 @@ The kind of light source:
     11   shade
     12   daylight fluorescent (D 5700-7100K)
     13   day white fluorescent (N 4600-5400K)
-    14   cool white fuorescent (W 3900 - 4500K)
+    14   cool white fluorescent (W 3900 - 4500K)
     15   white fluorescent (WW 3200 - 3700K)
     17   standard light A
     18   standard light B
@@ -607,7 +607,7 @@ A sum of:
 
 .. option:: "Exif:FlashEnergy" : float
 
-    Strobe energy when the image was captures, measured in Beam Candle Power
+    Strobe energy when the image was captured, measured in Beam Candle Power
     Seconds (BCPS).
 
 .. option:: "Exif:FocalPlaneXResolution" : float
@@ -637,7 +637,7 @@ A sum of:
 
 .. option:: "Exif:SensingMethod" : int
 
-    The image sensor type on the camra:
+    The image sensor type on the camera:
 
     ===  ==============================================================
     1    undefined


### PR DESCRIPTION
### Description

I noticed some typos while reading through the OIIO documentation and decided to let an LLM shine.

Assisted-by: Codex / GPT-5.5

### Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] **I have read the guidelines** on [contributions](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md) and [code review procedures](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/CodeReview.md).
- [x] **I have read the [Policy on AI Coding Assistants](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/AI_Policy.md)**
  and if I used AI coding assistants, I have an `Assisted-by: TOOL / MODEL`
  line in the pull request description above.
- [x] **I have updated the documentation** if my PR adds features or changes
  behavior.
- [x] **I am sure that this PR's changes are tested in the testsuite**.
- [x] **I have run and passed the testsuite in CI** *before* submitting the
  PR, by pushing the changes to my fork and seeing that the automated CI
  passed there. (Exceptions: If most tests pass and you can't figure out why
  the remaining ones fail, it's ok to submit the PR and ask for help. Or if
  any failures seem entirely unrelated to your change; sometimes things break
  on the GitHub runners.)
- [x] **My code follows the prevailing code style of this project** and I
  fixed any problems reported by the clang-format CI test.
- [x] If I added or modified a public C++ API call, I have also amended the
  corresponding Python bindings. If altering ImageBufAlgo functions, I also
  exposed the new functionality as oiiotool options.
