### PR TITLE
int(ImageBuf): remove redundant and dead code from ImageBuf internals

### DIFF
--- a/src/libOpenImageIO/imagebuf.cpp
+++ b/src/libOpenImageIO/imagebuf.cpp
@@ -1253,7 +1253,6 @@ ImageBufImpl::init_spec(string_view filename, int subimage, int miplevel,
         m_pixels_read      = false;
         m_nsubimages       = 0;
         m_nmiplevels       = 0;
-        m_badfile          = false;
         m_current_subimage = -1;
         m_current_miplevel = -1;
         auto input = ImageInput::open(filename, m_configspec.get(), m_rioproxy);
@@ -2118,7 +2117,6 @@ ImageBuf::nchannels() const
 int
 ImageBuf::orientation() const
 {
-    m_impl->validate_spec();
     return m_impl->spec().get_int_attribute("Orientation", 1);
 }
 
@@ -2407,7 +2405,7 @@ ImageBuf::copy(const ImageBuf& src, TypeDesc format)
         m_impl->m_deepdata = src.m_impl->m_deepdata;
         return true;
     }
-    if (format.basetype == TypeDesc::UNKNOWN || src.deep())
+    if (format.basetype == TypeDesc::UNKNOWN)
         m_impl->reset(src.name(), src.spec(), &src.nativespec());
     else {
         ImageSpec newspec(src.spec());


### PR DESCRIPTION
Found them while reading for the IBA::reorient() bug fix.
- `init_spec()`: drop a stray `m_badfile = false` that immediately undoes the `m_badfile = true` at the start of the branch. A failed open now leaves `m_badfile = true`, as it should have.
- `orientation()`: drop redundant `validate_spec()`.  `spec()` already calls validate_spec().
- `copy()`: drop unreachable `|| src.deep()` condition. Deep sources return earlier in the function.



### Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] **I have read the guidelines** on [contributions](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md) and [code review procedures](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/CodeReview.md).
- [x] **I have read the [Policy on AI Coding Assistants](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/AI_Policy.md)**
  and if I used AI coding assistants, I have an `Assisted-by: TOOL / MODEL`
  line in the pull request description above.
- [ ] **(N/A)** **I have updated the documentation** if my PR adds features or changes
  behavior.
- [x] **I am sure that this PR's changes are tested in the testsuite**.
- [x] **I have run and passed the testsuite in CI** *before* submitting the
  PR, by pushing the changes to my fork and seeing that the automated CI
  passed there. (Exceptions: If most tests pass and you can't figure out why
  the remaining ones fail, it's ok to submit the PR and ask for help. Or if
  any failures seem entirely unrelated to your change; sometimes things break
  on the GitHub runners.)
- [x] **My code follows the prevailing code style of this project** and I
  fixed any problems reported by the clang-format CI test.
- [ ] **(N/A)** If I added or modified a public C++ API call, I have also amended the
  corresponding Python bindings. If altering ImageBufAlgo functions, I also
  exposed the new functionality as oiiotool options.
