### PR TITLE
build: fix declaration mismatch for unity builds on Windows

### DIFF
--- a/src/openexr.imageio/exrinput.cpp
+++ b/src/openexr.imageio/exrinput.cpp
@@ -86,8 +86,8 @@ OIIO_PLUGIN_NAMESPACE_BEGIN
 // Defined in exrinput_c.cpp. Declare here at C++ namespace scope (not inside
 // the extern "C" block below) so the linkage matches the definition in the
 // non-embedded (dynamic plugin) build where OIIO_PLUGIN_EXPORTS_BEGIN is
-// `extern "C"`.
-extern ImageInput*
+// `extern "C"`. Use OIIO_EXPORT to ensure safe unity build on Windows.
+extern OIIO_EXPORT ImageInput*
 openexrcore_input_imageio_create();
 #endif
 


### PR DESCRIPTION
Windows Unity builds might combine exrinput.cpp and exrinput_c.cpp into one translation unit. The forward declaration in exrinput.cpp lacked OIIO_EXPORT while the definition in exrinput_c.cpp has it, causing MSVC error. I'm not sure why this never failed before today!

Assisted-by: Claude Code / Sonnet 5
