### PR TITLE
fix(filesystem): Use 64-bit file offsets on Windows

### DIFF
--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -552,7 +552,7 @@ int
 Filesystem::fseek(FILE* file, int64_t offset, int whence)
 {
 #ifdef _WIN32
-    return _fseeki64(file, __int64(offset), whence);
+    return _fseeki64(file, static_cast<__int64>(offset), whence);
 #else
     return fseeko(file, offset, whence);
 #endif

--- a/src/libutil/filesystem.cpp
+++ b/src/libutil/filesystem.cpp
@@ -551,7 +551,7 @@ Filesystem::fopen(string_view path, string_view mode)
 int
 Filesystem::fseek(FILE* file, int64_t offset, int whence)
 {
-#ifdef _MSC_VER
+#ifdef _WIN32
     return _fseeki64(file, __int64(offset), whence);
 #else
     return fseeko(file, offset, whence);
@@ -563,7 +563,7 @@ Filesystem::fseek(FILE* file, int64_t offset, int whence)
 int64_t
 Filesystem::ftell(FILE* file)
 {
-#ifdef _MSC_VER
+#ifdef _WIN32
     return _ftelli64(file);
 #else
     return ftello(file);


### PR DESCRIPTION
### Description

Use `_fseeki64()` and `_ftelli64()` on all Windows builds. MinGW does not
define `_MSC_VER`, so it previously used `fseeko()` and `ftello()`, which can
have 32-bit offsets.

Fixes #5351.

### Tests

- `clang-format --dry-run --Werror src/libutil/filesystem.cpp`
- `git diff --check`
- Verified that `oiiotool --stats` reads the reproducing EXR successfully