### PR TITLE
fix(IBA): detect iterator read errors in orientation functions

### DIFF
--- a/src/libOpenImageIO/imagebufalgo_orient.cpp
+++ b/src/libOpenImageIO/imagebufalgo_orient.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/AcademySoftwareFoundation/OpenImageIO
 
+#include <atomic>
 #include <cmath>
 #include <iostream>
 
@@ -33,7 +34,7 @@ flip_(ImageBuf& dst, const ImageBuf& src, ROI dst_roi, int /*nthreads*/)
         for (int c = dst_roi.chbegin; c < dst_roi.chend; ++c)
             d[c] = s[c];
     }
-    return true;
+    return !s.has_error();
 }
 
 
@@ -82,7 +83,7 @@ flop_(ImageBuf& dst, const ImageBuf& src, ROI dst_roi, int /*nthreads*/)
         for (int c = dst_roi.chbegin; c < dst_roi.chend; ++c)
             d[c] = s[c];
     }
-    return true;
+    return !s.has_error();
 }
 
 
@@ -153,7 +154,7 @@ rotate90_(ImageBuf& dst, const ImageBuf& src, ROI dst_roi, int /*nthreads*/)
         for (int c = dst_roi.chbegin; c < dst_roi.chend; ++c)
             d[c] = s[c];
     }
-    return true;
+    return !s.has_error();
 }
 
 
@@ -216,7 +217,7 @@ rotate180_(ImageBuf& dst, const ImageBuf& src, ROI dst_roi, int /*nthreads*/)
         for (int c = dst_roi.chbegin; c < dst_roi.chend; ++c)
             d[c] = s[c];
     }
-    return true;
+    return !s.has_error();
 }
 
 
@@ -267,7 +268,7 @@ rotate270_(ImageBuf& dst, const ImageBuf& src, ROI dst_roi, int /*nthreads*/)
         for (int c = dst_roi.chbegin; c < dst_roi.chend; ++c)
             d[c] = s[c];
     }
-    return true;
+    return !s.has_error();
 }
 
 
@@ -400,6 +401,7 @@ template<typename DSTTYPE, typename SRCTYPE = DSTTYPE>
 static bool
 transpose_(ImageBuf& dst, const ImageBuf& src, ROI roi, int nthreads)
 {
+    std::atomic<bool> ok(true);
     ImageBufAlgo::parallel_image(roi, nthreads, [&](ROI roi) {
         ImageBuf::ConstIterator<SRCTYPE, DSTTYPE> s(src, roi);
         ImageBuf::Iterator<DSTTYPE, DSTTYPE> d(dst);
@@ -410,8 +412,10 @@ transpose_(ImageBuf& dst, const ImageBuf& src, ROI roi, int nthreads)
             for (int c = roi.chbegin; c < roi.chend; ++c)
                 d[c] = s[c];
         }
+        if (s.has_error())
+            ok = false;
     });
-    return true;
+    return ok;
 }
 
 


### PR DESCRIPTION
Check the `ImageBuf::ConstIterator` error flag for IC images in orientation functions (flip, flop, rotate90/180/270, and transpose). Previously, such errors were silently ignored and the functions returned true. Now they return false if `ImageBuf::retile()` indicates an error during the read.
    
In `IBA::transpose()`, the error flag is a `std::atomic<bool>` because the multithreading helper `IBA::parallel_image()` is called.
    
Follow-up to #3233
    


### Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] **I have read the guidelines** on [contributions](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md) and [code review procedures](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/CodeReview.md).
- [x] **I have read the [Policy on AI Coding Assistants](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/AI_Policy.md)**
  and if I used AI coding assistants, I have an `Assisted-by: TOOL / MODEL`
  line in the pull request description above.
- [ ] **(N/A)** **I have updated the documentation** if my PR adds features or changes
  behavior.
- [x] **I am sure that this PR's changes are tested in the testsuite**.
- [x] **I have run and passed the testsuite in CI** *before* submitting the
  PR, by pushing the changes to my fork and seeing that the automated CI
  passed there. (Exceptions: If most tests pass and you can't figure out why
  the remaining ones fail, it's ok to submit the PR and ask for help. Or if
  any failures seem entirely unrelated to your change; sometimes things break
  on the GitHub runners.)
- [x] **My code follows the prevailing code style of this project** and I
  fixed any problems reported by the clang-format CI test.
- [ ] **(N/A)** If I added or modified a public C++ API call, I have also amended the
  corresponding Python bindings. If altering ImageBufAlgo functions, I also
  exposed the new functionality as oiiotool options.
