### PR TITLE
int: improve ImageSpec::default_channel_names -- nchannels safety

### DIFF
--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -197,7 +197,7 @@ ImageSpec::default_channel_names() noexcept
     channelnames.clear();
     alpha_channel = -1;
     z_channel     = -1;
-    if (nchannels < 1 || nchannels >= limit_channels)
+    if (nchannels < 1 || (limit_channels && nchannels > limit_channels))
         return;  // early out for invalid channel counts
     channelnames.reserve(nchannels);
     if (nchannels == 1) {  // Special case: 1-channel is named "Y"

--- a/src/libOpenImageIO/formatspec.cpp
+++ b/src/libOpenImageIO/formatspec.cpp
@@ -195,9 +195,11 @@ void
 ImageSpec::default_channel_names() noexcept
 {
     channelnames.clear();
-    channelnames.reserve(nchannels);
     alpha_channel = -1;
     z_channel     = -1;
+    if (nchannels < 1 || nchannels >= limit_channels)
+        return;  // early out for invalid channel counts
+    channelnames.reserve(nchannels);
     if (nchannels == 1) {  // Special case: 1-channel is named "Y"
         channelnames.emplace_back("Y");
         return;
@@ -214,7 +216,7 @@ ImageSpec::default_channel_names() noexcept
         alpha_channel = 3;
     }
     for (int c = 4; c < nchannels; ++c)
-        channelnames.push_back(Strutil::fmt::format("channel{}", c));
+        channelnames.emplace_back(Strutil::fmt::format("channel{}", c));
 }
 
 


### PR DESCRIPTION
Since ImageSpec::default_channel_names does an allocation (`channelnames.reserve(nchannels)`), it seems prudent to do a validity check on nchannels first.

This is similar in spirit to check_open, but of course this happens during construction of the ImageSpec, whereas check_open can't do its magic until after the ImageSpec already exists and has done this allocation.

I also took the opportunity to change a change a push_back to an emplace_back, possibly saving an occasional std::string allocation.
