### PR TITLE
Update simd.h  with check for Windows ARM64EC build option

### DIFF
--- a/src/include/OpenImageIO/simd.h
+++ b/src/include/OpenImageIO/simd.h
@@ -84,7 +84,7 @@
 #  define OIIO_NO_NEON 1
 #endif
 
-#if defined(_M_ARM64) || defined(__aarch64__) || defined(__aarch64)
+#if defined(_M_ARM64) || defined(_M_ARM64EC) || defined(__aarch64__) || defined(__aarch64)
 #  ifndef __ARM_NEON__
 #      define __ARM_NEON__
 #  endif
@@ -92,7 +92,7 @@
 
 // Disable Intel SIMD intrinsics on non-Intel architectures (including
 // building for Cuda on an Intel host).
-#if defined(_M_ARM64) || defined(__aarch64) || defined(__aarch64__) \
+#if defined(_M_ARM64) || defined(_M_ARM64EC) || defined(__aarch64) || defined(__aarch64__) \
     || defined(__CUDA_ARCH__)
 #  ifndef OIIO_NO_SSE
 #    define OIIO_NO_SSE 1
@@ -105,7 +105,7 @@
 #  endif
 #endif
 
-#if !(defined(_M_ARM64) || defined(__aarch64) || defined(__aarch64__)) || defined(__CUDA_ARCH__)
+#if !(defined(_M_ARM64) || defined(_M_ARM64EC) || defined(__aarch64) || defined(__aarch64__)) || defined(__CUDA_ARCH__)
 #  ifndef OIIO_NO_NEON
 #    define OIIO_NO_NEON 1
 #  endif


### PR DESCRIPTION
### Description

OIIO’s simd.h doesn’t treat ARM64EC as ARM, so it takes the wrong SIMD path.

Patch the three guard blocks in simd.h to include defined(_M_ARM64EC) wherever _M_ARM64 appears:

Switches OIIO to the NEON code path for a Windows  ARM64EC build when compiling with the command line switch /arm64EC


### Tests

no new tests added - would need a Window arm64 machine to run


### Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] **I have read the guidelines** on [contributions](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md) and [code review procedures](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/CodeReview.md).
- [x] **I have read the [Policy on AI Coding Assistants](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/dev/AI_Policy.md)**
  and if I used AI coding assistants, I have an `Assisted-by: TOOL / MODEL`
  line in the pull request description above.
- [x] **I am sure that this PR's changes are tested in the testsuite**.
- [x] **I have run and passed the testsuite in CI** *before* submitting the
  PR, by pushing the changes to my fork and seeing that the automated CI
  passed there. (Exceptions: If most tests pass and you can't figure out why
  the remaining ones fail, it's ok to submit the PR and ask for help. Or if
  any failures seem entirely unrelated to your change; sometimes things break
  on the GitHub runners.)
- [x] **My code follows the prevailing code style of this project** and I
  fixed any problems reported by the clang-format CI test.
